### PR TITLE
[FIX] account: invoice lines to journal entries currency rounding

### DIFF
--- a/addons/account/account_invoice.py
+++ b/addons/account/account_invoice.py
@@ -739,7 +739,7 @@ class account_invoice(models.Model):
             if self.currency_id != company_currency:
                 currency = self.currency_id.with_context(date=self.date_invoice or fields.Date.context_today(self))
                 line['currency_id'] = currency.id
-                line['amount_currency'] = line['price']
+                line['amount_currency'] = currency.round(line['price'])
                 line['price'] = currency.compute(line['price'], company_currency)
             else:
                 line['currency_id'] = False

--- a/addons/account/account_invoice.py
+++ b/addons/account/account_invoice.py
@@ -744,6 +744,7 @@ class account_invoice(models.Model):
             else:
                 line['currency_id'] = False
                 line['amount_currency'] = False
+                line['price'] = self.currency_id.round(line['price'])
             line['ref'] = ref
             if self.type in ('out_invoice','in_refund'):
                 total += line['price']


### PR DESCRIPTION
When converting an invoice in journal entries,
the invoice lines amounts must be currency rounded
not only when the invoice currency is different
than the company invoice,
but also when they are the same.

Otherwise, a rounding issue can happen
if the `Account` decimal accuracy is greater
than the currency rounding, the journal entries
total and the invoice total could be different.

e.g.
 - Set decimal accuracy of Account and product to 4
 - Create a supplier invoice, any supplier
 - Add a line as follow:
   - Product: None
   - Quantity: 2057
   - Price unit: 11.9150
   - Tax: 16% (create a new tax with 0.16 as percentage)
 - Validate the invoice
 - In the other information tab of the invoice,
   click on the journal entry
 - Notice that the first line has as credit amount 28430.6150
   While the invoice total is 28430.6200
 - Now if you try to create a bank statement with one line
   of -28430.6200 and as partner the supplier you chose
   in the second step of this explanation, and try
   to reconciliate it to the invoice created above,
   the above won't be marked as paid, while it should.

opw-647639
Fixes #8135