### PR TITLE
[8.0][stock] Avoiding move with waiting state at the moment to create the stock_move_operation_link objects

### DIFF
--- a/addons/stock/stock.py
+++ b/addons/stock/stock.py
@@ -1260,7 +1260,7 @@ class stock_picking(osv.osv):
         prod2move_ids = {}
         still_to_do = []
         #make a dictionary giving for each product, the moves and related quantity that can be used in operation links
-        for move in [x for x in picking.move_lines if x.state not in ('done', 'cancel')]:
+        for move in [x for x in picking.move_lines if x.state not in ('done', 'cancel', 'waiting')]:
             if not prod2move_ids.get(move.product_id.id):
                 prod2move_ids[move.product_id.id] = [{'move': move, 'remaining_qty': move.product_qty}]
             else:


### PR DESCRIPTION
When you have more than one line with the same product and one of these lines is in waiting state can bring problem because is considered at the moment generate the new link in the model stock_move_operation_link. For this reason the move with waiting state must be bypassed