### PR TITLE
[REF] performance: Patch to increase performance

### DIFF
--- a/addons/stock/product.py
+++ b/addons/stock/product.py
@@ -140,47 +140,57 @@ class product_product(osv.osv):
         context = context or {}
         field_names = field_names or []
 
+        virtual_compute_ok = True
+        # If only need qty available we can avoid get virtual qty
+        if [u'qty_available'] == field_names:
+            virtual_compute_ok = False
+
         domain_products = [('product_id', 'in', ids)]
         domain_quant, domain_move_in, domain_move_out = [], [], []
         domain_quant_loc, domain_move_in_loc, domain_move_out_loc = self._get_domain_locations(cr, uid, ids, context=context)
-        domain_move_in += self._get_domain_dates(cr, uid, ids, context=context) + [('state', 'not in', ('done', 'cancel', 'draft'))] + domain_products
-        domain_move_out += self._get_domain_dates(cr, uid, ids, context=context) + [('state', 'not in', ('done', 'cancel', 'draft'))] + domain_products
+        if virtual_compute_ok:
+            domain_move_in += self._get_domain_dates(cr, uid, ids, context=context) + [('state', 'not in', ('done', 'cancel', 'draft'))] + domain_products
+            domain_move_out += self._get_domain_dates(cr, uid, ids, context=context) + [('state', 'not in', ('done', 'cancel', 'draft'))] + domain_products
         domain_quant += domain_products
 
         if context.get('lot_id'):
             domain_quant.append(('lot_id', '=', context['lot_id']))
         if context.get('owner_id'):
             domain_quant.append(('owner_id', '=', context['owner_id']))
-            owner_domain = ('restrict_partner_id', '=', context['owner_id'])
-            domain_move_in.append(owner_domain)
-            domain_move_out.append(owner_domain)
+            if virtual_compute_ok:
+                owner_domain = ('restrict_partner_id', '=', context['owner_id'])
+                domain_move_in.append(owner_domain)
+                domain_move_out.append(owner_domain)
         if context.get('package_id'):
             domain_quant.append(('package_id', '=', context['package_id']))
 
-        domain_move_in += domain_move_in_loc
-        domain_move_out += domain_move_out_loc
-        moves_in = self.pool.get('stock.move').read_group(cr, uid, domain_move_in, ['product_id', 'product_qty'], ['product_id'], context=context)
-        moves_out = self.pool.get('stock.move').read_group(cr, uid, domain_move_out, ['product_id', 'product_qty'], ['product_id'], context=context)
+        if virtual_compute_ok:
+            domain_move_in += domain_move_in_loc
+            domain_move_out += domain_move_out_loc
+            moves_in = self.pool.get('stock.move').read_group(cr, uid, domain_move_in, ['product_id', 'product_qty'], ['product_id'], context=context)
+            moves_out = self.pool.get('stock.move').read_group(cr, uid, domain_move_out, ['product_id', 'product_qty'], ['product_id'], context=context)
 
         domain_quant += domain_quant_loc
         quants = self.pool.get('stock.quant').read_group(cr, uid, domain_quant, ['product_id', 'qty'], ['product_id'], context=context)
         quants = dict(map(lambda x: (x['product_id'][0], x['qty']), quants))
 
-        moves_in = dict(map(lambda x: (x['product_id'][0], x['product_qty']), moves_in))
-        moves_out = dict(map(lambda x: (x['product_id'][0], x['product_qty']), moves_out))
+        if virtual_compute_ok:
+            moves_in = dict(map(lambda x: (x['product_id'][0], x['product_qty']), moves_in))
+            moves_out = dict(map(lambda x: (x['product_id'][0], x['product_qty']), moves_out))
         res = {}
         for product in self.browse(cr, uid, ids, context=context):
             id = product.id
             qty_available = float_round(quants.get(id, 0.0), precision_rounding=product.uom_id.rounding)
-            incoming_qty = float_round(moves_in.get(id, 0.0), precision_rounding=product.uom_id.rounding)
-            outgoing_qty = float_round(moves_out.get(id, 0.0), precision_rounding=product.uom_id.rounding)
-            virtual_available = float_round(quants.get(id, 0.0) + moves_in.get(id, 0.0) - moves_out.get(id, 0.0), precision_rounding=product.uom_id.rounding)
-            res[id] = {
-                'qty_available': qty_available,
-                'incoming_qty': incoming_qty,
-                'outgoing_qty': outgoing_qty,
-                'virtual_available': virtual_available,
-            }
+            res[id] = {'qty_available': qty_available}
+            if virtual_compute_ok:
+                incoming_qty = float_round(moves_in.get(id, 0.0), precision_rounding=product.uom_id.rounding)
+                outgoing_qty = float_round(moves_out.get(id, 0.0), precision_rounding=product.uom_id.rounding)
+                virtual_available = float_round(quants.get(id, 0.0) + moves_in.get(id, 0.0) - moves_out.get(id, 0.0), precision_rounding=product.uom_id.rounding)
+                res[id].update({
+                    'incoming_qty': incoming_qty,
+                    'outgoing_qty': outgoing_qty,
+                    'virtual_available': virtual_available,
+                })
         return res
 
     def _search_product_quantity(self, cr, uid, obj, name, domain, context):
@@ -348,7 +358,7 @@ class product_template(osv.osv):
         var_ids = []
         for product in product_ids:
             var_ids += [p.id for p in product.product_variant_ids]
-        variant_available= self.pool['product.product']._product_available(cr, uid, var_ids, context=context)
+        variant_available= self.pool['product.product']._product_available(cr, uid, var_ids, name, context=context)
 
         for product in product_ids:
             qty_available = 0

--- a/addons/stock/stock.py
+++ b/addons/stock/stock.py
@@ -198,7 +198,7 @@ class stock_location(osv.osv):
         """
         wh_obj = self.pool.get("stock.warehouse")
         whs = wh_obj.search(cr, uid, [('view_location_id.parent_left', '<=', location.parent_left), 
-                                ('view_location_id.parent_right', '>=', location.parent_left)], context=context)
+                                ('view_location_id.parent_right', '>=', location.parent_left)], context=context, limit=1)
         return whs and whs[0] or False
 
 #----------------------------------------------------------


### PR DESCRIPTION
I saw that many slow script are because the odoo/odoo project have performance issues.

Current cProfile output in our modules:
```bash
Print cProfile sorted by  cumulative
ncalls     tottime    tt_percall cumtime    ct_percall file:lineno (method)
13008      0.073      0.000      1.127      0.000      /root/addons-vauxoo/stock_location_code/model/stock.py:83 (_name_get)
5311       0.013      0.000      0.587      0.000      /root/addons-vauxoo/partner_foreign/model/res_partner.py:34 (_get_location_options)
16833      0.041      0.000      0.466      0.000      /root/addons-vauxoo/sale_team_warehouse/models/sales_team.py:21 (default_get)
3146       0.023      0.000      0.434      0.000      /root/addons-vauxoo/website_product_availability/models/product.py:151 (_product_availability_warehouse)
5718       0.059      0.000      0.421      0.000      /root/addons-vauxoo/website_product_comment_purchased/models/mail.py:31 (_comment_bought)
```

After this change the output cProfile in our modules is:
```bash
Print cProfile sorted by  cumulative
ncalls     tottime    tt_percall cumtime    ct_percall file:lineno (method)
13022      0.079      0.000      1.159      0.000      /root/addons-vauxoo/stock_location_code/model/stock.py:83 (_name_get)
5314       0.012      0.000      0.592      0.000      /root/addons-vauxoo/partner_foreign/model/res_partner.py:34 (_get_location_options)
16845      0.045      0.000      0.488      0.000      /root/addons-vauxoo/sale_team_warehouse/models/sales_team.py:21 (default_get)
3160       0.029      0.000      0.477      0.000      /root/addons-vauxoo/website_product_availability/models/product.py:151 (_product_availability_warehouse)
5725       0.066      0.000      0.454      0.000      /root/addons-vauxoo/website_product_comment_purchased/models/mail.py:31 (_comment_bought)
```

After this tests I don't saw a change of performance... (please, check if odoo is updated correctly)