### PR TITLE
[FIX] report, website_report: barcode widget

### DIFF
--- a/addons/report/controllers/main.py
+++ b/addons/report/controllers/main.py
@@ -86,12 +86,7 @@ class ReportController(Controller):
         at the bottom of the output image
         """
         try:
-            width, height, humanreadable = int(width), int(height), bool(humanreadable)
-            barcode = createBarcodeDrawing(
-                type, value=value, format='png', width=width, height=height,
-                humanReadable = humanreadable
-            )
-            barcode = barcode.asString('png')
+            barcode = request.registry['report'].barcode(type, value, width=width, height=height, humanreadable=humanreadable)
         except (ValueError, AttributeError):
             raise exceptions.HTTPException(description='Cannot convert into barcode.')
 

--- a/addons/report/models/__init__.py
+++ b/addons/report/models/__init__.py
@@ -1,3 +1,4 @@
 import report
 import report_paperformat
 import abstract_report
+import ir_qweb

--- a/addons/report/models/ir_qweb.py
+++ b/addons/report/models/ir_qweb.py
@@ -1,0 +1,21 @@
+from reportlab.graphics.barcode import createBarcodeDrawing
+
+from openerp.osv import osv
+from openerp.addons.base.ir.ir_qweb import HTMLSafe
+
+
+class BarcodeConverter(osv.AbstractModel):
+    """ ``barcode`` widget rendering, inserts a data:uri-using image tag in the
+    document. May be overridden by e.g. the website module to generate links
+    instead.
+    """
+    _name = 'ir.qweb.field.barcode'
+    _inherit = 'ir.qweb.field'
+
+    def value_to_html(self, cr, uid, value, field, options=None, context=None):
+        barcode_type = options.get('type', 'Code128')
+        barcode = self.pool['report'].barcode(
+            barcode_type,
+            value,
+            **dict((key, value) for key, value in options.items() if key in ['width', 'height', 'humanreadable']))
+        return HTMLSafe('<img src="data:%s;base64,%s">' % ('png', barcode.encode('base64')))

--- a/addons/report/models/report.py
+++ b/addons/report/models/report.py
@@ -41,6 +41,7 @@ from contextlib import closing
 from distutils.version import LooseVersion
 from functools import partial
 from pyPdf import PdfFileWriter, PdfFileReader
+from reportlab.graphics.barcode import createBarcodeDrawing
 
 
 #--------------------------------------------------------------------------
@@ -574,3 +575,18 @@ class Report(osv.Model):
             stream.close()
 
         return merged_file_path
+
+    def barcode(self, barcode_type, value, width=600, height=100, humanreadable=0):
+        if barcode_type == 'UPCA' and len(value) in (11, 12, 13):
+            barcode_type = 'EAN13'
+            if len(value) in (11, 12):
+                value = '0%s' % value
+        try:
+            width, height, humanreadable = int(width), int(height), bool(humanreadable)
+            barcode = createBarcodeDrawing(
+                barcode_type, value=value, format='png', width=width, height=height,
+                humanReadable=humanreadable
+            )
+            return barcode.asString('png')
+        except (ValueError, AttributeError):
+            raise ValueError("Cannot convert into barcode.")

--- a/addons/website_report/__init__.py
+++ b/addons/website_report/__init__.py
@@ -1,2 +1,3 @@
 import controllers
 import report
+import ir_qweb

--- a/addons/website_report/ir_qweb.py
+++ b/addons/website_report/ir_qweb.py
@@ -1,0 +1,9 @@
+from openerp.osv import orm
+
+
+class Barcode(orm.AbstractModel):
+    _name = 'website.qweb.field.barcode'
+    _inherit = ['website.qweb.field', 'ir.qweb.field.barcode']
+
+    def from_html(self, cr, uid, model, field, element, context=None):
+        return None


### PR DESCRIPTION
Up to this revision, barcodes set in reports are generated
using the controller `/report/barcode`,
using a `img` HTML tag, e.g. (from `report_location_barcode`)
```
<img t-if="not o.loc_barcode"
     t-att-src="'/report/barcode/?type=%s&amp;value=%s&amp;width=%s&amp;height=%s'
     % ('Code128', o.name, 600, 100)" style="width:300px;height:50px"/>
``

This `/report/barcode` route is set as `auth='user'`, meaning
the route can only be accessed by signed in users.

When wkhtmltopdf prints a report containing such a barcode,
it calls this `report/barcode` route, making sure to pass
the request session in the cookies, so wkhtmltopdf
uses the same session than the one of the user. This is
needed, as only users can access this `report/barcode/` route.

This session is passed in `report.py`, in the method
`_run_wkhtmltopdf`, thanks to the --cookie wkhtmltopdf
parameter.

Nevertheless, if a report is printed through the website
front-end, as public (without a signed in user), the request
session is not associated to a signed in user, and therefore
the route `/report/barcode` refuses the access / redirects
to the login, making it impossible to print a report
containing a barcode without being signed in. This even
if the report is printed as `sudo` through a controller
(as this is the session of the not signed in user which is passed,
not a session associated to `sudo).

Fixes #10621
opw-667797