### PR TITLE
[REF] purchase: Use not duplicated 'default code' to test

### DIFF
--- a/addons/purchase/test/costmethodchange.yml
+++ b/addons/purchase/test/costmethodchange.yml
@@ -2,7 +2,7 @@
   Set a product as using average price. 
 -
   !record {model: product.product, id: product_variable_icecream}:
-    default_code: AVG
+    default_code: VARAVG
     name: Variable Ice Cream
     type: product
     categ_id: product.product_category_1

--- a/addons/purchase/test/fifo_returns.yml
+++ b/addons/purchase/test/fifo_returns.yml
@@ -2,7 +2,7 @@
   Set a product as using fifo price
 -
   !record {model: product.product, id: product_fiforet_icecream}:
-    default_code: FIFO
+    default_code: FIFORET
     name: FIFO Ice Cream
     type: product
     standard_price: 0.0


### PR DESCRIPTION
Similar case to: https://github.com/odoo/odoo/pull/5142 but for test data.

```python
default_code: AVG
```
https://github.com/odoo/odoo/blob/8.0/addons/purchase/test/costmethodchange.yml#L5
https://github.com/odoo/odoo/blob/8.0/addons/purchase/test/average_price.yml#L5

```python
default_code: FIFO
```
https://github.com/odoo/odoo/blob/8.0/addons/purchase/test/fifo_returns.yml#L5
https://github.com/odoo/odoo/blob/8.0/addons/purchase/test/fifo_price.yml#L5


