### PR TITLE
[FIX] point_of_sale: solved issue about kernel modules not loaded

### DIFF
--- a/addons/point_of_sale/tools/posbox/overwrite_before_init/etc/init_posbox_image.sh
+++ b/addons/point_of_sale/tools/posbox/overwrite_before_init/etc/init_posbox_image.sh
@@ -14,13 +14,15 @@ export DEBIAN_FRONTEND=noninteractive
 apt-get update
 apt-get -y dist-upgrade
 
-PKGS_TO_INSTALL="adduser postgresql-client python python-dateutil python-decorator python-docutils python-feedparser python-imaging python-jinja2 python-ldap python-libxslt1 python-lxml python-mako python-mock python-openid python-passlib python-psutil python-psycopg2 python-pybabel python-pychart python-pydot python-pyparsing python-pypdf python-reportlab python-requests python-tz python-vatnumber python-vobject python-werkzeug python-xlwt python-yaml postgresql python-gevent python-serial python-pip python-dev localepurge vim mc mg screen iw hostapd isc-dhcp-server git rsync console-data"
+PKGS_TO_INSTALL="adduser postgresql-client python python-dateutil python-decorator python-docutils python-feedparser python-imaging python-jinja2 python-ldap python-libxslt1 python-lxml python-mako python-mock python-openid python-passlib python-psutil python-psycopg2 python-pybabel python-pychart python-pydot python-pyparsing python-pypdf python-reportlab python-requests python-simplejson python-tz python-unittest2 python-vatnumber python-vobject python-werkzeug python-xlwt python-yaml postgresql python-gevent python-serial python-pip python-dev localepurge vim mc mg screen iw hostapd isc-dhcp-server git rsync console-data rpi-update"
 
 apt-get -y install ${PKGS_TO_INSTALL}
 
 apt-get clean
 localepurge
 rm -rf /usr/share/doc
+
+rpi-update 6e8b794818e06f50724774df3b1d4c6be0b5708c
 
 # python-usb in wheezy is too old
 # the latest pyusb from pip does not work either, usb.core.find() never returns

--- a/addons/point_of_sale/tools/posbox/posbox_download_images.sh
+++ b/addons/point_of_sale/tools/posbox/posbox_download_images.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-wget 'https://downloads.raspberrypi.org/raspbian_lite_latest' -O raspbian.img.zip
+wget 'https://downloads.raspberrypi.org/raspbian_lite/images/raspbian_lite-2016-03-18/2016-03-18-raspbian-jessie-lite.zip' -O raspbian.img.zip
 unzip raspbian.img.zip
 wget 'https://github.com/dhruvvyas90/qemu-rpi-kernel/raw/master/kernel-qemu-4.1.13-jessie' -O kernel-qemu


### PR DESCRIPTION
The issue odoo/odoo#12650 reports that no kernel modules are
installed when run script to create posbox image, and this is
caused because the command 'modprobe' who adds/removes modules
from the Linux kernel not find the modules directory:
'/lib/modules/(uname -r)'

To solve this issue was changed the script to download raspbian
image, replacing the raspbian link by another with a fixed kernel
version (4.1.19-v7+).

Also to ensure that '/lib/modules/(uname -r)' exists was used
rpi-update GIT-HASH to install a specific firmware-kernel version

About rpi-update:
https://tech.enekochan.com/en/2014/03/08/upgradedowngrade-to-a-specific-firmware-kernel-version-with-rpi-update-in-raspbian/

About command 'modprobe':
http://www.computerhope.com/unix/modprobe.htm