### PR TITLE
[FIX] point_of_sale: avoid partition read error when building the PosBox image

### DIFF
--- a/addons/point_of_sale/tools/posbox/posbox_create_image.sh
+++ b/addons/point_of_sale/tools/posbox/posbox_create_image.sh
@@ -69,6 +69,10 @@ START_OF_ROOT_PARTITION=$(fdisk -l posbox.img | tail -n 1 | awk '{print $2}')
 LOOP_MAPPER_PATH=$(kpartx -av posbox.img | tail -n 1 | cut -d ' ' -f 3)
 LOOP_MAPPER_PATH="/dev/mapper/${LOOP_MAPPER_PATH}"
 
+# kpartx needs sleep after add/remove partitions
+# https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=734794
+sleep 2
+
 # resize filesystem
 e2fsck -f "${LOOP_MAPPER_PATH}" # resize2fs requires clean fs
 resize2fs "${LOOP_MAPPER_PATH}"


### PR DESCRIPTION
Why this PR?
-------------

When adding/removing partitions using kpartx, is recommended wait a couple of seconds before running some other command that can assume that partitions are now gone or still yet. Otherwise, maybe could appear a error of this kind: '<COMMAND_NAME> /path/to/device failed: Device or resource busy'.

https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=734794