### PR TITLE
[FIX] stock_account: do not group move lines to invoices per saleman

### DIFF
--- a/addons/stock_account/stock.py
+++ b/addons/stock_account/stock.py
@@ -300,9 +300,13 @@ class stock_picking(osv.osv):
         for move in moves:
             company = move.company_id
             origin = move.picking_id.name
-            partner, user_id, currency_id = move_obj._get_master_data(cr, uid, move, company, context=context)
+            partner, _user_id, currency_id = move_obj._get_master_data(cr, uid, move, company, context=context)
 
-            key = (partner, currency_id, company.id, user_id)
+            # Force user_id to be current user, to avoid creating multiple invoices when lines
+            # have been sold by different salesmen
+            _user_id = uid
+
+            key = (partner, currency_id, company.id, _user_id)
             invoice_vals = self._get_invoice_vals(cr, uid, key, inv_type, journal_id, move, context=context)
 
             if key not in invoices:


### PR DESCRIPTION
When invoicing based on delivery lines, the system used
to group lines per partner, currency, *and* salesman, in
order to assign the corresponding salesman on the invoice.

However this creates multiple invoices for the same
customer, quite annoying for some businesses.

Assigning the invoice to the user creating it fixes this
problem and makes sense business-wise too.

In the future we could possibly assign a different
salesman to each invoice line, for reporting purposes
(e.g. for sales commissions)