### PR TITLE
[FIX] point_of_sale: mount /boot when building the POSBox image

### DIFF
--- a/addons/point_of_sale/tools/posbox/overwrite_before_init/etc/init_posbox_image.sh
+++ b/addons/point_of_sale/tools/posbox/overwrite_before_init/etc/init_posbox_image.sh
@@ -11,6 +11,8 @@ __base="$(basename ${__file} .sh)"
 # Recommends: antiword, graphviz, ghostscript, postgresql, python-gevent, poppler-utils
 export DEBIAN_FRONTEND=noninteractive
 
+mount /dev/sda1 /boot
+
 apt-get update
 apt-get -y dist-upgrade
 


### PR DESCRIPTION
We don't mount /boot in fstab to prevent systemd-udev looking for
corresponding kernel modules in /lib/modules. We need to do this
because the modified kernel-qemu image we use for emulation is usually
not 100% the same version as in the Raspbian image. Therefore
systemd-udev won't be able to find the 'correct' kernel modules in
/lib/modules.

This causes issues when the raspberrypi-kernel package is updated
however. apt will update /lib/modules and will write the new
kernel{7,}.img files to /boot. Before this patch /boot was just a
directory on /dev/sda2, not the 'real' /boot which is on /dev/sda1. So
you'd end up with old, not updated kernel images but new, updated
kernel modules in /lib/modules.

This mounts /boot after the system booted. /boot gets mapped to
/dev/sda1 by /etc/udev/rules.d/90-qemu.rules.

Fixes #12650
opw-682320