### PR TITLE
[FIX] the task form view now show the name field in the complete long of the sheet, before was showing only the half of the space, this because the kanban_state field was added and was generating split the grid space. Fix Vauxoo/instance-vauxoo-com#62

### DIFF
--- a/addons/project/project_view.xml
+++ b/addons/project/project_view.xml
@@ -389,7 +389,7 @@
                         <field name="kanban_state" class="oe_inline" widget="kanban_state_selection"/>
                     </div>
                     <h1>
-                        <field name="name" placeholder="Task summary..." class="oe_inline"/>
+                        <field name="name" placeholder="Task summary..."/>
                     </h1>
                     <group>
                         <group>


### PR DESCRIPTION
Task [vx#3781](https://www.vauxoo.com/web#id=3781&view_type=form&model=project.task&action=138)

Resullt:
![image](https://cloud.githubusercontent.com/assets/7593953/8529540/baaa65e0-23e0-11e5-860a-c2963888bc1e.png)

