### PR TITLE
[IMP] l10n_mx: Account tags in chart template

### DIFF
--- a/addons/l10n_mx/__openerp__.py
+++ b/addons/l10n_mx/__openerp__.py
@@ -33,6 +33,7 @@ With this module you will have:
     "depends": ["account", "base_vat"],
     "demo_xml": [],
     "data": [
+        "data/account_tag.xml",
         "data/account_chart.xml",
         "data/account_tax.xml",
         "data/account_chart_template.yml",

--- a/addons/l10n_mx/data/account_chart.xml
+++ b/addons/l10n_mx/data/account_chart.xml
@@ -42,23 +42,11 @@ Cuentas del plan
 <!--
     Cuenta Template
 -->
-        <record id='cuenta100' model='account.account.template'>
-            <field name='name'>Activo</field>
-            <field name='code'>100</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
-        </record>
         <record id='cuenta100_01' model='account.account.template'>
             <field name='name'>Activo a corto plazo</field>
             <field name='code'>100.01</field>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta101' model='account.account.template'>
-            <field name='name'>Caja</field>
-            <field name='code'>101</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account.data_account_type_liquidity"/>
-            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_100')])]"/>
         </record>
         <record id='cuenta101_01' model='account.account.template'>
             <field name='name'>Caja y efectivo</field>
@@ -66,13 +54,7 @@ Cuentas del plan
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account.data_account_type_liquidity"/>
             <field name="reconcile" eval="True"/>
-        </record>
-        <record id='cuenta102' model='account.account.template'>
-            <field name='name'>Bancos</field>
-            <field name='code'>102</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account.data_account_type_liquidity"/>
-            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_101')])]"/>
         </record>
         <record id='cuenta102_01' model='account.account.template'>
             <field name='name'>Bancos nacionales</field>
@@ -80,6 +62,7 @@ Cuentas del plan
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account.data_account_type_liquidity"/>
             <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_102')])]"/>
         </record>
         <record id='cuenta102_02' model='account.account.template'>
             <field name='name'>Bancos extranjeros</field>
@@ -87,49 +70,35 @@ Cuentas del plan
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account.data_account_type_liquidity"/>
             <field name="reconcile" eval="True"/>
-        </record>
-        <record id='cuenta103' model='account.account.template'>
-            <field name='name'>Inversiones</field>
-            <field name='code'>103</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_102')])]"/>
         </record>
         <record id='cuenta103_01' model='account.account.template'>
             <field name='name'>Inversiones temporales</field>
             <field name='code'>103.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_103')])]"/>
         </record>
         <record id='cuenta103_02' model='account.account.template'>
             <field name='name'>Inversiones en fideicomisos</field>
             <field name='code'>103.02</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_103')])]"/>
         </record>
         <record id='cuenta103_03' model='account.account.template'>
             <field name='name'>Otras inversiones</field>
             <field name='code'>103.03</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta104' model='account.account.template'>
-            <field name='name'>Otros instrumentos financieros</field>
-            <field name='code'>104</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_103')])]"/>
         </record>
         <record id='cuenta104_01' model='account.account.template'>
             <field name='name'>Otros instrumentos financieros</field>
             <field name='code'>104.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta105' model='account.account.template'>
-            <field name='name'>Clientes</field>
-            <field name='code'>105</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account.data_account_type_receivable"/>
-            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_104')])]"/>
         </record>
         <record id='cuenta105_01' model='account.account.template'>
             <field name='name'>Clientes nacionales</field>
@@ -137,6 +106,7 @@ Cuentas del plan
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account.data_account_type_receivable"/>
             <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_105')])]"/>
         </record>
         <record id='cuenta105_02' model='account.account.template'>
             <field name='name'>Clientes extranjeros</field>
@@ -144,6 +114,7 @@ Cuentas del plan
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account.data_account_type_receivable"/>
             <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_105')])]"/>
         </record>
         <record id='cuenta105_03' model='account.account.template'>
             <field name='name'>Clientes nacionales parte relacionada</field>
@@ -151,6 +122,7 @@ Cuentas del plan
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account.data_account_type_receivable"/>
             <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_105')])]"/>
         </record>
         <record id='cuenta105_04' model='account.account.template'>
             <field name='name'>Clientes extranjeros parte relacionada</field>
@@ -158,13 +130,7 @@ Cuentas del plan
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account.data_account_type_receivable"/>
             <field name="reconcile" eval="True"/>
-        </record>
-        <record id='cuenta106' model='account.account.template'>
-            <field name='name'>Cuentas y documentos por cobrar a corto plazo</field>
-            <field name='code'>106</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account.data_account_type_receivable"/>
-            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_105')])]"/>
         </record>
         <record id='cuenta106_01' model='account.account.template'>
             <field name='name'>Cuentas y documentos por cobrar a corto plazo nacional</field>
@@ -172,6 +138,7 @@ Cuentas del plan
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account.data_account_type_receivable"/>
             <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_106')])]"/>
         </record>
         <record id='cuenta106_02' model='account.account.template'>
             <field name='name'>Cuentas y documentos por cobrar a corto plazo extranjero</field>
@@ -179,6 +146,7 @@ Cuentas del plan
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account.data_account_type_receivable"/>
             <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_106')])]"/>
         </record>
         <record id='cuenta106_03' model='account.account.template'>
             <field name='name'>Cuentas y documentos por cobrar a corto plazo nacional parte relacionada</field>
@@ -186,6 +154,7 @@ Cuentas del plan
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account.data_account_type_receivable"/>
             <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_106')])]"/>
         </record>
         <record id='cuenta106_04' model='account.account.template'>
             <field name='name'>Cuentas y documentos por cobrar a corto plazo extranjero parte relacionada</field>
@@ -193,6 +162,7 @@ Cuentas del plan
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account.data_account_type_receivable"/>
             <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_106')])]"/>
         </record>
         <record id='cuenta106_05' model='account.account.template'>
             <field name='name'>Intereses por cobrar a corto plazo nacional</field>
@@ -200,6 +170,7 @@ Cuentas del plan
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account.data_account_type_receivable"/>
             <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_106')])]"/>
         </record>
         <record id='cuenta106_06' model='account.account.template'>
             <field name='name'>Intereses por cobrar a corto plazo extranjero</field>
@@ -207,6 +178,7 @@ Cuentas del plan
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account.data_account_type_receivable"/>
             <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_106')])]"/>
         </record>
         <record id='cuenta106_07' model='account.account.template'>
             <field name='name'>Intereses por cobrar a corto plazo nacional parte relacionada</field>
@@ -214,6 +186,7 @@ Cuentas del plan
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account.data_account_type_receivable"/>
             <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_106')])]"/>
         </record>
         <record id='cuenta106_08' model='account.account.template'>
             <field name='name'>Intereses por cobrar a corto plazo extranjero parte relacionada</field>
@@ -221,6 +194,7 @@ Cuentas del plan
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account.data_account_type_receivable"/>
             <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_106')])]"/>
         </record>
         <record id='cuenta106_09' model='account.account.template'>
             <field name='name'>Otras cuentas y documentos por cobrar a corto plazo</field>
@@ -228,6 +202,7 @@ Cuentas del plan
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account.data_account_type_receivable"/>
             <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_106')])]"/>
         </record>
         <record id='cuenta106_10' model='account.account.template'>
             <field name='name'>Otras cuentas y documentos por cobrar a corto plazo parte relacionada</field>
@@ -235,13 +210,7 @@ Cuentas del plan
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account.data_account_type_receivable"/>
             <field name="reconcile" eval="True"/>
-        </record>
-        <record id='cuenta107' model='account.account.template'>
-            <field name='name'>Deudores diversos</field>
-            <field name='code'>107</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account.data_account_type_receivable"/>
-            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_106')])]"/>
         </record>
         <record id='cuenta107_01' model='account.account.template'>
             <field name='name'>Funcionarios y empleados</field>
@@ -249,6 +218,7 @@ Cuentas del plan
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account.data_account_type_receivable"/>
             <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_107')])]"/>
         </record>
         <record id='cuenta107_02' model='account.account.template'>
             <field name='name'>Socios y accionistas</field>
@@ -256,6 +226,7 @@ Cuentas del plan
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account.data_account_type_receivable"/>
             <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_107')])]"/>
         </record>
         <record id='cuenta107_03' model='account.account.template'>
             <field name='name'>Partes relacionadas nacionales</field>
@@ -263,6 +234,7 @@ Cuentas del plan
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account.data_account_type_receivable"/>
             <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_107')])]"/>
         </record>
         <record id='cuenta107_04' model='account.account.template'>
             <field name='name'>Partes relacionadas extranjeros</field>
@@ -270,6 +242,7 @@ Cuentas del plan
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account.data_account_type_receivable"/>
             <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_107')])]"/>
         </record>
         <record id='cuenta107_05' model='account.account.template'>
             <field name='name'>Otros deudores diversos</field>
@@ -277,13 +250,7 @@ Cuentas del plan
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account.data_account_type_receivable"/>
             <field name="reconcile" eval="True"/>
-        </record>
-        <record id='cuenta108' model='account.account.template'>
-            <field name='name'>Estimación de cuentas incobrables</field>
-            <field name='code'>108</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account.data_account_type_receivable"/>
-            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_107')])]"/>
         </record>
         <record id='cuenta108_01' model='account.account.template'>
             <field name='name'>Estimación de cuentas incobrables nacional</field>
@@ -291,6 +258,7 @@ Cuentas del plan
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account.data_account_type_receivable"/>
             <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_108')])]"/>
         </record>
         <record id='cuenta108_02' model='account.account.template'>
             <field name='name'>Estimación de cuentas incobrables extranjero</field>
@@ -298,6 +266,7 @@ Cuentas del plan
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account.data_account_type_receivable"/>
             <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_108')])]"/>
         </record>
         <record id='cuenta108_03' model='account.account.template'>
             <field name='name'>Estimación de cuentas incobrables nacional parte relacionada</field>
@@ -305,6 +274,7 @@ Cuentas del plan
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account.data_account_type_receivable"/>
             <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_108')])]"/>
         </record>
         <record id='cuenta108_04' model='account.account.template'>
             <field name='name'>Estimación de cuentas incobrables extranjero parte relacionada</field>
@@ -312,13 +282,7 @@ Cuentas del plan
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account.data_account_type_receivable"/>
             <field name="reconcile" eval="True"/>
-        </record>
-        <record id='cuenta109' model='account.account.template'>
-            <field name='name'>Pagos anticipados</field>
-            <field name='code'>109</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account.data_account_type_receivable"/>
-            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_108')])]"/>
         </record>
         <record id='cuenta109_01' model='account.account.template'>
             <field name='name'>Seguros y fianzas pagados por anticipado nacional</field>
@@ -326,6 +290,7 @@ Cuentas del plan
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account.data_account_type_receivable"/>
             <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_109')])]"/>
         </record>
         <record id='cuenta109_02' model='account.account.template'>
             <field name='name'>Seguros y fianzas pagados por anticipado extranjero</field>
@@ -333,6 +298,7 @@ Cuentas del plan
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account.data_account_type_receivable"/>
             <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_109')])]"/>
         </record>
         <record id='cuenta109_03' model='account.account.template'>
             <field name='name'>Seguros y fianzas pagados por anticipado nacional parte relacionada</field>
@@ -340,6 +306,7 @@ Cuentas del plan
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account.data_account_type_receivable"/>
             <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_109')])]"/>
         </record>
         <record id='cuenta109_04' model='account.account.template'>
             <field name='name'>Seguros y fianzas pagados por anticipado extranjero parte relacionada</field>
@@ -347,6 +314,7 @@ Cuentas del plan
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account.data_account_type_receivable"/>
             <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_109')])]"/>
         </record>
         <record id='cuenta109_05' model='account.account.template'>
             <field name='name'>Rentas pagados por anticipado nacional</field>
@@ -354,6 +322,7 @@ Cuentas del plan
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account.data_account_type_receivable"/>
             <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_109')])]"/>
         </record>
         <record id='cuenta109_06' model='account.account.template'>
             <field name='name'>Rentas pagados por anticipado extranjero</field>
@@ -361,6 +330,7 @@ Cuentas del plan
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account.data_account_type_receivable"/>
             <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_109')])]"/>
         </record>
         <record id='cuenta109_07' model='account.account.template'>
             <field name='name'>Rentas pagados por anticipado nacional parte relacionada</field>
@@ -368,6 +338,7 @@ Cuentas del plan
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account.data_account_type_receivable"/>
             <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_109')])]"/>
         </record>
         <record id='cuenta109_08' model='account.account.template'>
             <field name='name'>Rentas pagados por anticipado extranjero parte relacionada</field>
@@ -375,6 +346,7 @@ Cuentas del plan
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account.data_account_type_receivable"/>
             <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_109')])]"/>
         </record>
         <record id='cuenta109_09' model='account.account.template'>
             <field name='name'>Intereses pagados por anticipado nacional</field>
@@ -382,6 +354,7 @@ Cuentas del plan
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account.data_account_type_receivable"/>
             <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_109')])]"/>
         </record>
         <record id='cuenta109_10' model='account.account.template'>
             <field name='name'>Intereses pagados por anticipado extranjero</field>
@@ -389,6 +362,7 @@ Cuentas del plan
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account.data_account_type_receivable"/>
             <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_109')])]"/>
         </record>
         <record id='cuenta109_11' model='account.account.template'>
             <field name='name'>Intereses pagados por anticipado nacional parte relacionada</field>
@@ -396,6 +370,7 @@ Cuentas del plan
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account.data_account_type_receivable"/>
             <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_109')])]"/>
         </record>
         <record id='cuenta109_12' model='account.account.template'>
             <field name='name'>Intereses pagados por anticipado extranjero parte relacionada</field>
@@ -403,6 +378,7 @@ Cuentas del plan
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account.data_account_type_receivable"/>
             <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_109')])]"/>
         </record>
         <record id='cuenta109_13' model='account.account.template'>
             <field name='name'>Factoraje financiero pagados por anticipado nacional</field>
@@ -410,6 +386,7 @@ Cuentas del plan
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account.data_account_type_receivable"/>
             <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_109')])]"/>
         </record>
         <record id='cuenta109_14' model='account.account.template'>
             <field name='name'>Factoraje financiero pagados por anticipado extranjero</field>
@@ -417,6 +394,7 @@ Cuentas del plan
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account.data_account_type_receivable"/>
             <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_109')])]"/>
         </record>
         <record id='cuenta109_15' model='account.account.template'>
             <field name='name'>Factoraje financiero pagados por anticipado nacional parte relacionada</field>
@@ -424,6 +402,7 @@ Cuentas del plan
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account.data_account_type_receivable"/>
             <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_109')])]"/>
         </record>
         <record id='cuenta109_16' model='account.account.template'>
             <field name='name'>Factoraje financiero pagados por anticipado extranjero parte relacionada</field>
@@ -431,6 +410,7 @@ Cuentas del plan
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account.data_account_type_receivable"/>
             <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_109')])]"/>
         </record>
         <record id='cuenta109_17' model='account.account.template'>
             <field name='name'>Arrendamiento financiero pagados por anticipado nacional</field>
@@ -438,6 +418,7 @@ Cuentas del plan
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account.data_account_type_receivable"/>
             <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_109')])]"/>
         </record>
         <record id='cuenta109_18' model='account.account.template'>
             <field name='name'>Arrendamiento financiero pagados por anticipado extranjero</field>
@@ -445,6 +426,7 @@ Cuentas del plan
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account.data_account_type_receivable"/>
             <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_109')])]"/>
         </record>
         <record id='cuenta109_19' model='account.account.template'>
             <field name='name'>Arrendamiento financiero pagados por anticipado nacional parte relacionada</field>
@@ -452,6 +434,7 @@ Cuentas del plan
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account.data_account_type_receivable"/>
             <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_109')])]"/>
         </record>
         <record id='cuenta109_20' model='account.account.template'>
             <field name='name'>Arrendamiento financiero pagados por anticipado extranjero parte relacionada</field>
@@ -459,6 +442,7 @@ Cuentas del plan
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account.data_account_type_receivable"/>
             <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_109')])]"/>
         </record>
         <record id='cuenta109_21' model='account.account.template'>
             <field name='name'>Pérdida por deterioro de pagos anticipados</field>
@@ -466,6 +450,7 @@ Cuentas del plan
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account.data_account_type_receivable"/>
             <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_109')])]"/>
         </record>
         <record id='cuenta109_22' model='account.account.template'>
             <field name='name'>Derechos fiduciarios</field>
@@ -473,6 +458,7 @@ Cuentas del plan
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account.data_account_type_receivable"/>
             <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_109')])]"/>
         </record>
         <record id='cuenta109_23' model='account.account.template'>
             <field name='name'>Otros pagos anticipados</field>
@@ -480,1135 +466,931 @@ Cuentas del plan
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account.data_account_type_receivable"/>
             <field name="reconcile" eval="True"/>
-        </record>
-        <record id='cuenta110' model='account.account.template'>
-            <field name='name'>Subsidio al empleo por aplicar</field>
-            <field name='code'>110</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_109')])]"/>
         </record>
         <record id='cuenta110_01' model='account.account.template'>
             <field name='name'>Subsidio al empleo por aplicar</field>
             <field name='code'>110.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta111' model='account.account.template'>
-            <field name='name'>Crédito al diesel por acreditar</field>
-            <field name='code'>111</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_110')])]"/>
         </record>
         <record id='cuenta111_01' model='account.account.template'>
             <field name='name'>Crédito al diesel por acreditar</field>
             <field name='code'>111.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta112' model='account.account.template'>
-            <field name='name'>Otros estímulos</field>
-            <field name='code'>112</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_111')])]"/>
         </record>
         <record id='cuenta112_01' model='account.account.template'>
             <field name='name'>Otros estímulos</field>
             <field name='code'>112.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta113' model='account.account.template'>
-            <field name='name'>Impuestos a favor</field>
-            <field name='code'>113</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_112')])]"/>
         </record>
         <record id='cuenta113_01' model='account.account.template'>
             <field name='name'>IVA a favor</field>
             <field name='code'>113.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_113')])]"/>
         </record>
         <record id='cuenta113_02' model='account.account.template'>
             <field name='name'>ISR a favor</field>
             <field name='code'>113.02</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_113')])]"/>
         </record>
         <record id='cuenta113_03' model='account.account.template'>
             <field name='name'>IETU a favor</field>
             <field name='code'>113.03</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_113')])]"/>
         </record>
         <record id='cuenta113_04' model='account.account.template'>
             <field name='name'>IDE a favor</field>
             <field name='code'>113.04</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_113')])]"/>
         </record>
         <record id='cuenta113_05' model='account.account.template'>
             <field name='name'>IA a favor</field>
             <field name='code'>113.05</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_113')])]"/>
         </record>
         <record id='cuenta113_06' model='account.account.template'>
             <field name='name'>Subsidio al empleo</field>
             <field name='code'>113.06</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_113')])]"/>
         </record>
         <record id='cuenta113_07' model='account.account.template'>
             <field name='name'>Pago de lo indebido</field>
             <field name='code'>113.07</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_113')])]"/>
         </record>
         <record id='cuenta113_08' model='account.account.template'>
             <field name='name'>Otros impuestos a favor</field>
             <field name='code'>113.08</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta114' model='account.account.template'>
-            <field name='name'>Pagos provisionales</field>
-            <field name='code'>114</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_113')])]"/>
         </record>
         <record id='cuenta114_01' model='account.account.template'>
             <field name='name'>Pagos provisionales de ISR</field>
             <field name='code'>114.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta115' model='account.account.template'>
-            <field name='name'>Inventario</field>
-            <field name='code'>115</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_114')])]"/>
         </record>
         <record id='cuenta115_01' model='account.account.template'>
             <field name='name'>Inventario</field>
             <field name='code'>115.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_115')])]"/>
         </record>
         <record id='cuenta115_02' model='account.account.template'>
             <field name='name'>Materia prima y materiales</field>
             <field name='code'>115.02</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_115')])]"/>
         </record>
         <record id='cuenta115_03' model='account.account.template'>
             <field name='name'>Producción en proceso</field>
             <field name='code'>115.03</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_115')])]"/>
         </record>
         <record id='cuenta115_04' model='account.account.template'>
             <field name='name'>Productos terminados</field>
             <field name='code'>115.04</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_115')])]"/>
         </record>
         <record id='cuenta115_05' model='account.account.template'>
             <field name='name'>Mercancías en tránsito</field>
             <field name='code'>115.05</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_115')])]"/>
         </record>
         <record id='cuenta115_06' model='account.account.template'>
             <field name='name'>Mercancías en poder de terceros</field>
             <field name='code'>115.06</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_115')])]"/>
         </record>
         <record id='cuenta115_07' model='account.account.template'>
             <field name='name'>Otros</field>
             <field name='code'>115.07</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta116' model='account.account.template'>
-            <field name='name'>Estimación de inventarios obsoletos y de lento movimiento</field>
-            <field name='code'>116</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_115')])]"/>
         </record>
         <record id='cuenta116_01' model='account.account.template'>
             <field name='name'>Estimación de inventarios obsoletos y de lento movimiento</field>
             <field name='code'>116.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta117' model='account.account.template'>
-            <field name='name'>Obras en proceso de inmuebles</field>
-            <field name='code'>117</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_116')])]"/>
         </record>
         <record id='cuenta117_01' model='account.account.template'>
             <field name='name'>Obras en proceso de inmuebles</field>
             <field name='code'>117.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta118' model='account.account.template'>
-            <field name='name'>Impuestos acreditables pagados</field>
-            <field name='code'>118</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_117')])]"/>
         </record>
         <record id='cuenta118_01' model='account.account.template'>
             <field name='name'>IVA acreditable pagado</field>
             <field name='code'>118.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_118')])]"/>
         </record>
         <record id='cuenta118_02' model='account.account.template'>
             <field name='name'>IVA acreditable de importación pagado</field>
             <field name='code'>118.02</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_118')])]"/>
         </record>
         <record id='cuenta118_03' model='account.account.template'>
             <field name='name'>IEPS acreditable pagado</field>
             <field name='code'>118.03</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_118')])]"/>
         </record>
         <record id='cuenta118_04' model='account.account.template'>
             <field name='name'>IEPS pagado en importación</field>
             <field name='code'>118.04</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta119' model='account.account.template'>
-            <field name='name'>Impuestos acreditables por pagar</field>
-            <field name='code'>119</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_118')])]"/>
         </record>
         <record id='cuenta119_01' model='account.account.template'>
             <field name='name'>IVA pendiente de pago</field>
             <field name='code'>119.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_119')])]"/>
         </record>
         <record id='cuenta119_02' model='account.account.template'>
             <field name='name'>IVA de importación pendiente de pago</field>
             <field name='code'>119.02</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_119')])]"/>
         </record>
         <record id='cuenta119_03' model='account.account.template'>
             <field name='name'>IEPS pendiente de pago</field>
             <field name='code'>119.03</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_119')])]"/>
         </record>
         <record id='cuenta119_04' model='account.account.template'>
             <field name='name'>IEPS pendiente de pago en importación</field>
             <field name='code'>119.04</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta120' model='account.account.template'>
-            <field name='name'>Anticipo a proveedores</field>
-            <field name='code'>120</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_119')])]"/>
         </record>
         <record id='cuenta120_01' model='account.account.template'>
             <field name='name'>Anticipo a proveedores nacional</field>
             <field name='code'>120.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_120')])]"/>
         </record>
         <record id='cuenta120_02' model='account.account.template'>
             <field name='name'>Anticipo a proveedores extranjero</field>
             <field name='code'>120.02</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_120')])]"/>
         </record>
         <record id='cuenta120_03' model='account.account.template'>
             <field name='name'>Anticipo a proveedores nacional parte relacionada</field>
             <field name='code'>120.03</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_120')])]"/>
         </record>
         <record id='cuenta120_04' model='account.account.template'>
             <field name='name'>Anticipo a proveedores extranjero parte relacionada</field>
             <field name='code'>120.04</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta121' model='account.account.template'>
-            <field name='name'>Otros activos a corto plazo</field>
-            <field name='code'>121</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_120')])]"/>
         </record>
         <record id='cuenta121_01' model='account.account.template'>
             <field name='name'>Otros activos a corto plazo</field>
             <field name='code'>121.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta100_02' model='account.account.template'>
-            <field name='name'>Activo a largo plazo</field>
-            <field name='code'>100.02</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta151' model='account.account.template'>
-            <field name='name'>Terrenos</field>
-            <field name='code'>151</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_121')])]"/>
         </record>
         <record id='cuenta151_01' model='account.account.template'>
             <field name='name'>Terrenos</field>
             <field name='code'>151.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta152' model='account.account.template'>
-            <field name='name'>Edificios</field>
-            <field name='code'>152</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_151')])]"/>
         </record>
         <record id='cuenta152_01' model='account.account.template'>
             <field name='name'>Edificios</field>
             <field name='code'>152.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta153' model='account.account.template'>
-            <field name='name'>Maquinaria y equipo</field>
-            <field name='code'>153</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_152')])]"/>
         </record>
         <record id='cuenta153_01' model='account.account.template'>
             <field name='name'>Maquinaria y equipo</field>
             <field name='code'>153.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta154' model='account.account.template'>
-            <field name='name'>Automóviles, autobuses, camiones de carga, tractocamiones, montacargas y remolques</field>
-            <field name='code'>154</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_153')])]"/>
         </record>
         <record id='cuenta154_01' model='account.account.template'>
             <field name='name'>Automóviles, autobuses, camiones de carga, tractocamiones, montacargas y remolques</field>
             <field name='code'>154.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta155' model='account.account.template'>
-            <field name='name'>Mobiliario y equipo de oficina</field>
-            <field name='code'>155</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_154')])]"/>
         </record>
         <record id='cuenta155_01' model='account.account.template'>
             <field name='name'>Mobiliario y equipo de oficina</field>
             <field name='code'>155.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta156' model='account.account.template'>
-            <field name='name'>Equipo de cómputo</field>
-            <field name='code'>156</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_155')])]"/>
         </record>
         <record id='cuenta156_01' model='account.account.template'>
             <field name='name'>Equipo de cómputo</field>
             <field name='code'>156.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta157' model='account.account.template'>
-            <field name='name'>Equipo de comunicación</field>
-            <field name='code'>157</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_156')])]"/>
         </record>
         <record id='cuenta157_01' model='account.account.template'>
             <field name='name'>Equipo de comunicación</field>
             <field name='code'>157.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta158' model='account.account.template'>
-            <field name='name'>Activos biológicos, vegetales y semovientes</field>
-            <field name='code'>158</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_157')])]"/>
         </record>
         <record id='cuenta158_01' model='account.account.template'>
             <field name='name'>Activos biológicos, vegetales y semovientes</field>
             <field name='code'>158.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta159' model='account.account.template'>
-            <field name='name'>Obras en proceso de activos fijos</field>
-            <field name='code'>159</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_158')])]"/>
         </record>
         <record id='cuenta159_01' model='account.account.template'>
             <field name='name'>Obras en proceso de activos fijos</field>
             <field name='code'>159.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta160' model='account.account.template'>
-            <field name='name'>Otros activos fijos</field>
-            <field name='code'>160</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_159')])]"/>
         </record>
         <record id='cuenta160_01' model='account.account.template'>
             <field name='name'>Otros activos fijos</field>
             <field name='code'>160.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta161' model='account.account.template'>
-            <field name='name'>Ferrocarriles</field>
-            <field name='code'>161</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_160')])]"/>
         </record>
         <record id='cuenta161_01' model='account.account.template'>
             <field name='name'>Ferrocarriles</field>
             <field name='code'>161.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta162' model='account.account.template'>
-            <field name='name'>Embarcaciones</field>
-            <field name='code'>162</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_161')])]"/>
         </record>
         <record id='cuenta162_01' model='account.account.template'>
             <field name='name'>Embarcaciones</field>
             <field name='code'>162.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta163' model='account.account.template'>
-            <field name='name'>Aviones</field>
-            <field name='code'>163</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_162')])]"/>
         </record>
         <record id='cuenta163_01' model='account.account.template'>
             <field name='name'>Aviones</field>
             <field name='code'>163.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta164' model='account.account.template'>
-            <field name='name'>Troqueles, moldes, matrices y herramental</field>
-            <field name='code'>164</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_163')])]"/>
         </record>
         <record id='cuenta164_01' model='account.account.template'>
             <field name='name'>Troqueles, moldes, matrices y herramental</field>
             <field name='code'>164.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta165' model='account.account.template'>
-            <field name='name'>Equipo de comunicaciones telefónicas</field>
-            <field name='code'>165</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_164')])]"/>
         </record>
         <record id='cuenta165_01' model='account.account.template'>
             <field name='name'>Equipo de comunicaciones telefónicas</field>
             <field name='code'>165.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta166' model='account.account.template'>
-            <field name='name'>Equipo de comunicación satelital</field>
-            <field name='code'>166</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_165')])]"/>
         </record>
         <record id='cuenta166_01' model='account.account.template'>
             <field name='name'>Equipo de comunicación satelital</field>
             <field name='code'>166.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta167' model='account.account.template'>
-            <field name='name'>Equipo de adaptaciones para personas con capacidades diferentes</field>
-            <field name='code'>167</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_166')])]"/>
         </record>
         <record id='cuenta167_01' model='account.account.template'>
             <field name='name'>Equipo de adaptaciones para personas con capacidades diferentes</field>
             <field name='code'>167.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta168' model='account.account.template'>
-            <field name='name'>Maquinaria y equipo de generación de energía de fuentes renovables o de sistemas de cogeneración de electricidad eficiente</field>
-            <field name='code'>168</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_167')])]"/>
         </record>
         <record id='cuenta168_01' model='account.account.template'>
             <field name='name'>Maquinaria y equipo de generación de energía de fuentes renovables o de sistemas de cogeneración de electricidad eficiente</field>
             <field name='code'>168.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta169' model='account.account.template'>
-            <field name='name'>Otra maquinaria y equipo</field>
-            <field name='code'>169</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_168')])]"/>
         </record>
         <record id='cuenta169_01' model='account.account.template'>
             <field name='name'>Otra maquinaria y equipo</field>
             <field name='code'>169.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta170' model='account.account.template'>
-            <field name='name'>Adaptaciones y mejoras</field>
-            <field name='code'>170</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_169')])]"/>
         </record>
         <record id='cuenta170_01' model='account.account.template'>
             <field name='name'>Adaptaciones y mejoras</field>
             <field name='code'>170.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta171' model='account.account.template'>
-            <field name='name'>Depreciación acumulada de activos fijos</field>
-            <field name='code'>171</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_170')])]"/>
         </record>
         <record id='cuenta171_01' model='account.account.template'>
             <field name='name'>Depreciación acumulada de edificios</field>
             <field name='code'>171.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_171')])]"/>
         </record>
         <record id='cuenta171_02' model='account.account.template'>
             <field name='name'>Depreciación acumulada de maquinaria y equipo</field>
             <field name='code'>171.02</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_171')])]"/>
         </record>
         <record id='cuenta171_03' model='account.account.template'>
             <field name='name'>Depreciación acumulada de automóviles, autobuses, camiones de carga, tractocamiones, montacargas y remolques</field>
             <field name='code'>171.03</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_171')])]"/>
         </record>
         <record id='cuenta171_04' model='account.account.template'>
             <field name='name'>Depreciación acumulada de mobiliario y equipo de oficina</field>
             <field name='code'>171.04</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_171')])]"/>
         </record>
         <record id='cuenta171_05' model='account.account.template'>
             <field name='name'>Depreciación acumulada de equipo de cómputo</field>
             <field name='code'>171.05</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_171')])]"/>
         </record>
         <record id='cuenta171_06' model='account.account.template'>
             <field name='name'>Depreciación acumulada de equipo de comunicación</field>
             <field name='code'>171.06</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_171')])]"/>
         </record>
         <record id='cuenta171_07' model='account.account.template'>
             <field name='name'>Depreciación acumulada de activos biológicos, vegetales y semovientes</field>
             <field name='code'>171.07</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_171')])]"/>
         </record>
         <record id='cuenta171_08' model='account.account.template'>
             <field name='name'>Depreciación acumulada de otros activos fijos</field>
             <field name='code'>171.08</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_171')])]"/>
         </record>
         <record id='cuenta171_09' model='account.account.template'>
             <field name='name'>Depreciación acumulada de ferrocarriles</field>
             <field name='code'>171.09</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_171')])]"/>
         </record>
         <record id='cuenta171_10' model='account.account.template'>
             <field name='name'>Depreciación acumulada de embarcaciones</field>
             <field name='code'>171.10</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_171')])]"/>
         </record>
         <record id='cuenta171_11' model='account.account.template'>
             <field name='name'>Depreciación acumulada de aviones</field>
             <field name='code'>171.11</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_171')])]"/>
         </record>
         <record id='cuenta171_12' model='account.account.template'>
             <field name='name'>Depreciación acumulada de troqueles, moldes, matrices y herramental</field>
             <field name='code'>171.12</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_171')])]"/>
         </record>
         <record id='cuenta171_13' model='account.account.template'>
             <field name='name'>Depreciación acumulada de equipo de comunicaciones telefónicas</field>
             <field name='code'>171.13</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_171')])]"/>
         </record>
         <record id='cuenta171_14' model='account.account.template'>
             <field name='name'>Depreciación acumulada de equipo de comunicación satelital</field>
             <field name='code'>171.14</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_171')])]"/>
         </record>
         <record id='cuenta171_15' model='account.account.template'>
             <field name='name'>Depreciación acumulada de equipo de adaptaciones para personas con capacidades diferentes</field>
             <field name='code'>171.15</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_171')])]"/>
         </record>
         <record id='cuenta171_16' model='account.account.template'>
             <field name='name'>Depreciación acumulada de maquinaria y equipo de generación de energía de fuentes renovables o de sistemas de cogeneración de electricidad eficiente</field>
             <field name='code'>171.16</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_171')])]"/>
         </record>
         <record id='cuenta171_17' model='account.account.template'>
             <field name='name'>Depreciación acumulada de adaptaciones y mejoras</field>
             <field name='code'>171.17</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_171')])]"/>
         </record>
         <record id='cuenta171_18' model='account.account.template'>
             <field name='name'>Depreciación acumulada de otra maquinaria y equipo</field>
             <field name='code'>171.18</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta172' model='account.account.template'>
-            <field name='name'>Pérdida por deterioro acumulado de activos fijos</field>
-            <field name='code'>172</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_171')])]"/>
         </record>
         <record id='cuenta172_01' model='account.account.template'>
             <field name='name'>Pérdida por deterioro acumulado de edificios</field>
             <field name='code'>172.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_172')])]"/>
         </record>
         <record id='cuenta172_02' model='account.account.template'>
             <field name='name'>Pérdida por deterioro acumulado de maquinaria y equipo</field>
             <field name='code'>172.02</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_172')])]"/>
         </record>
         <record id='cuenta172_03' model='account.account.template'>
             <field name='name'>Pérdida por deterioro acumulado de automóviles, autobuses, camiones de carga, tractocamiones, montacargas y remolques</field>
             <field name='code'>172.03</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_172')])]"/>
         </record>
         <record id='cuenta172_04' model='account.account.template'>
             <field name='name'>Pérdida por deterioro acumulado de mobiliario y equipo de oficina</field>
             <field name='code'>172.04</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_172')])]"/>
         </record>
         <record id='cuenta172_05' model='account.account.template'>
             <field name='name'>Pérdida por deterioro acumulado de equipo de cómputo</field>
             <field name='code'>172.05</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_172')])]"/>
         </record>
         <record id='cuenta172_06' model='account.account.template'>
             <field name='name'>Pérdida por deterioro acumulado de equipo de comunicación</field>
             <field name='code'>172.06</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_172')])]"/>
         </record>
         <record id='cuenta172_07' model='account.account.template'>
             <field name='name'>Pérdida por deterioro acumulado de activos biológicos, vegetales y semovientes</field>
             <field name='code'>172.07</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_172')])]"/>
         </record>
         <record id='cuenta172_08' model='account.account.template'>
             <field name='name'>Pérdida por deterioro acumulado de otros activos fijos</field>
             <field name='code'>172.08</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_172')])]"/>
         </record>
         <record id='cuenta172_09' model='account.account.template'>
             <field name='name'>Pérdida por deterioro acumulado de ferrocarriles</field>
             <field name='code'>172.09</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_172')])]"/>
         </record>
         <record id='cuenta172_10' model='account.account.template'>
             <field name='name'>Pérdida por deterioro acumulado de embarcaciones</field>
             <field name='code'>172.10</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_172')])]"/>
         </record>
         <record id='cuenta172_11' model='account.account.template'>
             <field name='name'>Pérdida por deterioro acumulado de aviones</field>
             <field name='code'>172.11</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_172')])]"/>
         </record>
         <record id='cuenta172_12' model='account.account.template'>
             <field name='name'>Pérdida por deterioro acumulado de troqueles, moldes, matrices y herramental</field>
             <field name='code'>172.12</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_172')])]"/>
         </record>
         <record id='cuenta172_13' model='account.account.template'>
             <field name='name'>Pérdida por deterioro acumulado de equipo de comunicaciones telefónicas</field>
             <field name='code'>172.13</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_172')])]"/>
         </record>
         <record id='cuenta172_14' model='account.account.template'>
             <field name='name'>Pérdida por deterioro acumulado de equipo de comunicación satelital</field>
             <field name='code'>172.14</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_172')])]"/>
         </record>
         <record id='cuenta172_15' model='account.account.template'>
             <field name='name'>Pérdida por deterioro acumulado de equipo de adaptaciones para personas con capacidades diferentes</field>
             <field name='code'>172.15</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_172')])]"/>
         </record>
         <record id='cuenta172_16' model='account.account.template'>
             <field name='name'>Pérdida por deterioro acumulado de maquinaria y equipo de generación de energía de fuentes renovables o de sistemas de cogeneración de electricidad eficiente</field>
             <field name='code'>172.16</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_172')])]"/>
         </record>
         <record id='cuenta172_17' model='account.account.template'>
             <field name='name'>Pérdida por deterioro acumulado de adaptaciones y mejoras</field>
             <field name='code'>172.17</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_172')])]"/>
         </record>
         <record id='cuenta172_18' model='account.account.template'>
             <field name='name'>Pérdida por deterioro acumulado de otra maquinaria y equipo</field>
             <field name='code'>172.18</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta173' model='account.account.template'>
-            <field name='name'>Gastos diferidos</field>
-            <field name='code'>173</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_172')])]"/>
         </record>
         <record id='cuenta173_01' model='account.account.template'>
             <field name='name'>Gastos diferidos</field>
             <field name='code'>173.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta174' model='account.account.template'>
-            <field name='name'>Gastos pre operativos</field>
-            <field name='code'>174</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_173')])]"/>
         </record>
         <record id='cuenta174_01' model='account.account.template'>
             <field name='name'>Gastos pre operativos</field>
             <field name='code'>174.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta175' model='account.account.template'>
-            <field name='name'>Regalías, asistencia técnica y otros gastos diferidos</field>
-            <field name='code'>175</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_174')])]"/>
         </record>
         <record id='cuenta175_01' model='account.account.template'>
             <field name='name'>Regalías, asistencia técnica y otros gastos diferidos</field>
             <field name='code'>175.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta176' model='account.account.template'>
-            <field name='name'>Activos intangibles</field>
-            <field name='code'>176</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_175')])]"/>
         </record>
         <record id='cuenta176_01' model='account.account.template'>
             <field name='name'>Activos intangibles</field>
             <field name='code'>176.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta177' model='account.account.template'>
-            <field name='name'>Gastos de organización</field>
-            <field name='code'>177</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_176')])]"/>
         </record>
         <record id='cuenta177_01' model='account.account.template'>
             <field name='name'>Gastos de organización</field>
             <field name='code'>177.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta178' model='account.account.template'>
-            <field name='name'>Investigación y desarrollo de mercado</field>
-            <field name='code'>178</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_177')])]"/>
         </record>
         <record id='cuenta178_01' model='account.account.template'>
             <field name='name'>Investigación y desarrollo de mercado</field>
             <field name='code'>178.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta179' model='account.account.template'>
-            <field name='name'>Marcas y patentes</field>
-            <field name='code'>179</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_178')])]"/>
         </record>
         <record id='cuenta179_01' model='account.account.template'>
             <field name='name'>Marcas y patentes</field>
             <field name='code'>179.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta180' model='account.account.template'>
-            <field name='name'>Crédito mercantil</field>
-            <field name='code'>180</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_179')])]"/>
         </record>
         <record id='cuenta180_01' model='account.account.template'>
             <field name='name'>Crédito mercantil</field>
             <field name='code'>180.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta181' model='account.account.template'>
-            <field name='name'>Gastos de instalación</field>
-            <field name='code'>181</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_180')])]"/>
         </record>
         <record id='cuenta181_01' model='account.account.template'>
             <field name='name'>Gastos de instalación</field>
             <field name='code'>181.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta182' model='account.account.template'>
-            <field name='name'>Otros activos diferidos</field>
-            <field name='code'>182</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_181')])]"/>
         </record>
         <record id='cuenta182_01' model='account.account.template'>
             <field name='name'>Otros activos diferidos</field>
             <field name='code'>182.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta183' model='account.account.template'>
-            <field name='name'>Amortización acumulada de activos diferidos</field>
-            <field name='code'>183</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_182')])]"/>
         </record>
         <record id='cuenta183_01' model='account.account.template'>
             <field name='name'>Amortización acumulada de gastos diferidos</field>
             <field name='code'>183.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_183')])]"/>
         </record>
         <record id='cuenta183_02' model='account.account.template'>
             <field name='name'>Amortización acumulada de gastos pre operativos</field>
             <field name='code'>183.02</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_183')])]"/>
         </record>
         <record id='cuenta183_03' model='account.account.template'>
             <field name='name'>Amortización acumulada de regalías, asistencia técnica y otros gastos diferidos</field>
             <field name='code'>183.03</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_183')])]"/>
         </record>
         <record id='cuenta183_04' model='account.account.template'>
             <field name='name'>Amortización acumulada de activos intangibles</field>
             <field name='code'>183.04</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_183')])]"/>
         </record>
         <record id='cuenta183_05' model='account.account.template'>
             <field name='name'>Amortización acumulada de gastos de organización</field>
             <field name='code'>183.05</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_183')])]"/>
         </record>
         <record id='cuenta183_06' model='account.account.template'>
             <field name='name'>Amortización acumulada de investigación y desarrollo de mercado</field>
             <field name='code'>183.06</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_183')])]"/>
         </record>
         <record id='cuenta183_07' model='account.account.template'>
             <field name='name'>Amortización acumulada de marcas y patentes</field>
             <field name='code'>183.07</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_183')])]"/>
         </record>
         <record id='cuenta183_08' model='account.account.template'>
             <field name='name'>Amortización acumulada de crédito mercantil</field>
             <field name='code'>183.08</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_183')])]"/>
         </record>
         <record id='cuenta183_09' model='account.account.template'>
             <field name='name'>Amortización acumulada de gastos de instalación</field>
             <field name='code'>183.09</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_183')])]"/>
         </record>
         <record id='cuenta183_10' model='account.account.template'>
             <field name='name'>Amortización acumulada de otros activos diferidos</field>
             <field name='code'>183.10</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta184' model='account.account.template'>
-            <field name='name'>Depósitos en garantía</field>
-            <field name='code'>184</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_183')])]"/>
         </record>
         <record id='cuenta184_01' model='account.account.template'>
             <field name='name'>Depósitos de fianzas</field>
             <field name='code'>184.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_184')])]"/>
         </record>
         <record id='cuenta184_02' model='account.account.template'>
             <field name='name'>Depósitos de arrendamiento de bienes inmuebles</field>
             <field name='code'>184.02</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_184')])]"/>
         </record>
         <record id='cuenta184_03' model='account.account.template'>
             <field name='name'>Otros depósitos en garantía</field>
             <field name='code'>184.03</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta185' model='account.account.template'>
-            <field name='name'>Impuestos diferidos</field>
-            <field name='code'>185</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_184')])]"/>
         </record>
         <record id='cuenta185_01' model='account.account.template'>
             <field name='name'>Impuestos diferidos ISR</field>
             <field name='code'>185.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta186' model='account.account.template'>
-            <field name='name'>Cuentas y documentos por cobrar a largo plazo</field>
-            <field name='code'>186</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_185')])]"/>
         </record>
         <record id='cuenta186_01' model='account.account.template'>
             <field name='name'>Cuentas y documentos por cobrar a largo plazo nacional</field>
             <field name='code'>186.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_186')])]"/>
         </record>
         <record id='cuenta186_02' model='account.account.template'>
             <field name='name'>Cuentas y documentos por cobrar a largo plazo extranjero</field>
             <field name='code'>186.02</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_186')])]"/>
         </record>
         <record id='cuenta186_03' model='account.account.template'>
             <field name='name'>Cuentas y documentos por cobrar a largo plazo nacional parte relacionada</field>
             <field name='code'>186.03</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_186')])]"/>
         </record>
         <record id='cuenta186_04' model='account.account.template'>
             <field name='name'>Cuentas y documentos por cobrar a largo plazo extranjero parte relacionada</field>
             <field name='code'>186.04</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_186')])]"/>
         </record>
         <record id='cuenta186_05' model='account.account.template'>
             <field name='name'>Intereses por cobrar a largo plazo nacional</field>
             <field name='code'>186.05</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_186')])]"/>
         </record>
         <record id='cuenta186_06' model='account.account.template'>
             <field name='name'>Intereses por cobrar a largo plazo extranjero</field>
             <field name='code'>186.06</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_186')])]"/>
         </record>
         <record id='cuenta186_07' model='account.account.template'>
             <field name='name'>Intereses por cobrar a largo plazo nacional parte relacionada</field>
             <field name='code'>186.07</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_186')])]"/>
         </record>
         <record id='cuenta186_08' model='account.account.template'>
             <field name='name'>Intereses por cobrar a largo plazo extranjero parte relacionada</field>
             <field name='code'>186.08</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_186')])]"/>
         </record>
         <record id='cuenta186_09' model='account.account.template'>
             <field name='name'>Otras cuentas y documentos por cobrar a largo plazo</field>
             <field name='code'>186.09</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_186')])]"/>
         </record>
         <record id='cuenta186_10' model='account.account.template'>
             <field name='name'>Otras cuentas y documentos por cobrar a largo plazo parte relacionada</field>
             <field name='code'>186.10</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta187' model='account.account.template'>
-            <field name='name'>Participación de los trabajadores en las utilidades diferidas</field>
-            <field name='code'>187</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_186')])]"/>
         </record>
         <record id='cuenta187_01' model='account.account.template'>
             <field name='name'>Participación de los trabajadores en las utilidades diferidas</field>
             <field name='code'>187.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta188' model='account.account.template'>
-            <field name='name'>Inversiones permanentes en acciones</field>
-            <field name='code'>188</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_187')])]"/>
         </record>
         <record id='cuenta188_01' model='account.account.template'>
             <field name='name'>Inversiones a largo plazo en subsidiarias</field>
             <field name='code'>188.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_188')])]"/>
         </record>
         <record id='cuenta188_02' model='account.account.template'>
             <field name='name'>Inversiones a largo plazo en asociadas</field>
             <field name='code'>188.02</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_188')])]"/>
         </record>
         <record id='cuenta188_03' model='account.account.template'>
             <field name='name'>Otras inversiones permanentes en acciones</field>
             <field name='code'>188.03</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta189' model='account.account.template'>
-            <field name='name'>Estimación por deterioro de inversiones permanentes en acciones</field>
-            <field name='code'>189</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_188')])]"/>
         </record>
         <record id='cuenta189_01' model='account.account.template'>
             <field name='name'>Estimación por deterioro de inversiones permanentes en acciones</field>
             <field name='code'>189.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta190' model='account.account.template'>
-            <field name='name'>Otros instrumentos financieros</field>
-            <field name='code'>190</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_189')])]"/>
         </record>
         <record id='cuenta190_01' model='account.account.template'>
             <field name='name'>Otros instrumentos financieros</field>
             <field name='code'>190.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta191' model='account.account.template'>
-            <field name='name'>Otros activos a largo plazo</field>
-            <field name='code'>191</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_190')])]"/>
         </record>
         <record id='cuenta191_01' model='account.account.template'>
             <field name='name'>Otros activos a largo plazo</field>
             <field name='code'>191.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta200' model='account.account.template'>
-            <field name='name'>Pasivo</field>
-            <field name='code'>200</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_190')])]"/>
         </record>
         <record id='cuenta200_01' model='account.account.template'>
             <field name='name'>Pasivo a corto plazo</field>
             <field name='code'>200.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta201' model='account.account.template'>
-            <field name='name'>Proveedores</field>
-            <field name='code'>201</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account.data_account_type_payable"/>
-            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_200')])]"/>
         </record>
         <record id='cuenta201_01' model='account.account.template'>
             <field name='name'>Proveedores nacionales</field>
@@ -1616,6 +1398,7 @@ Cuentas del plan
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account.data_account_type_payable"/>
             <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_201')])]"/>
         </record>
         <record id='cuenta201_02' model='account.account.template'>
             <field name='name'>Proveedores extranjeros</field>
@@ -1623,6 +1406,7 @@ Cuentas del plan
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account.data_account_type_payable"/>
             <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_201')])]"/>
         </record>
         <record id='cuenta201_03' model='account.account.template'>
             <field name='name'>Proveedores nacionales parte relacionada</field>
@@ -1630,6 +1414,7 @@ Cuentas del plan
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account.data_account_type_payable"/>
             <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_201')])]"/>
         </record>
         <record id='cuenta201_04' model='account.account.template'>
             <field name='name'>Proveedores extranjeros parte relacionada</field>
@@ -1637,13 +1422,7 @@ Cuentas del plan
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account.data_account_type_payable"/>
             <field name="reconcile" eval="True"/>
-        </record>
-        <record id='cuenta202' model='account.account.template'>
-            <field name='name'>Cuentas por pagar a corto plazo</field>
-            <field name='code'>202</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account.data_account_type_payable"/>
-            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_201')])]"/>
         </record>
         <record id='cuenta202_01' model='account.account.template'>
             <field name='name'>Documentos por pagar bancario y financiero nacional</field>
@@ -1651,6 +1430,7 @@ Cuentas del plan
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account.data_account_type_payable"/>
             <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_202')])]"/>
         </record>
         <record id='cuenta202_02' model='account.account.template'>
             <field name='name'>Documentos por pagar bancario y financiero extranjero</field>
@@ -1658,6 +1438,7 @@ Cuentas del plan
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account.data_account_type_payable"/>
             <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_202')])]"/>
         </record>
         <record id='cuenta202_03' model='account.account.template'>
             <field name='name'>Documentos y cuentas por pagar a corto plazo nacional</field>
@@ -1665,6 +1446,7 @@ Cuentas del plan
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account.data_account_type_payable"/>
             <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_202')])]"/>
         </record>
         <record id='cuenta202_04' model='account.account.template'>
             <field name='name'>Documentos y cuentas por pagar a corto plazo extranjero</field>
@@ -1672,6 +1454,7 @@ Cuentas del plan
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account.data_account_type_payable"/>
             <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_202')])]"/>
         </record>
         <record id='cuenta202_05' model='account.account.template'>
             <field name='name'>Documentos y cuentas por pagar a corto plazo nacional parte relacionada</field>
@@ -1679,6 +1462,7 @@ Cuentas del plan
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account.data_account_type_payable"/>
             <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_202')])]"/>
         </record>
         <record id='cuenta202_06' model='account.account.template'>
             <field name='name'>Documentos y cuentas por pagar a corto plazo extranjero parte relacionada</field>
@@ -1686,6 +1470,7 @@ Cuentas del plan
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account.data_account_type_payable"/>
             <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_202')])]"/>
         </record>
         <record id='cuenta202_07' model='account.account.template'>
             <field name='name'>Intereses por pagar a corto plazo nacional</field>
@@ -1693,6 +1478,7 @@ Cuentas del plan
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account.data_account_type_payable"/>
             <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_202')])]"/>
         </record>
         <record id='cuenta202_08' model='account.account.template'>
             <field name='name'>Intereses por pagar a corto plazo extranjero</field>
@@ -1700,6 +1486,7 @@ Cuentas del plan
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account.data_account_type_payable"/>
             <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_202')])]"/>
         </record>
         <record id='cuenta202_09' model='account.account.template'>
             <field name='name'>Intereses por pagar a corto plazo nacional parte relacionada</field>
@@ -1707,6 +1494,7 @@ Cuentas del plan
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account.data_account_type_payable"/>
             <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_202')])]"/>
         </record>
         <record id='cuenta202_10' model='account.account.template'>
             <field name='name'>Intereses por pagar a corto plazo extranjero parte relacionada</field>
@@ -1714,6 +1502,7 @@ Cuentas del plan
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account.data_account_type_payable"/>
             <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_202')])]"/>
         </record>
         <record id='cuenta202_11' model='account.account.template'>
             <field name='name'>Dividendo por pagar nacional</field>
@@ -1721,6 +1510,7 @@ Cuentas del plan
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account.data_account_type_payable"/>
             <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_202')])]"/>
         </record>
         <record id='cuenta202_12' model='account.account.template'>
             <field name='name'>Dividendo por pagar extranjero</field>
@@ -1728,13 +1518,7 @@ Cuentas del plan
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account.data_account_type_payable"/>
             <field name="reconcile" eval="True"/>
-        </record>
-        <record id='cuenta203' model='account.account.template'>
-            <field name='name'>Cobros anticipados a corto plazo</field>
-            <field name='code'>203</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account.data_account_type_payable"/>
-            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_202')])]"/>
         </record>
         <record id='cuenta203_01' model='account.account.template'>
             <field name='name'>Rentas cobradas por anticipado a corto plazo nacional</field>
@@ -1742,6 +1526,7 @@ Cuentas del plan
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account.data_account_type_payable"/>
             <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_203')])]"/>
         </record>
         <record id='cuenta203_02' model='account.account.template'>
             <field name='name'>Rentas cobradas por anticipado a corto plazo extranjero</field>
@@ -1749,6 +1534,7 @@ Cuentas del plan
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account.data_account_type_payable"/>
             <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_203')])]"/>
         </record>
         <record id='cuenta203_03' model='account.account.template'>
             <field name='name'>Rentas cobradas por anticipado a corto plazo nacional parte relacionada</field>
@@ -1756,6 +1542,7 @@ Cuentas del plan
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account.data_account_type_payable"/>
             <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_203')])]"/>
         </record>
         <record id='cuenta203_04' model='account.account.template'>
             <field name='name'>Rentas cobradas por anticipado a corto plazo extranjero parte relacionada</field>
@@ -1763,6 +1550,7 @@ Cuentas del plan
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account.data_account_type_payable"/>
             <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_203')])]"/>
         </record>
         <record id='cuenta203_05' model='account.account.template'>
             <field name='name'>Intereses cobrados por anticipado a corto plazo nacional</field>
@@ -1770,6 +1558,7 @@ Cuentas del plan
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account.data_account_type_payable"/>
             <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_203')])]"/>
         </record>
         <record id='cuenta203_06' model='account.account.template'>
             <field name='name'>Intereses cobrados por anticipado a corto plazo extranjero</field>
@@ -1777,6 +1566,7 @@ Cuentas del plan
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account.data_account_type_payable"/>
             <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_203')])]"/>
         </record>
         <record id='cuenta203_07' model='account.account.template'>
             <field name='name'>Intereses cobrados por anticipado a corto plazo nacional parte relacionada</field>
@@ -1784,6 +1574,7 @@ Cuentas del plan
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account.data_account_type_payable"/>
             <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_203')])]"/>
         </record>
         <record id='cuenta203_08' model='account.account.template'>
             <field name='name'>Intereses cobrados por anticipado a corto plazo extranjero parte relacionada</field>
@@ -1791,6 +1582,7 @@ Cuentas del plan
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account.data_account_type_payable"/>
             <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_203')])]"/>
         </record>
         <record id='cuenta203_09' model='account.account.template'>
             <field name='name'>Factoraje financiero cobrados por anticipado a corto plazo nacional</field>
@@ -1798,6 +1590,7 @@ Cuentas del plan
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account.data_account_type_payable"/>
             <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_203')])]"/>
         </record>
         <record id='cuenta203_10' model='account.account.template'>
             <field name='name'>Factoraje financiero cobrados por anticipado a corto plazo extranjero</field>
@@ -1805,6 +1598,7 @@ Cuentas del plan
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account.data_account_type_payable"/>
             <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_203')])]"/>
         </record>
         <record id='cuenta203_11' model='account.account.template'>
             <field name='name'>Factoraje financiero cobrados por anticipado a corto plazo nacional parte relacionada</field>
@@ -1812,6 +1606,7 @@ Cuentas del plan
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account.data_account_type_payable"/>
             <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_203')])]"/>
         </record>
         <record id='cuenta203_12' model='account.account.template'>
             <field name='name'>Factoraje financiero cobrados por anticipado a corto plazo extranjero parte relacionada</field>
@@ -1819,6 +1614,7 @@ Cuentas del plan
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account.data_account_type_payable"/>
             <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_203')])]"/>
         </record>
         <record id='cuenta203_13' model='account.account.template'>
             <field name='name'>Arrendamiento financiero cobrados por anticipado a corto plazo nacional</field>
@@ -1826,6 +1622,7 @@ Cuentas del plan
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account.data_account_type_payable"/>
             <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_203')])]"/>
         </record>
         <record id='cuenta203_14' model='account.account.template'>
             <field name='name'>Arrendamiento financiero cobrados por anticipado a corto plazo extranjero</field>
@@ -1833,6 +1630,7 @@ Cuentas del plan
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account.data_account_type_payable"/>
             <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_203')])]"/>
         </record>
         <record id='cuenta203_15' model='account.account.template'>
             <field name='name'>Arrendamiento financiero cobrados por anticipado a corto plazo nacional parte relacionada</field>
@@ -1840,6 +1638,7 @@ Cuentas del plan
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account.data_account_type_payable"/>
             <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_203')])]"/>
         </record>
         <record id='cuenta203_16' model='account.account.template'>
             <field name='name'>Arrendamiento financiero cobrados por anticipado a corto plazo extranjero parte relacionada</field>
@@ -1847,6 +1646,7 @@ Cuentas del plan
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account.data_account_type_payable"/>
             <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_203')])]"/>
         </record>
         <record id='cuenta203_17' model='account.account.template'>
             <field name='name'>Derechos fiduciarios</field>
@@ -1854,6 +1654,7 @@ Cuentas del plan
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account.data_account_type_payable"/>
             <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_203')])]"/>
         </record>
         <record id='cuenta203_18' model='account.account.template'>
             <field name='name'>Otros cobros anticipados</field>
@@ -1861,3977 +1662,4234 @@ Cuentas del plan
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account.data_account_type_payable"/>
             <field name="reconcile" eval="True"/>
-        </record>
-        <record id='cuenta204' model='account.account.template'>
-            <field name='name'>Instrumentos financieros a corto plazo</field>
-            <field name='code'>204</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_203')])]"/>
         </record>
         <record id='cuenta204_01' model='account.account.template'>
             <field name='name'>Instrumentos financieros a corto plazo</field>
             <field name='code'>204.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta205' model='account.account.template'>
-            <field name='name'>Acreedores diversos a corto plazo</field>
-            <field name='code'>205</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_204')])]"/>
         </record>
         <record id='cuenta205_01' model='account.account.template'>
             <field name='name'>Socios, accionistas o representante legal</field>
             <field name='code'>205.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_205')])]"/>
         </record>
         <record id='cuenta205_02' model='account.account.template'>
             <field name='name'>Acreedores diversos a corto plazo nacional</field>
             <field name='code'>205.02</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_205')])]"/>
         </record>
         <record id='cuenta205_03' model='account.account.template'>
             <field name='name'>Acreedores diversos a corto plazo extranjero</field>
             <field name='code'>205.03</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_205')])]"/>
         </record>
         <record id='cuenta205_04' model='account.account.template'>
             <field name='name'>Acreedores diversos a corto plazo nacional parte relacionada</field>
             <field name='code'>205.04</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_205')])]"/>
         </record>
         <record id='cuenta205_05' model='account.account.template'>
             <field name='name'>Acreedores diversos a corto plazo extranjero parte relacionada</field>
             <field name='code'>205.05</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_205')])]"/>
         </record>
         <record id='cuenta205_06' model='account.account.template'>
             <field name='name'>Otros acreedores diversos a corto plazo</field>
             <field name='code'>205.06</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta206' model='account.account.template'>
-            <field name='name'>Anticipo de cliente</field>
-            <field name='code'>206</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_205')])]"/>
         </record>
         <record id='cuenta206_01' model='account.account.template'>
             <field name='name'>Anticipo de cliente nacional</field>
             <field name='code'>206.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_206')])]"/>
         </record>
         <record id='cuenta206_02' model='account.account.template'>
             <field name='name'>Anticipo de cliente extranjero</field>
             <field name='code'>206.02</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_206')])]"/>
         </record>
         <record id='cuenta206_03' model='account.account.template'>
             <field name='name'>Anticipo de cliente nacional parte relacionada</field>
             <field name='code'>206.03</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_206')])]"/>
         </record>
         <record id='cuenta206_04' model='account.account.template'>
             <field name='name'>Anticipo de cliente extranjero parte relacionada</field>
             <field name='code'>206.04</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_206')])]"/>
         </record>
         <record id='cuenta206_05' model='account.account.template'>
             <field name='name'>Otros anticipos de clientes</field>
             <field name='code'>206.05</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta207' model='account.account.template'>
-            <field name='name'>Impuestos trasladados</field>
-            <field name='code'>207</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_206')])]"/>
         </record>
         <record id='cuenta207_01' model='account.account.template'>
             <field name='name'>IVA trasladado</field>
             <field name='code'>207.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_207')])]"/>
         </record>
         <record id='cuenta207_02' model='account.account.template'>
             <field name='name'>IEPS trasladado</field>
             <field name='code'>207.02</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta208' model='account.account.template'>
-            <field name='name'>Impuestos trasladados cobrados</field>
-            <field name='code'>208</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_207')])]"/>
         </record>
         <record id='cuenta208_01' model='account.account.template'>
             <field name='name'>IVA trasladado cobrado</field>
             <field name='code'>208.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_208')])]"/>
         </record>
         <record id='cuenta208_02' model='account.account.template'>
             <field name='name'>IEPS trasladado cobrado</field>
             <field name='code'>208.02</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta209' model='account.account.template'>
-            <field name='name'>Impuestos trasladados no cobrados</field>
-            <field name='code'>209</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_208')])]"/>
         </record>
         <record id='cuenta209_01' model='account.account.template'>
             <field name='name'>IVA trasladado no cobrado</field>
             <field name='code'>209.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_209')])]"/>
         </record>
         <record id='cuenta209_02' model='account.account.template'>
             <field name='name'>IEPS trasladado no cobrado</field>
             <field name='code'>209.02</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta210' model='account.account.template'>
-            <field name='name'>Provisión de sueldos y salarios por pagar</field>
-            <field name='code'>210</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_209')])]"/>
         </record>
         <record id='cuenta210_01' model='account.account.template'>
             <field name='name'>Provisión de sueldos y salarios por pagar</field>
             <field name='code'>210.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_210')])]"/>
         </record>
         <record id='cuenta210_02' model='account.account.template'>
             <field name='name'>Provisión de vacaciones por pagar</field>
             <field name='code'>210.02</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_210')])]"/>
         </record>
         <record id='cuenta210_03' model='account.account.template'>
             <field name='name'>Provisión de aguinaldo por pagar</field>
             <field name='code'>210.03</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_210')])]"/>
         </record>
         <record id='cuenta210_04' model='account.account.template'>
             <field name='name'>Provisión de fondo de ahorro por pagar</field>
             <field name='code'>210.04</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_210')])]"/>
         </record>
         <record id='cuenta210_05' model='account.account.template'>
             <field name='name'>Provisión de asimilados a salarios por pagar</field>
             <field name='code'>210.05</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_210')])]"/>
         </record>
         <record id='cuenta210_06' model='account.account.template'>
             <field name='name'>Provisión de anticipos o remanentes por distribuir</field>
             <field name='code'>210.06</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_210')])]"/>
         </record>
         <record id='cuenta210_07' model='account.account.template'>
             <field name='name'>Provisión de otros sueldos y salarios por pagar</field>
             <field name='code'>210.07</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta211' model='account.account.template'>
-            <field name='name'>Provisión de contribuciones de seguridad social por pagar</field>
-            <field name='code'>211</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_210')])]"/>
         </record>
         <record id='cuenta211_01' model='account.account.template'>
             <field name='name'>Provisión de IMSS patronal por pagar</field>
             <field name='code'>211.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_211')])]"/>
         </record>
         <record id='cuenta211_02' model='account.account.template'>
             <field name='name'>Provisión de SAR por pagar</field>
             <field name='code'>211.02</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_211')])]"/>
         </record>
         <record id='cuenta211_03' model='account.account.template'>
             <field name='name'>Provisión de infonavit por pagar</field>
             <field name='code'>211.03</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta212' model='account.account.template'>
-            <field name='name'>Provisión de impuesto estatal sobre nómina por pagar</field>
-            <field name='code'>212</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_211')])]"/>
         </record>
         <record id='cuenta212_01' model='account.account.template'>
             <field name='name'>Provisión de impuesto estatal sobre nómina por pagar</field>
             <field name='code'>212.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta213' model='account.account.template'>
-            <field name='name'>Impuestos y derechos por pagar</field>
-            <field name='code'>213</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_212')])]"/>
         </record>
         <record id='cuenta213_01' model='account.account.template'>
             <field name='name'>IVA por pagar</field>
             <field name='code'>213.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_213')])]"/>
         </record>
         <record id='cuenta213_02' model='account.account.template'>
             <field name='name'>IEPS por pagar</field>
             <field name='code'>213.02</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_213')])]"/>
         </record>
         <record id='cuenta213_03' model='account.account.template'>
             <field name='name'>ISR por pagar</field>
             <field name='code'>213.03</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_213')])]"/>
         </record>
         <record id='cuenta213_04' model='account.account.template'>
             <field name='name'>Impuesto estatal sobre nómina por pagar</field>
             <field name='code'>213.04</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_213')])]"/>
         </record>
         <record id='cuenta213_05' model='account.account.template'>
             <field name='name'>Impuesto estatal y municipal por pagar</field>
             <field name='code'>213.05</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_213')])]"/>
         </record>
         <record id='cuenta213_06' model='account.account.template'>
             <field name='name'>Derechos por pagar</field>
             <field name='code'>213.06</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_213')])]"/>
         </record>
         <record id='cuenta213_07' model='account.account.template'>
             <field name='name'>Otros impuestos por pagar</field>
             <field name='code'>213.07</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta214' model='account.account.template'>
-            <field name='name'>Dividendos por pagar</field>
-            <field name='code'>214</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_213')])]"/>
         </record>
         <record id='cuenta214_01' model='account.account.template'>
             <field name='name'>Dividendos por pagar</field>
             <field name='code'>214.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta215' model='account.account.template'>
-            <field name='name'>PTU por pagar</field>
-            <field name='code'>215</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_214')])]"/>
         </record>
         <record id='cuenta215_01' model='account.account.template'>
             <field name='name'>PTU por pagar</field>
             <field name='code'>215.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_215')])]"/>
         </record>
         <record id='cuenta215_02' model='account.account.template'>
             <field name='name'>PTU por pagar de ejercicios anteriores</field>
             <field name='code'>215.02</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_215')])]"/>
         </record>
         <record id='cuenta215_03' model='account.account.template'>
             <field name='name'>Provisión de PTU por pagar</field>
             <field name='code'>215.03</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta216' model='account.account.template'>
-            <field name='name'>Impuestos retenidos</field>
-            <field name='code'>216</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_215')])]"/>
         </record>
         <record id='cuenta216_01' model='account.account.template'>
             <field name='name'>Impuestos retenidos de ISR por sueldos y salarios</field>
             <field name='code'>216.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_216')])]"/>
         </record>
         <record id='cuenta216_02' model='account.account.template'>
             <field name='name'>Impuestos retenidos de ISR por asimilados a salarios</field>
             <field name='code'>216.02</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_216')])]"/>
         </record>
         <record id='cuenta216_03' model='account.account.template'>
             <field name='name'>Impuestos retenidos de ISR por arrendamiento</field>
             <field name='code'>216.03</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_216')])]"/>
         </record>
         <record id='cuenta216_04' model='account.account.template'>
             <field name='name'>Impuestos retenidos de ISR por servicios profesionales</field>
             <field name='code'>216.04</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_216')])]"/>
         </record>
         <record id='cuenta216_05' model='account.account.template'>
             <field name='name'>Impuestos retenidos de ISR por dividendos</field>
             <field name='code'>216.05</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_216')])]"/>
         </record>
         <record id='cuenta216_06' model='account.account.template'>
             <field name='name'>Impuestos retenidos de ISR por intereses</field>
             <field name='code'>216.06</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_216')])]"/>
         </record>
         <record id='cuenta216_07' model='account.account.template'>
             <field name='name'>Impuestos retenidos de ISR por pagos al extranjero</field>
             <field name='code'>216.07</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_216')])]"/>
         </record>
         <record id='cuenta216_08' model='account.account.template'>
             <field name='name'>Impuestos retenidos de ISR por venta de acciones</field>
             <field name='code'>216.08</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_216')])]"/>
         </record>
         <record id='cuenta216_09' model='account.account.template'>
             <field name='name'>Impuestos retenidos de ISR por venta de partes sociales</field>
             <field name='code'>216.09</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_216')])]"/>
         </record>
         <record id='cuenta216_10' model='account.account.template'>
             <field name='name'>Impuestos retenidos de IVA</field>
             <field name='code'>216.10</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_216')])]"/>
         </record>
         <record id='cuenta216_11' model='account.account.template'>
             <field name='name'>Retenciones de IMSS a los trabajadores</field>
             <field name='code'>216.11</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_216')])]"/>
         </record>
         <record id='cuenta216_12' model='account.account.template'>
             <field name='name'>Otras impuestos retenidos</field>
             <field name='code'>216.12</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta217' model='account.account.template'>
-            <field name='name'>Pagos realizados por cuenta de terceros</field>
-            <field name='code'>217</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_216')])]"/>
         </record>
         <record id='cuenta217_01' model='account.account.template'>
             <field name='name'>Pagos realizados por cuenta de terceros</field>
             <field name='code'>217.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta218' model='account.account.template'>
-            <field name='name'>Otros pasivos a corto plazo</field>
-            <field name='code'>218</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_217')])]"/>
         </record>
         <record id='cuenta218_01' model='account.account.template'>
             <field name='name'>Otros pasivos a corto plazo</field>
             <field name='code'>218.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta200_02' model='account.account.template'>
-            <field name='name'>Pasivo a largo plazo</field>
-            <field name='code'>200.02</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta251' model='account.account.template'>
-            <field name='name'>Acreedores diversos a largo plazo</field>
-            <field name='code'>251</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_218')])]"/>
         </record>
         <record id='cuenta251_01' model='account.account.template'>
             <field name='name'>Socios, accionistas o representante legal</field>
             <field name='code'>251.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_251')])]"/>
         </record>
         <record id='cuenta251_02' model='account.account.template'>
             <field name='name'>Acreedores diversos a largo plazo nacional</field>
             <field name='code'>251.02</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_251')])]"/>
         </record>
         <record id='cuenta251_03' model='account.account.template'>
             <field name='name'>Acreedores diversos a largo plazo extranjero</field>
             <field name='code'>251.03</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_251')])]"/>
         </record>
         <record id='cuenta251_04' model='account.account.template'>
             <field name='name'>Acreedores diversos a largo plazo nacional parte relacionada</field>
             <field name='code'>251.04</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_251')])]"/>
         </record>
         <record id='cuenta251_05' model='account.account.template'>
             <field name='name'>Acreedores diversos a largo plazo extranjero parte relacionada</field>
             <field name='code'>251.05</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_251')])]"/>
         </record>
         <record id='cuenta251_06' model='account.account.template'>
             <field name='name'>Otros acreedores diversos a largo plazo</field>
             <field name='code'>251.06</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta252' model='account.account.template'>
-            <field name='name'>Cuentas por pagar a largo plazo</field>
-            <field name='code'>252</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_251')])]"/>
         </record>
         <record id='cuenta252_01' model='account.account.template'>
             <field name='name'>Documentos bancarios y financieros por pagar a largo plazo nacional</field>
             <field name='code'>252.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_252')])]"/>
         </record>
         <record id='cuenta252_02' model='account.account.template'>
             <field name='name'>Documentos bancarios y financieros por pagar a largo plazo extranjero</field>
             <field name='code'>252.02</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_252')])]"/>
         </record>
         <record id='cuenta252_03' model='account.account.template'>
             <field name='name'>Documentos y cuentas por pagar a largo plazo nacional</field>
             <field name='code'>252.03</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_252')])]"/>
         </record>
         <record id='cuenta252_04' model='account.account.template'>
             <field name='name'>Documentos y cuentas por pagar a largo plazo extranjero</field>
             <field name='code'>252.04</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_252')])]"/>
         </record>
         <record id='cuenta252_05' model='account.account.template'>
             <field name='name'>Documentos y cuentas por pagar a largo plazo nacional parte relacionada</field>
             <field name='code'>252.05</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_252')])]"/>
         </record>
         <record id='cuenta252_06' model='account.account.template'>
             <field name='name'>Documentos y cuentas por pagar a largo plazo extranjero parte relacionada</field>
             <field name='code'>252.06</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_252')])]"/>
         </record>
         <record id='cuenta252_07' model='account.account.template'>
             <field name='name'>Hipotecas por pagar a largo plazo nacional</field>
             <field name='code'>252.07</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_252')])]"/>
         </record>
         <record id='cuenta252_08' model='account.account.template'>
             <field name='name'>Hipotecas por pagar a largo plazo extranjero</field>
             <field name='code'>252.08</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_252')])]"/>
         </record>
         <record id='cuenta252_09' model='account.account.template'>
             <field name='name'>Hipotecas por pagar a largo plazo nacional parte relacionada</field>
             <field name='code'>252.09</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_252')])]"/>
         </record>
         <record id='cuenta252_10' model='account.account.template'>
             <field name='name'>Hipotecas por pagar a largo plazo extranjero parte relacionada</field>
             <field name='code'>252.10</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_252')])]"/>
         </record>
         <record id='cuenta252_11' model='account.account.template'>
             <field name='name'>Intereses por pagar a largo plazo nacional</field>
             <field name='code'>252.11</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_252')])]"/>
         </record>
         <record id='cuenta252_12' model='account.account.template'>
             <field name='name'>Intereses por pagar a largo plazo extranjero</field>
             <field name='code'>252.12</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_252')])]"/>
         </record>
         <record id='cuenta252_13' model='account.account.template'>
             <field name='name'>Intereses por pagar a largo plazo nacional parte relacionada</field>
             <field name='code'>252.13</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_252')])]"/>
         </record>
         <record id='cuenta252_14' model='account.account.template'>
             <field name='name'>Intereses por pagar a largo plazo extranjero parte relacionada</field>
             <field name='code'>252.14</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_252')])]"/>
         </record>
         <record id='cuenta252_15' model='account.account.template'>
             <field name='name'>Dividendos por pagar nacionales</field>
             <field name='code'>252.15</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_252')])]"/>
         </record>
         <record id='cuenta252_16' model='account.account.template'>
             <field name='name'>Dividendos por pagar extranjeros</field>
             <field name='code'>252.16</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_252')])]"/>
         </record>
         <record id='cuenta252_17' model='account.account.template'>
             <field name='name'>Otras cuentas y documentos por pagar a largo plazo</field>
             <field name='code'>252.17</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta253' model='account.account.template'>
-            <field name='name'>Cobros anticipados a largo plazo</field>
-            <field name='code'>253</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_252')])]"/>
         </record>
         <record id='cuenta253_01' model='account.account.template'>
             <field name='name'>Rentas cobradas por anticipado a largo plazo nacional</field>
             <field name='code'>253.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_253')])]"/>
         </record>
         <record id='cuenta253_02' model='account.account.template'>
             <field name='name'>Rentas cobradas por anticipado a largo plazo extranjero</field>
             <field name='code'>253.02</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_253')])]"/>
         </record>
         <record id='cuenta253_03' model='account.account.template'>
             <field name='name'>Rentas cobradas por anticipado a largo plazo nacional parte relacionada</field>
             <field name='code'>253.03</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_253')])]"/>
         </record>
         <record id='cuenta253_04' model='account.account.template'>
             <field name='name'>Rentas cobradas por anticipado a largo plazo extranjero parte relacionada</field>
             <field name='code'>253.04</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_253')])]"/>
         </record>
         <record id='cuenta253_05' model='account.account.template'>
             <field name='name'>Intereses cobrados por anticipado a largo plazo nacional</field>
             <field name='code'>253.05</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_253')])]"/>
         </record>
         <record id='cuenta253_06' model='account.account.template'>
             <field name='name'>Intereses cobrados por anticipado a largo plazo extranjero</field>
             <field name='code'>253.06</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_253')])]"/>
         </record>
         <record id='cuenta253_07' model='account.account.template'>
             <field name='name'>Intereses cobrados por anticipado a largo plazo nacional parte relacionada</field>
             <field name='code'>253.07</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_253')])]"/>
         </record>
         <record id='cuenta253_08' model='account.account.template'>
             <field name='name'>Intereses cobrados por anticipado a largo plazo extranjero parte relacionada</field>
             <field name='code'>253.08</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_253')])]"/>
         </record>
         <record id='cuenta253_09' model='account.account.template'>
             <field name='name'>Factoraje financiero cobrados por anticipado a largo plazo nacional</field>
             <field name='code'>253.09</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_253')])]"/>
         </record>
         <record id='cuenta253_10' model='account.account.template'>
             <field name='name'>Factoraje financiero cobrados por anticipado a largo plazo extranjero</field>
             <field name='code'>253.10</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_253')])]"/>
         </record>
         <record id='cuenta253_11' model='account.account.template'>
             <field name='name'>Factoraje financiero cobrados por anticipado a largo plazo nacional parte relacionada</field>
             <field name='code'>253.11</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_253')])]"/>
         </record>
         <record id='cuenta253_12' model='account.account.template'>
             <field name='name'>Factoraje financiero cobrados por anticipado a largo plazo extranjero parte relacionada</field>
             <field name='code'>253.12</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_253')])]"/>
         </record>
         <record id='cuenta253_13' model='account.account.template'>
             <field name='name'>Arrendamiento financiero cobrados por anticipado a largo plazo nacional</field>
             <field name='code'>253.13</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_253')])]"/>
         </record>
         <record id='cuenta253_14' model='account.account.template'>
             <field name='name'>Arrendamiento financiero cobrados por anticipado a largo plazo extranjero</field>
             <field name='code'>253.14</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_253')])]"/>
         </record>
         <record id='cuenta253_15' model='account.account.template'>
             <field name='name'>Arrendamiento financiero cobrados por anticipado a largo plazo nacional parte relacionada</field>
             <field name='code'>253.15</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_253')])]"/>
         </record>
         <record id='cuenta253_16' model='account.account.template'>
             <field name='name'>Arrendamiento financiero cobrados por anticipado a largo plazo extranjero parte relacionada</field>
             <field name='code'>253.16</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_253')])]"/>
         </record>
         <record id='cuenta253_17' model='account.account.template'>
             <field name='name'>Derechos fiduciarios</field>
             <field name='code'>253.17</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_253')])]"/>
         </record>
         <record id='cuenta253_18' model='account.account.template'>
             <field name='name'>Otros cobros anticipados</field>
             <field name='code'>253.18</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta254' model='account.account.template'>
-            <field name='name'>Instrumentos financieros a largo plazo</field>
-            <field name='code'>254</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_253')])]"/>
         </record>
         <record id='cuenta254_01' model='account.account.template'>
             <field name='name'>Instrumentos financieros a largo plazo</field>
             <field name='code'>254.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta255' model='account.account.template'>
-            <field name='name'>Pasivos por beneficios a los empleados a largo plazo</field>
-            <field name='code'>255</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_254')])]"/>
         </record>
         <record id='cuenta255_01' model='account.account.template'>
             <field name='name'>Pasivos por beneficios a los empleados a largo plazo</field>
             <field name='code'>255.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta256' model='account.account.template'>
-            <field name='name'>Otros pasivos a largo plazo</field>
-            <field name='code'>256</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_255')])]"/>
         </record>
         <record id='cuenta256_01' model='account.account.template'>
             <field name='name'>Otros pasivos a largo plazo</field>
             <field name='code'>256.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta257' model='account.account.template'>
-            <field name='name'>Participación de los trabajadores en las utilidades diferida</field>
-            <field name='code'>257</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_256')])]"/>
         </record>
         <record id='cuenta257_01' model='account.account.template'>
             <field name='name'>Participación de los trabajadores en las utilidades diferida</field>
             <field name='code'>257.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta258' model='account.account.template'>
-            <field name='name'>Obligaciones contraídas de fideicomisos</field>
-            <field name='code'>258</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_257')])]"/>
         </record>
         <record id='cuenta258_01' model='account.account.template'>
             <field name='name'>Obligaciones contraídas de fideicomisos</field>
             <field name='code'>258.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta259' model='account.account.template'>
-            <field name='name'>Impuestos diferidos</field>
-            <field name='code'>259</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_258')])]"/>
         </record>
         <record id='cuenta259_01' model='account.account.template'>
             <field name='name'>ISR diferido</field>
             <field name='code'>259.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_259')])]"/>
         </record>
         <record id='cuenta259_02' model='account.account.template'>
             <field name='name'>ISR por dividendo diferido</field>
             <field name='code'>259.02</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_259')])]"/>
         </record>
         <record id='cuenta259_03' model='account.account.template'>
             <field name='name'>Otros impuestos diferidos</field>
             <field name='code'>259.03</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta260' model='account.account.template'>
-            <field name='name'>Pasivos diferidos</field>
-            <field name='code'>260</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_259')])]"/>
         </record>
         <record id='cuenta260_01' model='account.account.template'>
             <field name='name'>Pasivos diferidos</field>
             <field name='code'>260.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta300' model='account.account.template'>
-            <field name='name'>Capital contable</field>
-            <field name='code'>300</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta301' model='account.account.template'>
-            <field name='name'>Capital social</field>
-            <field name='code'>301</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_260')])]"/>
         </record>
         <record id='cuenta301_01' model='account.account.template'>
             <field name='name'>Capital fijo</field>
             <field name='code'>301.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_301')])]"/>
         </record>
         <record id='cuenta301_02' model='account.account.template'>
             <field name='name'>Capital variable</field>
             <field name='code'>301.02</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_301')])]"/>
         </record>
         <record id='cuenta301_03' model='account.account.template'>
             <field name='name'>Aportaciones para futuros aumentos de capital</field>
             <field name='code'>301.03</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_301')])]"/>
         </record>
         <record id='cuenta301_04' model='account.account.template'>
             <field name='name'>Prima en suscripción de acciones</field>
             <field name='code'>301.04</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_301')])]"/>
         </record>
         <record id='cuenta301_05' model='account.account.template'>
             <field name='name'>Prima en suscripción de partes sociales</field>
             <field name='code'>301.05</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta302' model='account.account.template'>
-            <field name='name'>Patrimonio</field>
-            <field name='code'>302</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_301')])]"/>
         </record>
         <record id='cuenta302_01' model='account.account.template'>
             <field name='name'>Patrimonio</field>
             <field name='code'>302.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_302')])]"/>
         </record>
         <record id='cuenta302_02' model='account.account.template'>
             <field name='name'>Aportación patrimonial</field>
             <field name='code'>302.02</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_302')])]"/>
         </record>
         <record id='cuenta302_03' model='account.account.template'>
             <field name='name'>Déficit o remanente del ejercicio</field>
             <field name='code'>302.03</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta303' model='account.account.template'>
-            <field name='name'>Reserva legal</field>
-            <field name='code'>303</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_302')])]"/>
         </record>
         <record id='cuenta303_01' model='account.account.template'>
             <field name='name'>Reserva legal</field>
             <field name='code'>303.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta304' model='account.account.template'>
-            <field name='name'>Resultado de ejercicios anteriores</field>
-            <field name='code'>304</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_303')])]"/>
         </record>
         <record id='cuenta304_01' model='account.account.template'>
             <field name='name'>Utilidad de ejercicios anteriores</field>
             <field name='code'>304.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_304')])]"/>
         </record>
         <record id='cuenta304_02' model='account.account.template'>
             <field name='name'>Pérdida de ejercicios anteriores</field>
             <field name='code'>304.02</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_304')])]"/>
         </record>
         <record id='cuenta304_03' model='account.account.template'>
             <field name='name'>Resultado integral de ejercicios anteriores</field>
             <field name='code'>304.03</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_304')])]"/>
         </record>
         <record id='cuenta304_04' model='account.account.template'>
             <field name='name'>Déficit o remanente de ejercicio anteriores</field>
             <field name='code'>304.04</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta305' model='account.account.template'>
-            <field name='name'>Resultado del ejercicio</field>
-            <field name='code'>305</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_304')])]"/>
         </record>
         <record id='cuenta305_01' model='account.account.template'>
             <field name='name'>Utilidad del ejercicio</field>
             <field name='code'>305.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_305')])]"/>
         </record>
         <record id='cuenta305_02' model='account.account.template'>
             <field name='name'>Pérdida del ejercicio</field>
             <field name='code'>305.02</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_305')])]"/>
         </record>
         <record id='cuenta305_03' model='account.account.template'>
             <field name='name'>Resultado integral</field>
             <field name='code'>305.03</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta306' model='account.account.template'>
-            <field name='name'>Otras cuentas de capital</field>
-            <field name='code'>306</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_305')])]"/>
         </record>
         <record id='cuenta306_01' model='account.account.template'>
             <field name='name'>Otras cuentas de capital</field>
             <field name='code'>306.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta400' model='account.account.template'>
-            <field name='name'>Ingresos</field>
-            <field name='code'>400</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta401' model='account.account.template'>
-            <field name='name'>Ingresos</field>
-            <field name='code'>401</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_306')])]"/>
         </record>
         <record id='cuenta401_01' model='account.account.template'>
             <field name='name'>Ventas y/o servicios gravados a la tasa general</field>
             <field name='code'>401.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_401')])]"/>
         </record>
         <record id='cuenta401_02' model='account.account.template'>
             <field name='name'>Ventas y/o servicios gravados a la tasa general de contado</field>
             <field name='code'>401.02</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_401')])]"/>
         </record>
         <record id='cuenta401_03' model='account.account.template'>
             <field name='name'>Ventas y/o servicios gravados a la tasa general a crédito</field>
             <field name='code'>401.03</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_401')])]"/>
         </record>
         <record id='cuenta401_04' model='account.account.template'>
             <field name='name'>Ventas y/o servicios gravados al 0%</field>
             <field name='code'>401.04</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_401')])]"/>
         </record>
         <record id='cuenta401_05' model='account.account.template'>
             <field name='name'>Ventas y/o servicios gravados al 0% de contado</field>
             <field name='code'>401.05</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_401')])]"/>
         </record>
         <record id='cuenta401_06' model='account.account.template'>
             <field name='name'>Ventas y/o servicios gravados al 0% a crédito</field>
             <field name='code'>401.06</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_401')])]"/>
         </record>
         <record id='cuenta401_07' model='account.account.template'>
             <field name='name'>Ventas y/o servicios exentos</field>
             <field name='code'>401.07</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_401')])]"/>
         </record>
         <record id='cuenta401_08' model='account.account.template'>
             <field name='name'>Ventas y/o servicios exentos de contado</field>
             <field name='code'>401.08</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_401')])]"/>
         </record>
         <record id='cuenta401_09' model='account.account.template'>
             <field name='name'>Ventas y/o servicios exentos a crédito</field>
             <field name='code'>401.09</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_401')])]"/>
         </record>
         <record id='cuenta401_10' model='account.account.template'>
             <field name='name'>Ventas y/o servicios gravados a la tasa general nacionales partes relacionadas</field>
             <field name='code'>401.10</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_401')])]"/>
         </record>
         <record id='cuenta401_11' model='account.account.template'>
             <field name='name'>Ventas y/o servicios gravados a la tasa general extranjeros partes relacionadas</field>
             <field name='code'>401.11</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_401')])]"/>
         </record>
         <record id='cuenta401_12' model='account.account.template'>
             <field name='name'>Ventas y/o servicios gravados al 0% nacionales partes relacionadas</field>
             <field name='code'>401.12</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_401')])]"/>
         </record>
         <record id='cuenta401_13' model='account.account.template'>
             <field name='name'>Ventas y/o servicios gravados al 0% extranjeros partes relacionadas</field>
             <field name='code'>401.13</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_401')])]"/>
         </record>
         <record id='cuenta401_14' model='account.account.template'>
             <field name='name'>Ventas y/o servicios exentos nacionales partes relacionadas</field>
             <field name='code'>401.14</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_401')])]"/>
         </record>
         <record id='cuenta401_15' model='account.account.template'>
             <field name='name'>Ventas y/o servicios exentos extranjeros partes relacionadas</field>
             <field name='code'>401.15</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_401')])]"/>
         </record>
         <record id='cuenta401_16' model='account.account.template'>
             <field name='name'>Ingresos por servicios administrativos</field>
             <field name='code'>401.16</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_401')])]"/>
         </record>
         <record id='cuenta401_17' model='account.account.template'>
             <field name='name'>Ingresos por servicios administrativos nacionales partes relacionadas</field>
             <field name='code'>401.17</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_401')])]"/>
         </record>
         <record id='cuenta401_18' model='account.account.template'>
             <field name='name'>Ingresos por servicios administrativos extranjeros partes relacionadas</field>
             <field name='code'>401.18</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_401')])]"/>
         </record>
         <record id='cuenta401_19' model='account.account.template'>
             <field name='name'>Ingresos por servicios profesionales</field>
             <field name='code'>401.19</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_401')])]"/>
         </record>
         <record id='cuenta401_20' model='account.account.template'>
             <field name='name'>Ingresos por servicios profesionales nacionales partes relacionadas</field>
             <field name='code'>401.20</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_401')])]"/>
         </record>
         <record id='cuenta401_21' model='account.account.template'>
             <field name='name'>Ingresos por servicios profesionales extranjeros partes relacionadas</field>
             <field name='code'>401.21</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_401')])]"/>
         </record>
         <record id='cuenta401_22' model='account.account.template'>
             <field name='name'>Ingresos por arrendamiento</field>
             <field name='code'>401.22</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_401')])]"/>
         </record>
         <record id='cuenta401_23' model='account.account.template'>
             <field name='name'>Ingresos por arrendamiento nacionales partes relacionadas</field>
             <field name='code'>401.23</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_401')])]"/>
         </record>
         <record id='cuenta401_24' model='account.account.template'>
             <field name='name'>Ingresos por arrendamiento extranjeros partes relacionadas</field>
             <field name='code'>401.24</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_401')])]"/>
         </record>
         <record id='cuenta401_25' model='account.account.template'>
             <field name='name'>Ingresos por exportación</field>
             <field name='code'>401.25</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_401')])]"/>
         </record>
         <record id='cuenta401_26' model='account.account.template'>
             <field name='name'>Ingresos por comisiones</field>
             <field name='code'>401.26</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_401')])]"/>
         </record>
         <record id='cuenta401_27' model='account.account.template'>
             <field name='name'>Ingresos por maquila</field>
             <field name='code'>401.27</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_401')])]"/>
         </record>
         <record id='cuenta401_28' model='account.account.template'>
             <field name='name'>Ingresos por coordinados</field>
             <field name='code'>401.28</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_401')])]"/>
         </record>
         <record id='cuenta401_29' model='account.account.template'>
             <field name='name'>Ingresos por regalías</field>
             <field name='code'>401.29</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_401')])]"/>
         </record>
         <record id='cuenta401_30' model='account.account.template'>
             <field name='name'>Ingresos por asistencia técnica</field>
             <field name='code'>401.30</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_401')])]"/>
         </record>
         <record id='cuenta401_31' model='account.account.template'>
             <field name='name'>Ingresos por donativos</field>
             <field name='code'>401.31</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_401')])]"/>
         </record>
         <record id='cuenta401_32' model='account.account.template'>
             <field name='name'>Ingresos por intereses (actividad propia)</field>
             <field name='code'>401.32</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_401')])]"/>
         </record>
         <record id='cuenta401_33' model='account.account.template'>
             <field name='name'>Ingresos de copropiedad</field>
             <field name='code'>401.33</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_401')])]"/>
         </record>
         <record id='cuenta401_34' model='account.account.template'>
             <field name='name'>Ingresos por fideicomisos</field>
             <field name='code'>401.34</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_401')])]"/>
         </record>
         <record id='cuenta401_35' model='account.account.template'>
             <field name='name'>Ingresos por factoraje financiero</field>
             <field name='code'>401.35</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_401')])]"/>
         </record>
         <record id='cuenta401_36' model='account.account.template'>
             <field name='name'>Ingresos por arrendamiento financiero</field>
             <field name='code'>401.36</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_401')])]"/>
         </record>
         <record id='cuenta401_37' model='account.account.template'>
             <field name='name'>Ingresos de extranjeros con establecimiento en el país</field>
             <field name='code'>401.37</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_401')])]"/>
         </record>
         <record id='cuenta401_38' model='account.account.template'>
             <field name='name'>Otros ingresos propios</field>
             <field name='code'>401.38</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta402' model='account.account.template'>
-            <field name='name'>Devoluciones, descuentos o bonificaciones sobre ingresos</field>
-            <field name='code'>402</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_401')])]"/>
         </record>
         <record id='cuenta402_01' model='account.account.template'>
             <field name='name'>Devoluciones, descuentos o bonificaciones sobre ventas y/o servicios a la tasa general</field>
             <field name='code'>402.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_402')])]"/>
         </record>
         <record id='cuenta402_02' model='account.account.template'>
             <field name='name'>Devoluciones, descuentos o bonificaciones sobre ventas y/o servicios al 0%</field>
             <field name='code'>402.02</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_402')])]"/>
         </record>
         <record id='cuenta402_03' model='account.account.template'>
             <field name='name'>Devoluciones, descuentos o bonificaciones sobre ventas y/o servicios exentos</field>
             <field name='code'>402.03</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_402')])]"/>
         </record>
         <record id='cuenta402_04' model='account.account.template'>
             <field name='name'>Devoluciones, descuentos o bonificaciones de otros ingresos</field>
             <field name='code'>402.04</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta403' model='account.account.template'>
-            <field name='name'>Otros ingresos</field>
-            <field name='code'>403</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_402')])]"/>
         </record>
         <record id='cuenta403_01' model='account.account.template'>
             <field name='name'>Otros Ingresos</field>
             <field name='code'>403.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_403')])]"/>
         </record>
         <record id='cuenta403_02' model='account.account.template'>
             <field name='name'>Otros ingresos nacionales parte relacionada</field>
             <field name='code'>403.02</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_403')])]"/>
         </record>
         <record id='cuenta403_03' model='account.account.template'>
             <field name='name'>Otros ingresos extranjeros parte relacionada</field>
             <field name='code'>403.03</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_403')])]"/>
         </record>
         <record id='cuenta403_04' model='account.account.template'>
             <field name='name'>Ingresos por operaciones discontinuas</field>
             <field name='code'>403.04</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_403')])]"/>
         </record>
         <record id='cuenta403_05' model='account.account.template'>
             <field name='name'>Ingresos por condonación de adeudo</field>
             <field name='code'>403.05</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta500' model='account.account.template'>
-            <field name='name'>Costos</field>
-            <field name='code'>500</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta501' model='account.account.template'>
-            <field name='name'>Costo de venta y/o servicio</field>
-            <field name='code'>501</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_403')])]"/>
         </record>
         <record id='cuenta501_01' model='account.account.template'>
             <field name='name'>Costo de venta</field>
             <field name='code'>501.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_501')])]"/>
         </record>
         <record id='cuenta501_02' model='account.account.template'>
             <field name='name'>Costo de servicios (Mano de obra)</field>
             <field name='code'>501.02</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_501')])]"/>
         </record>
         <record id='cuenta501_03' model='account.account.template'>
             <field name='name'>Materia prima directa utilizada para la producción</field>
             <field name='code'>501.03</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_501')])]"/>
         </record>
         <record id='cuenta501_04' model='account.account.template'>
             <field name='name'>Materia prima consumida en el proceso productivo</field>
             <field name='code'>501.04</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_501')])]"/>
         </record>
         <record id='cuenta501_05' model='account.account.template'>
             <field name='name'>Mano de obra directa consumida</field>
             <field name='code'>501.05</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_501')])]"/>
         </record>
         <record id='cuenta501_06' model='account.account.template'>
             <field name='name'>Mano de obra directa</field>
             <field name='code'>501.06</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_501')])]"/>
         </record>
         <record id='cuenta501_07' model='account.account.template'>
             <field name='name'>Cargos indirectos de producción</field>
             <field name='code'>501.07</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_501')])]"/>
         </record>
         <record id='cuenta501_08' model='account.account.template'>
             <field name='name'>Otros conceptos de costo</field>
             <field name='code'>501.08</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta502' model='account.account.template'>
-            <field name='name'>Compras</field>
-            <field name='code'>502</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_501')])]"/>
         </record>
         <record id='cuenta502_01' model='account.account.template'>
             <field name='name'>Compras nacionales</field>
             <field name='code'>502.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_502')])]"/>
         </record>
         <record id='cuenta502_02' model='account.account.template'>
             <field name='name'>Compras nacionales parte relacionada</field>
             <field name='code'>502.02</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_502')])]"/>
         </record>
         <record id='cuenta502_03' model='account.account.template'>
             <field name='name'>Compras de Importación</field>
             <field name='code'>502.03</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_502')])]"/>
         </record>
         <record id='cuenta502_04' model='account.account.template'>
             <field name='name'>Compras de Importación partes relacionadas</field>
             <field name='code'>502.04</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta503' model='account.account.template'>
-            <field name='name'>Devoluciones, descuentos o bonificaciones sobre compras</field>
-            <field name='code'>503</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_502')])]"/>
         </record>
         <record id='cuenta503_01' model='account.account.template'>
             <field name='name'>Devoluciones, descuentos o bonificaciones sobre compras</field>
             <field name='code'>503.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta504' model='account.account.template'>
-            <field name='name'>Otras cuentas de costos</field>
-            <field name='code'>504</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_503')])]"/>
         </record>
         <record id='cuenta504_01' model='account.account.template'>
             <field name='name'>Gastos indirectos de fabricación</field>
             <field name='code'>504.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_504')])]"/>
         </record>
         <record id='cuenta504_02' model='account.account.template'>
             <field name='name'>Gastos indirectos de fabricación de partes relacionadas nacionales</field>
             <field name='code'>504.02</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_504')])]"/>
         </record>
         <record id='cuenta504_03' model='account.account.template'>
             <field name='name'>Gastos indirectos de fabricación de partes relacionadas extranjeras</field>
             <field name='code'>504.03</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_504')])]"/>
         </record>
         <record id='cuenta504_04' model='account.account.template'>
             <field name='name'>Otras cuentas de costos incurridos</field>
             <field name='code'>504.04</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_504')])]"/>
         </record>
         <record id='cuenta504_05' model='account.account.template'>
             <field name='name'>Otras cuentas de costos incurridos con partes relacionadas nacionales</field>
             <field name='code'>504.05</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_504')])]"/>
         </record>
         <record id='cuenta504_06' model='account.account.template'>
             <field name='name'>Otras cuentas de costos incurridos con partes relacionadas extranjeras</field>
             <field name='code'>504.06</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_504')])]"/>
         </record>
         <record id='cuenta504_07' model='account.account.template'>
             <field name='name'>Depreciación de edificios</field>
             <field name='code'>504.07</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_504')])]"/>
         </record>
         <record id='cuenta504_08' model='account.account.template'>
             <field name='name'>Depreciación de maquinaria y equipo</field>
             <field name='code'>504.08</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_504')])]"/>
         </record>
         <record id='cuenta504_09' model='account.account.template'>
             <field name='name'>Depreciación de automóviles, autobuses, camiones de carga, tractocamiones, montacargas y remolques</field>
             <field name='code'>504.09</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_504')])]"/>
         </record>
         <record id='cuenta504_10' model='account.account.template'>
             <field name='name'>Depreciación de mobiliario y equipo de oficina</field>
             <field name='code'>504.10</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_504')])]"/>
         </record>
         <record id='cuenta504_11' model='account.account.template'>
             <field name='name'>Depreciación de equipo de cómputo</field>
             <field name='code'>504.11</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_504')])]"/>
         </record>
         <record id='cuenta504_12' model='account.account.template'>
             <field name='name'>Depreciación de equipo de comunicación</field>
             <field name='code'>504.12</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_504')])]"/>
         </record>
         <record id='cuenta504_13' model='account.account.template'>
             <field name='name'>Depreciación de activos biológicos, vegetales y semovientes</field>
             <field name='code'>504.13</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_504')])]"/>
         </record>
         <record id='cuenta504_14' model='account.account.template'>
             <field name='name'>Depreciación de otros activos fijos</field>
             <field name='code'>504.14</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_504')])]"/>
         </record>
         <record id='cuenta504_15' model='account.account.template'>
             <field name='name'>Depreciación de ferrocarriles</field>
             <field name='code'>504.15</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_504')])]"/>
         </record>
         <record id='cuenta504_16' model='account.account.template'>
             <field name='name'>Depreciación de embarcaciones</field>
             <field name='code'>504.16</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_504')])]"/>
         </record>
         <record id='cuenta504_17' model='account.account.template'>
             <field name='name'>Depreciación de aviones</field>
             <field name='code'>504.17</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_504')])]"/>
         </record>
         <record id='cuenta504_18' model='account.account.template'>
             <field name='name'>Depreciación de troqueles, moldes, matrices y herramental</field>
             <field name='code'>504.18</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_504')])]"/>
         </record>
         <record id='cuenta504_19' model='account.account.template'>
             <field name='name'>Depreciación de equipo de comunicaciones telefónicas</field>
             <field name='code'>504.19</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_504')])]"/>
         </record>
         <record id='cuenta504_20' model='account.account.template'>
             <field name='name'>Depreciación de equipo de comunicación satelital</field>
             <field name='code'>504.20</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_504')])]"/>
         </record>
         <record id='cuenta504_21' model='account.account.template'>
             <field name='name'>Depreciación de equipo de adaptaciones para personas con capacidades diferentes</field>
             <field name='code'>504.21</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_504')])]"/>
         </record>
         <record id='cuenta504_22' model='account.account.template'>
             <field name='name'>Depreciación de maquinaria y equipo de generación de energía de fuentes renovables o de sistemas de cogeneración de electricidad eficiente</field>
             <field name='code'>504.22</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_504')])]"/>
         </record>
         <record id='cuenta504_23' model='account.account.template'>
             <field name='name'>Depreciación de adaptaciones y mejoras</field>
             <field name='code'>504.23</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_504')])]"/>
         </record>
         <record id='cuenta504_24' model='account.account.template'>
             <field name='name'>Depreciación de otra maquinaria y equipo</field>
             <field name='code'>504.24</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_504')])]"/>
         </record>
         <record id='cuenta504_25' model='account.account.template'>
             <field name='name'>Otras cuentas de costos</field>
             <field name='code'>504.25</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta505' model='account.account.template'>
-            <field name='name'>Costo de activo fijo</field>
-            <field name='code'>505</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_504')])]"/>
         </record>
         <record id='cuenta505_01' model='account.account.template'>
             <field name='name'>Costo por venta de activo fijo</field>
             <field name='code'>505.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_505')])]"/>
         </record>
         <record id='cuenta505_02' model='account.account.template'>
             <field name='name'>Costo por baja de activo fijo</field>
             <field name='code'>505.02</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta600' model='account.account.template'>
-            <field name='name'>Gastos</field>
-            <field name='code'>600</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta601' model='account.account.template'>
-            <field name='name'>Gastos generales</field>
-            <field name='code'>601</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_505')])]"/>
         </record>
         <record id='cuenta601_01' model='account.account.template'>
             <field name='name'>Sueldos y salarios</field>
             <field name='code'>601.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601')])]"/>
         </record>
         <record id='cuenta601_02' model='account.account.template'>
             <field name='name'>Compensaciones</field>
             <field name='code'>601.02</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601')])]"/>
         </record>
         <record id='cuenta601_03' model='account.account.template'>
             <field name='name'>Tiempos extras</field>
             <field name='code'>601.03</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601')])]"/>
         </record>
         <record id='cuenta601_04' model='account.account.template'>
             <field name='name'>Premios de asistencia</field>
             <field name='code'>601.04</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601')])]"/>
         </record>
         <record id='cuenta601_05' model='account.account.template'>
             <field name='name'>Premios de puntualidad</field>
             <field name='code'>601.05</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601')])]"/>
         </record>
         <record id='cuenta601_06' model='account.account.template'>
             <field name='name'>Vacaciones</field>
             <field name='code'>601.06</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601')])]"/>
         </record>
         <record id='cuenta601_07' model='account.account.template'>
             <field name='name'>Prima vacacional</field>
             <field name='code'>601.07</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601')])]"/>
         </record>
         <record id='cuenta601_08' model='account.account.template'>
             <field name='name'>Prima dominical</field>
             <field name='code'>601.08</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601')])]"/>
         </record>
         <record id='cuenta601_09' model='account.account.template'>
             <field name='name'>Días festivos</field>
             <field name='code'>601.09</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601')])]"/>
         </record>
         <record id='cuenta601_10' model='account.account.template'>
             <field name='name'>Gratificaciones</field>
             <field name='code'>601.10</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601')])]"/>
         </record>
         <record id='cuenta601_11' model='account.account.template'>
             <field name='name'>Primas de antigüedad</field>
             <field name='code'>601.11</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601')])]"/>
         </record>
         <record id='cuenta601_12' model='account.account.template'>
             <field name='name'>Aguinaldo</field>
             <field name='code'>601.12</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601')])]"/>
         </record>
         <record id='cuenta601_13' model='account.account.template'>
             <field name='name'>Indemnizaciones</field>
             <field name='code'>601.13</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601')])]"/>
         </record>
         <record id='cuenta601_14' model='account.account.template'>
             <field name='name'>Destajo</field>
             <field name='code'>601.14</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601')])]"/>
         </record>
         <record id='cuenta601_15' model='account.account.template'>
             <field name='name'>Despensa</field>
             <field name='code'>601.15</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601')])]"/>
         </record>
         <record id='cuenta601_16' model='account.account.template'>
             <field name='name'>Transporte</field>
             <field name='code'>601.16</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601')])]"/>
         </record>
         <record id='cuenta601_17' model='account.account.template'>
             <field name='name'>Servicio médico</field>
             <field name='code'>601.17</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601')])]"/>
         </record>
         <record id='cuenta601_18' model='account.account.template'>
             <field name='name'>Ayuda en gastos funerarios</field>
             <field name='code'>601.18</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601')])]"/>
         </record>
         <record id='cuenta601_19' model='account.account.template'>
             <field name='name'>Fondo de ahorro</field>
             <field name='code'>601.19</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601')])]"/>
         </record>
         <record id='cuenta601_20' model='account.account.template'>
             <field name='name'>Cuotas sindicales</field>
             <field name='code'>601.20</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601')])]"/>
         </record>
         <record id='cuenta601_21' model='account.account.template'>
             <field name='name'>PTU</field>
             <field name='code'>601.21</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601')])]"/>
         </record>
         <record id='cuenta601_22' model='account.account.template'>
             <field name='name'>Estímulo al personal</field>
             <field name='code'>601.22</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601')])]"/>
         </record>
         <record id='cuenta601_23' model='account.account.template'>
             <field name='name'>Previsión social</field>
             <field name='code'>601.23</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601')])]"/>
         </record>
         <record id='cuenta601_24' model='account.account.template'>
             <field name='name'>Aportaciones para el plan de jubilación</field>
             <field name='code'>601.24</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601')])]"/>
         </record>
         <record id='cuenta601_25' model='account.account.template'>
             <field name='name'>Otras prestaciones al personal</field>
             <field name='code'>601.25</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601')])]"/>
         </record>
         <record id='cuenta601_26' model='account.account.template'>
             <field name='name'>Cuotas al IMSS</field>
             <field name='code'>601.26</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601')])]"/>
         </record>
         <record id='cuenta601_27' model='account.account.template'>
             <field name='name'>Aportaciones al infonavit</field>
             <field name='code'>601.27</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601')])]"/>
         </record>
         <record id='cuenta601_28' model='account.account.template'>
             <field name='name'>Aportaciones al SAR</field>
             <field name='code'>601.28</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601')])]"/>
         </record>
         <record id='cuenta601_29' model='account.account.template'>
             <field name='name'>Impuesto estatal sobre nóminas</field>
             <field name='code'>601.29</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601')])]"/>
         </record>
         <record id='cuenta601_30' model='account.account.template'>
             <field name='name'>Otras aportaciones</field>
             <field name='code'>601.30</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601')])]"/>
         </record>
         <record id='cuenta601_31' model='account.account.template'>
             <field name='name'>Asimilados a salarios</field>
             <field name='code'>601.31</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601')])]"/>
         </record>
         <record id='cuenta601_32' model='account.account.template'>
             <field name='name'>Servicios administrativos</field>
             <field name='code'>601.32</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601')])]"/>
         </record>
         <record id='cuenta601_33' model='account.account.template'>
             <field name='name'>Servicios administrativos partes relacionadas</field>
             <field name='code'>601.33</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601')])]"/>
         </record>
         <record id='cuenta601_34' model='account.account.template'>
             <field name='name'>Honorarios a personas físicas residentes nacionales</field>
             <field name='code'>601.34</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601')])]"/>
         </record>
         <record id='cuenta601_35' model='account.account.template'>
             <field name='name'>Honorarios a personas físicas residentes nacionales partes relacionadas</field>
             <field name='code'>601.35</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601')])]"/>
         </record>
         <record id='cuenta601_36' model='account.account.template'>
             <field name='name'>Honorarios a personas físicas residentes del extranjero</field>
             <field name='code'>601.36</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601')])]"/>
         </record>
         <record id='cuenta601_37' model='account.account.template'>
             <field name='name'>Honorarios a personas físicas residentes del extranjero partes relacionadas</field>
             <field name='code'>601.37</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601')])]"/>
         </record>
         <record id='cuenta601_38' model='account.account.template'>
             <field name='name'>Honorarios a personas morales residentes nacionales</field>
             <field name='code'>601.38</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601')])]"/>
         </record>
         <record id='cuenta601_39' model='account.account.template'>
             <field name='name'>Honorarios a personas morales residentes nacionales partes relacionadas</field>
             <field name='code'>601.39</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601')])]"/>
         </record>
         <record id='cuenta601_40' model='account.account.template'>
             <field name='name'>Honorarios a personas morales residentes del extranjero</field>
             <field name='code'>601.40</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601')])]"/>
         </record>
         <record id='cuenta601_41' model='account.account.template'>
             <field name='name'>Honorarios a personas morales residentes del extranjero partes relacionadas</field>
             <field name='code'>601.41</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601')])]"/>
         </record>
         <record id='cuenta601_42' model='account.account.template'>
             <field name='name'>Honorarios aduanales personas físicas</field>
             <field name='code'>601.42</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601')])]"/>
         </record>
         <record id='cuenta601_43' model='account.account.template'>
             <field name='name'>Honorarios aduanales personas morales</field>
             <field name='code'>601.43</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601')])]"/>
         </record>
         <record id='cuenta601_44' model='account.account.template'>
             <field name='name'>Honorarios al consejo de administración</field>
             <field name='code'>601.44</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601')])]"/>
         </record>
         <record id='cuenta601_45' model='account.account.template'>
             <field name='name'>Arrendamiento a personas físicas residentes nacionales</field>
             <field name='code'>601.45</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601')])]"/>
         </record>
         <record id='cuenta601_46' model='account.account.template'>
             <field name='name'>Arrendamiento a personas morales residentes nacionales</field>
             <field name='code'>601.46</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601')])]"/>
         </record>
         <record id='cuenta601_47' model='account.account.template'>
             <field name='name'>Arrendamiento a residentes del extranjero</field>
             <field name='code'>601.47</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601')])]"/>
         </record>
         <record id='cuenta601_48' model='account.account.template'>
             <field name='name'>Combustibles y lubricantes</field>
             <field name='code'>601.48</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601')])]"/>
         </record>
         <record id='cuenta601_49' model='account.account.template'>
             <field name='name'>Viáticos y gastos de viaje</field>
             <field name='code'>601.49</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601')])]"/>
         </record>
         <record id='cuenta601_50' model='account.account.template'>
             <field name='name'>Teléfono, internet</field>
             <field name='code'>601.50</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601')])]"/>
         </record>
         <record id='cuenta601_51' model='account.account.template'>
             <field name='name'>Agua</field>
             <field name='code'>601.51</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601')])]"/>
         </record>
         <record id='cuenta601_52' model='account.account.template'>
             <field name='name'>Energía eléctrica</field>
             <field name='code'>601.52</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601')])]"/>
         </record>
         <record id='cuenta601_53' model='account.account.template'>
             <field name='name'>Vigilancia y seguridad</field>
             <field name='code'>601.53</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601')])]"/>
         </record>
         <record id='cuenta601_54' model='account.account.template'>
             <field name='name'>Limpieza</field>
             <field name='code'>601.54</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601')])]"/>
         </record>
         <record id='cuenta601_55' model='account.account.template'>
             <field name='name'>Papelería y artículos de oficina</field>
             <field name='code'>601.55</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601')])]"/>
         </record>
         <record id='cuenta601_56' model='account.account.template'>
             <field name='name'>Mantenimiento y conservación</field>
             <field name='code'>601.56</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601')])]"/>
         </record>
         <record id='cuenta601_57' model='account.account.template'>
             <field name='name'>Seguros y fianzas</field>
             <field name='code'>601.57</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601')])]"/>
         </record>
         <record id='cuenta601_58' model='account.account.template'>
             <field name='name'>Otros impuestos y derechos</field>
             <field name='code'>601.58</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601')])]"/>
         </record>
         <record id='cuenta601_59' model='account.account.template'>
             <field name='name'>Recargos fiscales</field>
             <field name='code'>601.59</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601')])]"/>
         </record>
         <record id='cuenta601_60' model='account.account.template'>
             <field name='name'>Cuotas y suscripciones</field>
             <field name='code'>601.60</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601')])]"/>
         </record>
         <record id='cuenta601_61' model='account.account.template'>
             <field name='name'>Propaganda y publicidad</field>
             <field name='code'>601.61</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601')])]"/>
         </record>
         <record id='cuenta601_62' model='account.account.template'>
             <field name='name'>Capacitación al personal</field>
             <field name='code'>601.62</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601')])]"/>
         </record>
         <record id='cuenta601_63' model='account.account.template'>
             <field name='name'>Donativos y ayudas</field>
             <field name='code'>601.63</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601')])]"/>
         </record>
         <record id='cuenta601_64' model='account.account.template'>
             <field name='name'>Asistencia técnica</field>
             <field name='code'>601.64</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601')])]"/>
         </record>
         <record id='cuenta601_65' model='account.account.template'>
             <field name='name'>Regalías sujetas a otros porcentajes</field>
             <field name='code'>601.65</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601')])]"/>
         </record>
         <record id='cuenta601_66' model='account.account.template'>
             <field name='name'>Regalías sujetas al 5%</field>
             <field name='code'>601.66</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601')])]"/>
         </record>
         <record id='cuenta601_67' model='account.account.template'>
             <field name='name'>Regalías sujetas al 10%</field>
             <field name='code'>601.67</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601')])]"/>
         </record>
         <record id='cuenta601_68' model='account.account.template'>
             <field name='name'>Regalías sujetas al 15%</field>
             <field name='code'>601.68</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601')])]"/>
         </record>
         <record id='cuenta601_69' model='account.account.template'>
             <field name='name'>Regalías sujetas al 25%</field>
             <field name='code'>601.69</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601')])]"/>
         </record>
         <record id='cuenta601_70' model='account.account.template'>
             <field name='name'>Regalías sujetas al 30%</field>
             <field name='code'>601.70</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601')])]"/>
         </record>
         <record id='cuenta601_71' model='account.account.template'>
             <field name='name'>Regalías sin retención</field>
             <field name='code'>601.71</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601')])]"/>
         </record>
         <record id='cuenta601_72' model='account.account.template'>
             <field name='name'>Fletes y acarreos</field>
             <field name='code'>601.72</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601')])]"/>
         </record>
         <record id='cuenta601_73' model='account.account.template'>
             <field name='name'>Gastos de importación</field>
             <field name='code'>601.73</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601')])]"/>
         </record>
         <record id='cuenta601_74' model='account.account.template'>
             <field name='name'>Comisiones sobre ventas</field>
             <field name='code'>601.74</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601')])]"/>
         </record>
         <record id='cuenta601_75' model='account.account.template'>
             <field name='name'>Comisiones por tarjetas de crédito</field>
             <field name='code'>601.75</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601')])]"/>
         </record>
         <record id='cuenta601_76' model='account.account.template'>
             <field name='name'>Patentes y marcas</field>
             <field name='code'>601.76</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601')])]"/>
         </record>
         <record id='cuenta601_77' model='account.account.template'>
             <field name='name'>Uniformes</field>
             <field name='code'>601.77</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601')])]"/>
         </record>
         <record id='cuenta601_78' model='account.account.template'>
             <field name='name'>Prediales</field>
             <field name='code'>601.78</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601')])]"/>
         </record>
         <record id='cuenta601_79' model='account.account.template'>
             <field name='name'>Gastos generales de urbanización</field>
             <field name='code'>601.79</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601')])]"/>
         </record>
         <record id='cuenta601_80' model='account.account.template'>
             <field name='name'>Gastos generales de construcción</field>
             <field name='code'>601.80</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601')])]"/>
         </record>
         <record id='cuenta601_81' model='account.account.template'>
             <field name='name'>Fletes del extranjero</field>
             <field name='code'>601.81</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601')])]"/>
         </record>
         <record id='cuenta601_82' model='account.account.template'>
             <field name='name'>Recolección de bienes del sector agropecuario y/o ganadero</field>
             <field name='code'>601.82</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601')])]"/>
         </record>
         <record id='cuenta601_83' model='account.account.template'>
             <field name='name'>Gastos no deducibles (sin requisitos fiscales)</field>
             <field name='code'>601.83</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601')])]"/>
         </record>
         <record id='cuenta601_84' model='account.account.template'>
             <field name='name'>Otros gastos generales</field>
             <field name='code'>601.84</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta602' model='account.account.template'>
-            <field name='name'>Gastos de venta</field>
-            <field name='code'>602</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601')])]"/>
         </record>
         <record id='cuenta602_01' model='account.account.template'>
             <field name='name'>Sueldos y salarios</field>
             <field name='code'>602.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602')])]"/>
         </record>
         <record id='cuenta602_02' model='account.account.template'>
             <field name='name'>Compensaciones</field>
             <field name='code'>602.02</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602')])]"/>
         </record>
         <record id='cuenta602_03' model='account.account.template'>
             <field name='name'>Tiempos extras</field>
             <field name='code'>602.03</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602')])]"/>
         </record>
         <record id='cuenta602_04' model='account.account.template'>
             <field name='name'>Premios de asistencia</field>
             <field name='code'>602.04</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602')])]"/>
         </record>
         <record id='cuenta602_05' model='account.account.template'>
             <field name='name'>Premios de puntualidad</field>
             <field name='code'>602.05</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602')])]"/>
         </record>
         <record id='cuenta602_06' model='account.account.template'>
             <field name='name'>Vacaciones</field>
             <field name='code'>602.06</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602')])]"/>
         </record>
         <record id='cuenta602_07' model='account.account.template'>
             <field name='name'>Prima vacacional</field>
             <field name='code'>602.07</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602')])]"/>
         </record>
         <record id='cuenta602_08' model='account.account.template'>
             <field name='name'>Prima dominical</field>
             <field name='code'>602.08</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602')])]"/>
         </record>
         <record id='cuenta602_09' model='account.account.template'>
             <field name='name'>Días festivos</field>
             <field name='code'>602.09</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602')])]"/>
         </record>
         <record id='cuenta602_10' model='account.account.template'>
             <field name='name'>Gratificaciones</field>
             <field name='code'>602.10</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602')])]"/>
         </record>
         <record id='cuenta602_11' model='account.account.template'>
             <field name='name'>Primas de antigüedad</field>
             <field name='code'>602.11</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602')])]"/>
         </record>
         <record id='cuenta602_12' model='account.account.template'>
             <field name='name'>Aguinaldo</field>
             <field name='code'>602.12</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602')])]"/>
         </record>
         <record id='cuenta602_13' model='account.account.template'>
             <field name='name'>Indemnizaciones</field>
             <field name='code'>602.13</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602')])]"/>
         </record>
         <record id='cuenta602_14' model='account.account.template'>
             <field name='name'>Destajo</field>
             <field name='code'>602.14</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602')])]"/>
         </record>
         <record id='cuenta602_15' model='account.account.template'>
             <field name='name'>Despensa</field>
             <field name='code'>602.15</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602')])]"/>
         </record>
         <record id='cuenta602_16' model='account.account.template'>
             <field name='name'>Transporte</field>
             <field name='code'>602.16</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602')])]"/>
         </record>
         <record id='cuenta602_17' model='account.account.template'>
             <field name='name'>Servicio médico</field>
             <field name='code'>602.17</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602')])]"/>
         </record>
         <record id='cuenta602_18' model='account.account.template'>
             <field name='name'>Ayuda en gastos funerarios</field>
             <field name='code'>602.18</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602')])]"/>
         </record>
         <record id='cuenta602_19' model='account.account.template'>
             <field name='name'>Fondo de ahorro</field>
             <field name='code'>602.19</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602')])]"/>
         </record>
         <record id='cuenta602_20' model='account.account.template'>
             <field name='name'>Cuotas sindicales</field>
             <field name='code'>602.20</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602')])]"/>
         </record>
         <record id='cuenta602_21' model='account.account.template'>
             <field name='name'>PTU</field>
             <field name='code'>602.21</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602')])]"/>
         </record>
         <record id='cuenta602_22' model='account.account.template'>
             <field name='name'>Estímulo al personal</field>
             <field name='code'>602.22</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602')])]"/>
         </record>
         <record id='cuenta602_23' model='account.account.template'>
             <field name='name'>Previsión social</field>
             <field name='code'>602.23</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602')])]"/>
         </record>
         <record id='cuenta602_24' model='account.account.template'>
             <field name='name'>Aportaciones para el plan de jubilación</field>
             <field name='code'>602.24</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602')])]"/>
         </record>
         <record id='cuenta602_25' model='account.account.template'>
             <field name='name'>Otras prestaciones al personal</field>
             <field name='code'>602.25</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602')])]"/>
         </record>
         <record id='cuenta602_26' model='account.account.template'>
             <field name='name'>Cuotas al IMSS</field>
             <field name='code'>602.26</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602')])]"/>
         </record>
         <record id='cuenta602_27' model='account.account.template'>
             <field name='name'>Aportaciones al infonavit</field>
             <field name='code'>602.27</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602')])]"/>
         </record>
         <record id='cuenta602_28' model='account.account.template'>
             <field name='name'>Aportaciones al SAR</field>
             <field name='code'>602.28</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602')])]"/>
         </record>
         <record id='cuenta602_29' model='account.account.template'>
             <field name='name'>Impuesto estatal sobre nóminas</field>
             <field name='code'>602.29</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602')])]"/>
         </record>
         <record id='cuenta602_30' model='account.account.template'>
             <field name='name'>Otras aportaciones</field>
             <field name='code'>602.30</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602')])]"/>
         </record>
         <record id='cuenta602_31' model='account.account.template'>
             <field name='name'>Asimilados a salarios</field>
             <field name='code'>602.31</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602')])]"/>
         </record>
         <record id='cuenta602_32' model='account.account.template'>
             <field name='name'>Servicios administrativos</field>
             <field name='code'>602.32</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602')])]"/>
         </record>
         <record id='cuenta602_33' model='account.account.template'>
             <field name='name'>Servicios administrativos partes relacionadas</field>
             <field name='code'>602.33</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602')])]"/>
         </record>
         <record id='cuenta602_34' model='account.account.template'>
             <field name='name'>Honorarios a personas físicas residentes nacionales</field>
             <field name='code'>602.34</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602')])]"/>
         </record>
         <record id='cuenta602_35' model='account.account.template'>
             <field name='name'>Honorarios a personas físicas residentes nacionales partes relacionadas</field>
             <field name='code'>602.35</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602')])]"/>
         </record>
         <record id='cuenta602_36' model='account.account.template'>
             <field name='name'>Honorarios a personas físicas residentes del extranjero</field>
             <field name='code'>602.36</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602')])]"/>
         </record>
         <record id='cuenta602_37' model='account.account.template'>
             <field name='name'>Honorarios a personas físicas residentes del extranjero partes relacionadas</field>
             <field name='code'>602.37</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602')])]"/>
         </record>
         <record id='cuenta602_38' model='account.account.template'>
             <field name='name'>Honorarios a personas morales residentes nacionales</field>
             <field name='code'>602.38</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602')])]"/>
         </record>
         <record id='cuenta602_39' model='account.account.template'>
             <field name='name'>Honorarios a personas morales residentes nacionales partes relacionadas</field>
             <field name='code'>602.39</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602')])]"/>
         </record>
         <record id='cuenta602_40' model='account.account.template'>
             <field name='name'>Honorarios a personas morales residentes del extranjero</field>
             <field name='code'>602.40</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602')])]"/>
         </record>
         <record id='cuenta602_41' model='account.account.template'>
             <field name='name'>Honorarios a personas morales residentes del extranjero partes relacionadas</field>
             <field name='code'>602.41</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602')])]"/>
         </record>
         <record id='cuenta602_42' model='account.account.template'>
             <field name='name'>Honorarios aduanales personas físicas</field>
             <field name='code'>602.42</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602')])]"/>
         </record>
         <record id='cuenta602_43' model='account.account.template'>
             <field name='name'>Honorarios aduanales personas morales</field>
             <field name='code'>602.43</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602')])]"/>
         </record>
         <record id='cuenta602_44' model='account.account.template'>
             <field name='name'>Honorarios al consejo de administración</field>
             <field name='code'>602.44</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602')])]"/>
         </record>
         <record id='cuenta602_45' model='account.account.template'>
             <field name='name'>Arrendamiento a personas físicas residentes nacionales</field>
             <field name='code'>602.45</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602')])]"/>
         </record>
         <record id='cuenta602_46' model='account.account.template'>
             <field name='name'>Arrendamiento a personas morales residentes nacionales</field>
             <field name='code'>602.46</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602')])]"/>
         </record>
         <record id='cuenta602_47' model='account.account.template'>
             <field name='name'>Arrendamiento a residentes del extranjero</field>
             <field name='code'>602.47</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602')])]"/>
         </record>
         <record id='cuenta602_48' model='account.account.template'>
             <field name='name'>Combustibles y lubricantes</field>
             <field name='code'>602.48</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602')])]"/>
         </record>
         <record id='cuenta602_49' model='account.account.template'>
             <field name='name'>Viáticos y gastos de viaje</field>
             <field name='code'>602.49</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602')])]"/>
         </record>
         <record id='cuenta602_50' model='account.account.template'>
             <field name='name'>Teléfono, internet</field>
             <field name='code'>602.50</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602')])]"/>
         </record>
         <record id='cuenta602_51' model='account.account.template'>
             <field name='name'>Agua</field>
             <field name='code'>602.51</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602')])]"/>
         </record>
         <record id='cuenta602_52' model='account.account.template'>
             <field name='name'>Energía eléctrica</field>
             <field name='code'>602.52</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602')])]"/>
         </record>
         <record id='cuenta602_53' model='account.account.template'>
             <field name='name'>Vigilancia y seguridad</field>
             <field name='code'>602.53</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602')])]"/>
         </record>
         <record id='cuenta602_54' model='account.account.template'>
             <field name='name'>Limpieza</field>
             <field name='code'>602.54</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602')])]"/>
         </record>
         <record id='cuenta602_55' model='account.account.template'>
             <field name='name'>Papelería y artículos de oficina</field>
             <field name='code'>602.55</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602')])]"/>
         </record>
         <record id='cuenta602_56' model='account.account.template'>
             <field name='name'>Mantenimiento y conservación</field>
             <field name='code'>602.56</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602')])]"/>
         </record>
         <record id='cuenta602_57' model='account.account.template'>
             <field name='name'>Seguros y fianzas</field>
             <field name='code'>602.57</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602')])]"/>
         </record>
         <record id='cuenta602_58' model='account.account.template'>
             <field name='name'>Otros impuestos y derechos</field>
             <field name='code'>602.58</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602')])]"/>
         </record>
         <record id='cuenta602_59' model='account.account.template'>
             <field name='name'>Recargos fiscales</field>
             <field name='code'>602.59</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602')])]"/>
         </record>
         <record id='cuenta602_60' model='account.account.template'>
             <field name='name'>Cuotas y suscripciones</field>
             <field name='code'>602.60</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602')])]"/>
         </record>
         <record id='cuenta602_61' model='account.account.template'>
             <field name='name'>Propaganda y publicidad</field>
             <field name='code'>602.61</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602')])]"/>
         </record>
         <record id='cuenta602_62' model='account.account.template'>
             <field name='name'>Capacitación al personal</field>
             <field name='code'>602.62</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602')])]"/>
         </record>
         <record id='cuenta602_63' model='account.account.template'>
             <field name='name'>Donativos y ayudas</field>
             <field name='code'>602.63</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602')])]"/>
         </record>
         <record id='cuenta602_64' model='account.account.template'>
             <field name='name'>Asistencia técnica</field>
             <field name='code'>602.64</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602')])]"/>
         </record>
         <record id='cuenta602_65' model='account.account.template'>
             <field name='name'>Regalías sujetas a otros porcentajes</field>
             <field name='code'>602.65</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602')])]"/>
         </record>
         <record id='cuenta602_66' model='account.account.template'>
             <field name='name'>Regalías sujetas al 5%</field>
             <field name='code'>602.66</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602')])]"/>
         </record>
         <record id='cuenta602_67' model='account.account.template'>
             <field name='name'>Regalías sujetas al 10%</field>
             <field name='code'>602.67</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602')])]"/>
         </record>
         <record id='cuenta602_68' model='account.account.template'>
             <field name='name'>Regalías sujetas al 15%</field>
             <field name='code'>602.68</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602')])]"/>
         </record>
         <record id='cuenta602_69' model='account.account.template'>
             <field name='name'>Regalías sujetas al 25%</field>
             <field name='code'>602.69</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602')])]"/>
         </record>
         <record id='cuenta602_70' model='account.account.template'>
             <field name='name'>Regalías sujetas al 30%</field>
             <field name='code'>602.70</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602')])]"/>
         </record>
         <record id='cuenta602_71' model='account.account.template'>
             <field name='name'>Regalías sin retención</field>
             <field name='code'>602.71</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602')])]"/>
         </record>
         <record id='cuenta602_72' model='account.account.template'>
             <field name='name'>Fletes y acarreos</field>
             <field name='code'>602.72</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602')])]"/>
         </record>
         <record id='cuenta602_73' model='account.account.template'>
             <field name='name'>Gastos de importación</field>
             <field name='code'>602.73</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602')])]"/>
         </record>
         <record id='cuenta602_74' model='account.account.template'>
             <field name='name'>Comisiones sobre ventas</field>
             <field name='code'>602.74</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602')])]"/>
         </record>
         <record id='cuenta602_75' model='account.account.template'>
             <field name='name'>Comisiones por tarjetas de crédito</field>
             <field name='code'>602.75</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602')])]"/>
         </record>
         <record id='cuenta602_76' model='account.account.template'>
             <field name='name'>Patentes y marcas</field>
             <field name='code'>602.76</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602')])]"/>
         </record>
         <record id='cuenta602_77' model='account.account.template'>
             <field name='name'>Uniformes</field>
             <field name='code'>602.77</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602')])]"/>
         </record>
         <record id='cuenta602_78' model='account.account.template'>
             <field name='name'>Prediales</field>
             <field name='code'>602.78</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602')])]"/>
         </record>
         <record id='cuenta602_79' model='account.account.template'>
             <field name='name'>Gastos de venta de urbanización</field>
             <field name='code'>602.79</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602')])]"/>
         </record>
         <record id='cuenta602_80' model='account.account.template'>
             <field name='name'>Gastos de venta de construcción</field>
             <field name='code'>602.80</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602')])]"/>
         </record>
         <record id='cuenta602_81' model='account.account.template'>
             <field name='name'>Fletes del extranjero</field>
             <field name='code'>602.81</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602')])]"/>
         </record>
         <record id='cuenta602_82' model='account.account.template'>
             <field name='name'>Recolección de bienes del sector agropecuario y/o ganadero</field>
             <field name='code'>602.82</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602')])]"/>
         </record>
         <record id='cuenta602_83' model='account.account.template'>
             <field name='name'>Gastos no deducibles (sin requisitos fiscales)</field>
             <field name='code'>602.83</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602')])]"/>
         </record>
         <record id='cuenta602_84' model='account.account.template'>
             <field name='name'>Otros gastos de venta</field>
             <field name='code'>602.84</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta603' model='account.account.template'>
-            <field name='name'>Gastos de administración</field>
-            <field name='code'>603</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602')])]"/>
         </record>
         <record id='cuenta603_01' model='account.account.template'>
             <field name='name'>Sueldos y salarios</field>
             <field name='code'>603.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603')])]"/>
         </record>
         <record id='cuenta603_02' model='account.account.template'>
             <field name='name'>Compensaciones</field>
             <field name='code'>603.02</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603')])]"/>
         </record>
         <record id='cuenta603_03' model='account.account.template'>
             <field name='name'>Tiempos extras</field>
             <field name='code'>603.03</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603')])]"/>
         </record>
         <record id='cuenta603_04' model='account.account.template'>
             <field name='name'>Premios de asistencia</field>
             <field name='code'>603.04</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603')])]"/>
         </record>
         <record id='cuenta603_05' model='account.account.template'>
             <field name='name'>Premios de puntualidad</field>
             <field name='code'>603.05</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603')])]"/>
         </record>
         <record id='cuenta603_06' model='account.account.template'>
             <field name='name'>Vacaciones</field>
             <field name='code'>603.06</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603')])]"/>
         </record>
         <record id='cuenta603_07' model='account.account.template'>
             <field name='name'>Prima vacacional</field>
             <field name='code'>603.07</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603')])]"/>
         </record>
         <record id='cuenta603_08' model='account.account.template'>
             <field name='name'>Prima dominical</field>
             <field name='code'>603.08</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603')])]"/>
         </record>
         <record id='cuenta603_09' model='account.account.template'>
             <field name='name'>Días festivos</field>
             <field name='code'>603.09</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603')])]"/>
         </record>
         <record id='cuenta603_10' model='account.account.template'>
             <field name='name'>Gratificaciones</field>
             <field name='code'>603.10</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603')])]"/>
         </record>
         <record id='cuenta603_11' model='account.account.template'>
             <field name='name'>Primas de antigüedad</field>
             <field name='code'>603.11</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603')])]"/>
         </record>
         <record id='cuenta603_12' model='account.account.template'>
             <field name='name'>Aguinaldo</field>
             <field name='code'>603.12</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603')])]"/>
         </record>
         <record id='cuenta603_13' model='account.account.template'>
             <field name='name'>Indemnizaciones</field>
             <field name='code'>603.13</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603')])]"/>
         </record>
         <record id='cuenta603_14' model='account.account.template'>
             <field name='name'>Destajo</field>
             <field name='code'>603.14</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603')])]"/>
         </record>
         <record id='cuenta603_15' model='account.account.template'>
             <field name='name'>Despensa</field>
             <field name='code'>603.15</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603')])]"/>
         </record>
         <record id='cuenta603_16' model='account.account.template'>
             <field name='name'>Transporte</field>
             <field name='code'>603.16</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603')])]"/>
         </record>
         <record id='cuenta603_17' model='account.account.template'>
             <field name='name'>Servicio médico</field>
             <field name='code'>603.17</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603')])]"/>
         </record>
         <record id='cuenta603_18' model='account.account.template'>
             <field name='name'>Ayuda en gastos funerarios</field>
             <field name='code'>603.18</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603')])]"/>
         </record>
         <record id='cuenta603_19' model='account.account.template'>
             <field name='name'>Fondo de ahorro</field>
             <field name='code'>603.19</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603')])]"/>
         </record>
         <record id='cuenta603_20' model='account.account.template'>
             <field name='name'>Cuotas sindicales</field>
             <field name='code'>603.20</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603')])]"/>
         </record>
         <record id='cuenta603_21' model='account.account.template'>
             <field name='name'>PTU</field>
             <field name='code'>603.21</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603')])]"/>
         </record>
         <record id='cuenta603_22' model='account.account.template'>
             <field name='name'>Estímulo al personal</field>
             <field name='code'>603.22</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603')])]"/>
         </record>
         <record id='cuenta603_23' model='account.account.template'>
             <field name='name'>Previsión social</field>
             <field name='code'>603.23</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603')])]"/>
         </record>
         <record id='cuenta603_24' model='account.account.template'>
             <field name='name'>Aportaciones para el plan de jubilación</field>
             <field name='code'>603.24</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603')])]"/>
         </record>
         <record id='cuenta603_25' model='account.account.template'>
             <field name='name'>Otras prestaciones al personal</field>
             <field name='code'>603.25</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603')])]"/>
         </record>
         <record id='cuenta603_26' model='account.account.template'>
             <field name='name'>Cuotas al IMSS</field>
             <field name='code'>603.26</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603')])]"/>
         </record>
         <record id='cuenta603_27' model='account.account.template'>
             <field name='name'>Aportaciones al infonavit</field>
             <field name='code'>603.27</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603')])]"/>
         </record>
         <record id='cuenta603_28' model='account.account.template'>
             <field name='name'>Aportaciones al SAR</field>
             <field name='code'>603.28</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603')])]"/>
         </record>
         <record id='cuenta603_29' model='account.account.template'>
             <field name='name'>Impuesto estatal sobre nóminas</field>
             <field name='code'>603.29</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603')])]"/>
         </record>
         <record id='cuenta603_30' model='account.account.template'>
             <field name='name'>Otras aportaciones</field>
             <field name='code'>603.30</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603')])]"/>
         </record>
         <record id='cuenta603_31' model='account.account.template'>
             <field name='name'>Asimilados a salarios</field>
             <field name='code'>603.31</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603')])]"/>
         </record>
         <record id='cuenta603_32' model='account.account.template'>
             <field name='name'>Servicios administrativos</field>
             <field name='code'>603.32</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603')])]"/>
         </record>
         <record id='cuenta603_33' model='account.account.template'>
             <field name='name'>Servicios administrativos partes relacionadas</field>
             <field name='code'>603.33</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603')])]"/>
         </record>
         <record id='cuenta603_34' model='account.account.template'>
             <field name='name'>Honorarios a personas físicas residentes nacionales</field>
             <field name='code'>603.34</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603')])]"/>
         </record>
         <record id='cuenta603_35' model='account.account.template'>
             <field name='name'>Honorarios a personas físicas residentes nacionales partes relacionadas</field>
             <field name='code'>603.35</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603')])]"/>
         </record>
         <record id='cuenta603_36' model='account.account.template'>
             <field name='name'>Honorarios a personas físicas residentes del extranjero</field>
             <field name='code'>603.36</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603')])]"/>
         </record>
         <record id='cuenta603_37' model='account.account.template'>
             <field name='name'>Honorarios a personas físicas residentes del extranjero partes relacionadas</field>
             <field name='code'>603.37</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603')])]"/>
         </record>
         <record id='cuenta603_38' model='account.account.template'>
             <field name='name'>Honorarios a personas morales residentes nacionales</field>
             <field name='code'>603.38</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603')])]"/>
         </record>
         <record id='cuenta603_39' model='account.account.template'>
             <field name='name'>Honorarios a personas morales residentes nacionales partes relacionadas</field>
             <field name='code'>603.39</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603')])]"/>
         </record>
         <record id='cuenta603_40' model='account.account.template'>
             <field name='name'>Honorarios a personas morales residentes del extranjero</field>
             <field name='code'>603.40</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603')])]"/>
         </record>
         <record id='cuenta603_41' model='account.account.template'>
             <field name='name'>Honorarios a personas morales residentes del extranjero partes relacionadas</field>
             <field name='code'>603.41</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603')])]"/>
         </record>
         <record id='cuenta603_42' model='account.account.template'>
             <field name='name'>Honorarios aduanales personas físicas</field>
             <field name='code'>603.42</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603')])]"/>
         </record>
         <record id='cuenta603_43' model='account.account.template'>
             <field name='name'>Honorarios aduanales personas morales</field>
             <field name='code'>603.43</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603')])]"/>
         </record>
         <record id='cuenta603_44' model='account.account.template'>
             <field name='name'>Honorarios al consejo de administración</field>
             <field name='code'>603.44</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603')])]"/>
         </record>
         <record id='cuenta603_45' model='account.account.template'>
             <field name='name'>Arrendamiento a personas físicas residentes nacionales</field>
             <field name='code'>603.45</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603')])]"/>
         </record>
         <record id='cuenta603_46' model='account.account.template'>
             <field name='name'>Arrendamiento a personas morales residentes nacionales</field>
             <field name='code'>603.46</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603')])]"/>
         </record>
         <record id='cuenta603_47' model='account.account.template'>
             <field name='name'>Arrendamiento a residentes del extranjero</field>
             <field name='code'>603.47</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603')])]"/>
         </record>
         <record id='cuenta603_48' model='account.account.template'>
             <field name='name'>Combustibles y lubricantes</field>
             <field name='code'>603.48</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603')])]"/>
         </record>
         <record id='cuenta603_49' model='account.account.template'>
             <field name='name'>Viáticos y gastos de viaje</field>
             <field name='code'>603.49</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603')])]"/>
         </record>
         <record id='cuenta603_50' model='account.account.template'>
             <field name='name'>Teléfono, internet</field>
             <field name='code'>603.50</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603')])]"/>
         </record>
         <record id='cuenta603_51' model='account.account.template'>
             <field name='name'>Agua</field>
             <field name='code'>603.51</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603')])]"/>
         </record>
         <record id='cuenta603_52' model='account.account.template'>
             <field name='name'>Energía eléctrica</field>
             <field name='code'>603.52</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603')])]"/>
         </record>
         <record id='cuenta603_53' model='account.account.template'>
             <field name='name'>Vigilancia y seguridad</field>
             <field name='code'>603.53</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603')])]"/>
         </record>
         <record id='cuenta603_54' model='account.account.template'>
             <field name='name'>Limpieza</field>
             <field name='code'>603.54</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603')])]"/>
         </record>
         <record id='cuenta603_55' model='account.account.template'>
             <field name='name'>Papelería y artículos de oficina</field>
             <field name='code'>603.55</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603')])]"/>
         </record>
         <record id='cuenta603_56' model='account.account.template'>
             <field name='name'>Mantenimiento y conservación</field>
             <field name='code'>603.56</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603')])]"/>
         </record>
         <record id='cuenta603_57' model='account.account.template'>
             <field name='name'>Seguros y fianzas</field>
             <field name='code'>603.57</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603')])]"/>
         </record>
         <record id='cuenta603_58' model='account.account.template'>
             <field name='name'>Otros impuestos y derechos</field>
             <field name='code'>603.58</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603')])]"/>
         </record>
         <record id='cuenta603_59' model='account.account.template'>
             <field name='name'>Recargos fiscales</field>
             <field name='code'>603.59</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603')])]"/>
         </record>
         <record id='cuenta603_60' model='account.account.template'>
             <field name='name'>Cuotas y suscripciones</field>
             <field name='code'>603.60</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603')])]"/>
         </record>
         <record id='cuenta603_61' model='account.account.template'>
             <field name='name'>Propaganda y publicidad</field>
             <field name='code'>603.61</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603')])]"/>
         </record>
         <record id='cuenta603_62' model='account.account.template'>
             <field name='name'>Capacitación al personal</field>
             <field name='code'>603.62</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603')])]"/>
         </record>
         <record id='cuenta603_63' model='account.account.template'>
             <field name='name'>Donativos y ayudas</field>
             <field name='code'>603.63</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603')])]"/>
         </record>
         <record id='cuenta603_64' model='account.account.template'>
             <field name='name'>Asistencia técnica</field>
             <field name='code'>603.64</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603')])]"/>
         </record>
         <record id='cuenta603_65' model='account.account.template'>
             <field name='name'>Regalías sujetas a otros porcentajes</field>
             <field name='code'>603.65</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603')])]"/>
         </record>
         <record id='cuenta603_66' model='account.account.template'>
             <field name='name'>Regalías sujetas al 5%</field>
             <field name='code'>603.66</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603')])]"/>
         </record>
         <record id='cuenta603_67' model='account.account.template'>
             <field name='name'>Regalías sujetas al 10%</field>
             <field name='code'>603.67</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603')])]"/>
         </record>
         <record id='cuenta603_68' model='account.account.template'>
             <field name='name'>Regalías sujetas al 15%</field>
             <field name='code'>603.68</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603')])]"/>
         </record>
         <record id='cuenta603_69' model='account.account.template'>
             <field name='name'>Regalías sujetas al 25%</field>
             <field name='code'>603.69</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603')])]"/>
         </record>
         <record id='cuenta603_70' model='account.account.template'>
             <field name='name'>Regalías sujetas al 30%</field>
             <field name='code'>603.70</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603')])]"/>
         </record>
         <record id='cuenta603_71' model='account.account.template'>
             <field name='name'>Regalías sin retención</field>
             <field name='code'>603.71</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603')])]"/>
         </record>
         <record id='cuenta603_72' model='account.account.template'>
             <field name='name'>Fletes y acarreos</field>
             <field name='code'>603.72</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603')])]"/>
         </record>
         <record id='cuenta603_73' model='account.account.template'>
             <field name='name'>Gastos de importación</field>
             <field name='code'>603.73</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603')])]"/>
         </record>
         <record id='cuenta603_74' model='account.account.template'>
             <field name='name'>Patentes y marcas</field>
             <field name='code'>603.74</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603')])]"/>
         </record>
         <record id='cuenta603_75' model='account.account.template'>
             <field name='name'>Uniformes</field>
             <field name='code'>603.75</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603')])]"/>
         </record>
         <record id='cuenta603_76' model='account.account.template'>
             <field name='name'>Prediales</field>
             <field name='code'>603.76</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603')])]"/>
         </record>
         <record id='cuenta603_77' model='account.account.template'>
             <field name='name'>Gastos de administración de urbanización</field>
             <field name='code'>603.77</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603')])]"/>
         </record>
         <record id='cuenta603_78' model='account.account.template'>
             <field name='name'>Gastos de administración de construcción</field>
             <field name='code'>603.78</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603')])]"/>
         </record>
         <record id='cuenta603_79' model='account.account.template'>
             <field name='name'>Fletes del extranjero</field>
             <field name='code'>603.79</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603')])]"/>
         </record>
         <record id='cuenta603_80' model='account.account.template'>
             <field name='name'>Recolección de bienes del sector agropecuario y/o ganadero</field>
             <field name='code'>603.80</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603')])]"/>
         </record>
         <record id='cuenta603_81' model='account.account.template'>
             <field name='name'>Gastos no deducibles (sin requisitos fiscales)</field>
             <field name='code'>603.81</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603')])]"/>
         </record>
         <record id='cuenta603_82' model='account.account.template'>
             <field name='name'>Otros gastos de administración</field>
             <field name='code'>603.82</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta604' model='account.account.template'>
-            <field name='name'>Gastos de fabricación</field>
-            <field name='code'>604</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603')])]"/>
         </record>
         <record id='cuenta604_01' model='account.account.template'>
             <field name='name'>Sueldos y salarios</field>
             <field name='code'>604.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604')])]"/>
         </record>
         <record id='cuenta604_02' model='account.account.template'>
             <field name='name'>Compensaciones</field>
             <field name='code'>604.02</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604')])]"/>
         </record>
         <record id='cuenta604_03' model='account.account.template'>
             <field name='name'>Tiempos extras</field>
             <field name='code'>604.03</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604')])]"/>
         </record>
         <record id='cuenta604_04' model='account.account.template'>
             <field name='name'>Premios de asistencia</field>
             <field name='code'>604.04</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604')])]"/>
         </record>
         <record id='cuenta604_05' model='account.account.template'>
             <field name='name'>Premios de puntualidad</field>
             <field name='code'>604.05</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604')])]"/>
         </record>
         <record id='cuenta604_06' model='account.account.template'>
             <field name='name'>Vacaciones</field>
             <field name='code'>604.06</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604')])]"/>
         </record>
         <record id='cuenta604_07' model='account.account.template'>
             <field name='name'>Prima vacacional</field>
             <field name='code'>604.07</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604')])]"/>
         </record>
         <record id='cuenta604_08' model='account.account.template'>
             <field name='name'>Prima dominical</field>
             <field name='code'>604.08</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604')])]"/>
         </record>
         <record id='cuenta604_09' model='account.account.template'>
             <field name='name'>Días festivos</field>
             <field name='code'>604.09</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604')])]"/>
         </record>
         <record id='cuenta604_10' model='account.account.template'>
             <field name='name'>Gratificaciones</field>
             <field name='code'>604.10</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604')])]"/>
         </record>
         <record id='cuenta604_11' model='account.account.template'>
             <field name='name'>Primas de antigüedad</field>
             <field name='code'>604.11</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604')])]"/>
         </record>
         <record id='cuenta604_12' model='account.account.template'>
             <field name='name'>Aguinaldo</field>
             <field name='code'>604.12</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604')])]"/>
         </record>
         <record id='cuenta604_13' model='account.account.template'>
             <field name='name'>Indemnizaciones</field>
             <field name='code'>604.13</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604')])]"/>
         </record>
         <record id='cuenta604_14' model='account.account.template'>
             <field name='name'>Destajo</field>
             <field name='code'>604.14</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604')])]"/>
         </record>
         <record id='cuenta604_15' model='account.account.template'>
             <field name='name'>Despensa</field>
             <field name='code'>604.15</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604')])]"/>
         </record>
         <record id='cuenta604_16' model='account.account.template'>
             <field name='name'>Transporte</field>
             <field name='code'>604.16</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604')])]"/>
         </record>
         <record id='cuenta604_17' model='account.account.template'>
             <field name='name'>Servicio médico</field>
             <field name='code'>604.17</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604')])]"/>
         </record>
         <record id='cuenta604_18' model='account.account.template'>
             <field name='name'>Ayuda en gastos funerarios</field>
             <field name='code'>604.18</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604')])]"/>
         </record>
         <record id='cuenta604_19' model='account.account.template'>
             <field name='name'>Fondo de ahorro</field>
             <field name='code'>604.19</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604')])]"/>
         </record>
         <record id='cuenta604_20' model='account.account.template'>
             <field name='name'>Cuotas sindicales</field>
             <field name='code'>604.20</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604')])]"/>
         </record>
         <record id='cuenta604_21' model='account.account.template'>
             <field name='name'>PTU</field>
             <field name='code'>604.21</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604')])]"/>
         </record>
         <record id='cuenta604_22' model='account.account.template'>
             <field name='name'>Estímulo al personal</field>
             <field name='code'>604.22</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604')])]"/>
         </record>
         <record id='cuenta604_23' model='account.account.template'>
             <field name='name'>Previsión social</field>
             <field name='code'>604.23</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604')])]"/>
         </record>
         <record id='cuenta604_24' model='account.account.template'>
             <field name='name'>Aportaciones para el plan de jubilación</field>
             <field name='code'>604.24</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604')])]"/>
         </record>
         <record id='cuenta604_25' model='account.account.template'>
             <field name='name'>Otras prestaciones al personal</field>
             <field name='code'>604.25</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604')])]"/>
         </record>
         <record id='cuenta604_26' model='account.account.template'>
             <field name='name'>Cuotas al IMSS</field>
             <field name='code'>604.26</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604')])]"/>
         </record>
         <record id='cuenta604_27' model='account.account.template'>
             <field name='name'>Aportaciones al infonavit</field>
             <field name='code'>604.27</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604')])]"/>
         </record>
         <record id='cuenta604_28' model='account.account.template'>
             <field name='name'>Aportaciones al SAR</field>
             <field name='code'>604.28</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604')])]"/>
         </record>
         <record id='cuenta604_29' model='account.account.template'>
             <field name='name'>Impuesto estatal sobre nóminas</field>
             <field name='code'>604.29</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604')])]"/>
         </record>
         <record id='cuenta604_30' model='account.account.template'>
             <field name='name'>Otras aportaciones</field>
             <field name='code'>604.30</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604')])]"/>
         </record>
         <record id='cuenta604_31' model='account.account.template'>
             <field name='name'>Asimilados a salarios</field>
             <field name='code'>604.31</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604')])]"/>
         </record>
         <record id='cuenta604_32' model='account.account.template'>
             <field name='name'>Servicios administrativos</field>
             <field name='code'>604.32</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604')])]"/>
         </record>
         <record id='cuenta604_33' model='account.account.template'>
             <field name='name'>Servicios administrativos partes relacionadas</field>
             <field name='code'>604.33</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604')])]"/>
         </record>
         <record id='cuenta604_34' model='account.account.template'>
             <field name='name'>Honorarios a personas físicas residentes nacionales</field>
             <field name='code'>604.34</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604')])]"/>
         </record>
         <record id='cuenta604_35' model='account.account.template'>
             <field name='name'>Honorarios a personas físicas residentes nacionales partes relacionadas</field>
             <field name='code'>604.35</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604')])]"/>
         </record>
         <record id='cuenta604_36' model='account.account.template'>
             <field name='name'>Honorarios a personas físicas residentes del extranjero</field>
             <field name='code'>604.36</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604')])]"/>
         </record>
         <record id='cuenta604_37' model='account.account.template'>
             <field name='name'>Honorarios a personas físicas residentes del extranjero partes relacionadas</field>
             <field name='code'>604.37</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604')])]"/>
         </record>
         <record id='cuenta604_38' model='account.account.template'>
             <field name='name'>Honorarios a personas morales residentes nacionales</field>
             <field name='code'>604.38</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604')])]"/>
         </record>
         <record id='cuenta604_39' model='account.account.template'>
             <field name='name'>Honorarios a personas morales residentes nacionales partes relacionadas</field>
             <field name='code'>604.39</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604')])]"/>
         </record>
         <record id='cuenta604_40' model='account.account.template'>
             <field name='name'>Honorarios a personas morales residentes del extranjero</field>
             <field name='code'>604.40</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604')])]"/>
         </record>
         <record id='cuenta604_41' model='account.account.template'>
             <field name='name'>Honorarios a personas morales residentes del extranjero partes relacionadas</field>
             <field name='code'>604.41</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604')])]"/>
         </record>
         <record id='cuenta604_42' model='account.account.template'>
             <field name='name'>Honorarios aduanales personas físicas</field>
             <field name='code'>604.42</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604')])]"/>
         </record>
         <record id='cuenta604_43' model='account.account.template'>
             <field name='name'>Honorarios aduanales personas morales</field>
             <field name='code'>604.43</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604')])]"/>
         </record>
         <record id='cuenta604_44' model='account.account.template'>
             <field name='name'>Honorarios al consejo de administración</field>
             <field name='code'>604.44</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604')])]"/>
         </record>
         <record id='cuenta604_45' model='account.account.template'>
             <field name='name'>Arrendamiento a personas físicas residentes nacionales</field>
             <field name='code'>604.45</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604')])]"/>
         </record>
         <record id='cuenta604_46' model='account.account.template'>
             <field name='name'>Arrendamiento a personas morales residentes nacionales</field>
             <field name='code'>604.46</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604')])]"/>
         </record>
         <record id='cuenta604_47' model='account.account.template'>
             <field name='name'>Arrendamiento a residentes del extranjero</field>
             <field name='code'>604.47</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604')])]"/>
         </record>
         <record id='cuenta604_48' model='account.account.template'>
             <field name='name'>Combustibles y lubricantes</field>
             <field name='code'>604.48</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604')])]"/>
         </record>
         <record id='cuenta604_49' model='account.account.template'>
             <field name='name'>Viáticos y gastos de viaje</field>
             <field name='code'>604.49</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604')])]"/>
         </record>
         <record id='cuenta604_50' model='account.account.template'>
             <field name='name'>Teléfono, internet</field>
             <field name='code'>604.50</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604')])]"/>
         </record>
         <record id='cuenta604_51' model='account.account.template'>
             <field name='name'>Agua</field>
             <field name='code'>604.51</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604')])]"/>
         </record>
         <record id='cuenta604_52' model='account.account.template'>
             <field name='name'>Energía eléctrica</field>
             <field name='code'>604.52</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604')])]"/>
         </record>
         <record id='cuenta604_53' model='account.account.template'>
             <field name='name'>Vigilancia y seguridad</field>
             <field name='code'>604.53</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604')])]"/>
         </record>
         <record id='cuenta604_54' model='account.account.template'>
             <field name='name'>Limpieza</field>
             <field name='code'>604.54</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604')])]"/>
         </record>
         <record id='cuenta604_55' model='account.account.template'>
             <field name='name'>Papelería y artículos de oficina</field>
             <field name='code'>604.55</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604')])]"/>
         </record>
         <record id='cuenta604_56' model='account.account.template'>
             <field name='name'>Mantenimiento y conservación</field>
             <field name='code'>604.56</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604')])]"/>
         </record>
         <record id='cuenta604_57' model='account.account.template'>
             <field name='name'>Seguros y fianzas</field>
             <field name='code'>604.57</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604')])]"/>
         </record>
         <record id='cuenta604_58' model='account.account.template'>
             <field name='name'>Otros impuestos y derechos</field>
             <field name='code'>604.58</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604')])]"/>
         </record>
         <record id='cuenta604_59' model='account.account.template'>
             <field name='name'>Recargos fiscales</field>
             <field name='code'>604.59</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604')])]"/>
         </record>
         <record id='cuenta604_60' model='account.account.template'>
             <field name='name'>Cuotas y suscripciones</field>
             <field name='code'>604.60</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604')])]"/>
         </record>
         <record id='cuenta604_61' model='account.account.template'>
             <field name='name'>Propaganda y publicidad</field>
             <field name='code'>604.61</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604')])]"/>
         </record>
         <record id='cuenta604_62' model='account.account.template'>
             <field name='name'>Capacitación al personal</field>
             <field name='code'>604.62</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604')])]"/>
         </record>
         <record id='cuenta604_63' model='account.account.template'>
             <field name='name'>Donativos y ayudas</field>
             <field name='code'>604.63</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604')])]"/>
         </record>
         <record id='cuenta604_64' model='account.account.template'>
             <field name='name'>Asistencia técnica</field>
             <field name='code'>604.64</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604')])]"/>
         </record>
         <record id='cuenta604_65' model='account.account.template'>
             <field name='name'>Regalías sujetas a otros porcentajes</field>
             <field name='code'>604.65</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604')])]"/>
         </record>
         <record id='cuenta604_66' model='account.account.template'>
             <field name='name'>Regalías sujetas al 5%</field>
             <field name='code'>604.66</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604')])]"/>
         </record>
         <record id='cuenta604_67' model='account.account.template'>
             <field name='name'>Regalías sujetas al 10%</field>
             <field name='code'>604.67</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604')])]"/>
         </record>
         <record id='cuenta604_68' model='account.account.template'>
             <field name='name'>Regalías sujetas al 15%</field>
             <field name='code'>604.68</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604')])]"/>
         </record>
         <record id='cuenta604_69' model='account.account.template'>
             <field name='name'>Regalías sujetas al 25%</field>
             <field name='code'>604.69</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604')])]"/>
         </record>
         <record id='cuenta604_70' model='account.account.template'>
             <field name='name'>Regalías sujetas al 30%</field>
             <field name='code'>604.70</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604')])]"/>
         </record>
         <record id='cuenta604_71' model='account.account.template'>
             <field name='name'>Regalías sin retención</field>
             <field name='code'>604.71</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604')])]"/>
         </record>
         <record id='cuenta604_72' model='account.account.template'>
             <field name='name'>Fletes y acarreos</field>
             <field name='code'>604.72</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604')])]"/>
         </record>
         <record id='cuenta604_73' model='account.account.template'>
             <field name='name'>Gastos de importación</field>
             <field name='code'>604.73</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604')])]"/>
         </record>
         <record id='cuenta604_74' model='account.account.template'>
             <field name='name'>Patentes y marcas</field>
             <field name='code'>604.74</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604')])]"/>
         </record>
         <record id='cuenta604_75' model='account.account.template'>
             <field name='name'>Uniformes</field>
             <field name='code'>604.75</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604')])]"/>
         </record>
         <record id='cuenta604_76' model='account.account.template'>
             <field name='name'>Prediales</field>
             <field name='code'>604.76</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604')])]"/>
         </record>
         <record id='cuenta604_77' model='account.account.template'>
             <field name='name'>Gastos de fabricación de urbanización</field>
             <field name='code'>604.77</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604')])]"/>
         </record>
         <record id='cuenta604_78' model='account.account.template'>
             <field name='name'>Gastos de fabricación de construcción</field>
             <field name='code'>604.78</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604')])]"/>
         </record>
         <record id='cuenta604_79' model='account.account.template'>
             <field name='name'>Fletes del extranjero</field>
             <field name='code'>604.79</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604')])]"/>
         </record>
         <record id='cuenta604_80' model='account.account.template'>
             <field name='name'>Recolección de bienes del sector agropecuario y/o ganadero</field>
             <field name='code'>604.80</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604')])]"/>
         </record>
         <record id='cuenta604_81' model='account.account.template'>
             <field name='name'>Gastos no deducibles (sin requisitos fiscales)</field>
             <field name='code'>604.81</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604')])]"/>
         </record>
         <record id='cuenta604_82' model='account.account.template'>
             <field name='name'>Otros gastos de fabricación</field>
             <field name='code'>604.82</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta605' model='account.account.template'>
-            <field name='name'>Mano de obra directa</field>
-            <field name='code'>605</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604')])]"/>
         </record>
         <record id='cuenta605_01' model='account.account.template'>
             <field name='name'>Mano de obra</field>
             <field name='code'>605.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_605')])]"/>
         </record>
         <record id='cuenta605_02' model='account.account.template'>
             <field name='name'>Sueldos y Salarios</field>
             <field name='code'>605.02</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_605')])]"/>
         </record>
         <record id='cuenta605_03' model='account.account.template'>
             <field name='name'>Compensaciones</field>
             <field name='code'>605.03</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_605')])]"/>
         </record>
         <record id='cuenta605_04' model='account.account.template'>
             <field name='name'>Tiempos extras</field>
             <field name='code'>605.04</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_605')])]"/>
         </record>
         <record id='cuenta605_05' model='account.account.template'>
             <field name='name'>Premios de asistencia</field>
             <field name='code'>605.05</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_605')])]"/>
         </record>
         <record id='cuenta605_06' model='account.account.template'>
             <field name='name'>Premios de puntualidad</field>
             <field name='code'>605.06</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_605')])]"/>
         </record>
         <record id='cuenta605_07' model='account.account.template'>
             <field name='name'>Vacaciones</field>
             <field name='code'>605.07</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_605')])]"/>
         </record>
         <record id='cuenta605_08' model='account.account.template'>
             <field name='name'>Prima vacacional</field>
             <field name='code'>605.08</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_605')])]"/>
         </record>
         <record id='cuenta605_09' model='account.account.template'>
             <field name='name'>Prima dominical</field>
             <field name='code'>605.09</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_605')])]"/>
         </record>
         <record id='cuenta605_1' model='account.account.template'>
             <field name='name'>Días festivos</field>
             <field name='code'>605.10</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_605')])]"/>
         </record>
         <record id='cuenta605_11' model='account.account.template'>
             <field name='name'>Gratificaciones</field>
             <field name='code'>605.11</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_605')])]"/>
         </record>
         <record id='cuenta605_12' model='account.account.template'>
             <field name='name'>Primas de antigüedad</field>
             <field name='code'>605.12</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_605')])]"/>
         </record>
         <record id='cuenta605_13' model='account.account.template'>
             <field name='name'>Aguinaldo</field>
             <field name='code'>605.13</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_605')])]"/>
         </record>
         <record id='cuenta605_14' model='account.account.template'>
             <field name='name'>Indemnizaciones</field>
             <field name='code'>605.14</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_605')])]"/>
         </record>
         <record id='cuenta605_15' model='account.account.template'>
             <field name='name'>Destajo</field>
             <field name='code'>605.15</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_605')])]"/>
         </record>
         <record id='cuenta605_16' model='account.account.template'>
             <field name='name'>Despensa</field>
             <field name='code'>605.16</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_605')])]"/>
         </record>
         <record id='cuenta605_17' model='account.account.template'>
             <field name='name'>Transporte</field>
             <field name='code'>605.17</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_605')])]"/>
         </record>
         <record id='cuenta605_18' model='account.account.template'>
             <field name='name'>Servicio médico</field>
             <field name='code'>605.18</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_605')])]"/>
         </record>
         <record id='cuenta605_19' model='account.account.template'>
             <field name='name'>Ayuda en gastos funerarios</field>
             <field name='code'>605.19</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_605')])]"/>
         </record>
         <record id='cuenta605_20' model='account.account.template'>
             <field name='name'>Fondo de ahorro</field>
             <field name='code'>605.20</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_605')])]"/>
         </record>
         <record id='cuenta605_21' model='account.account.template'>
             <field name='name'>Cuotas sindicales</field>
             <field name='code'>605.21</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_605')])]"/>
         </record>
         <record id='cuenta605_22' model='account.account.template'>
             <field name='name'>PTU</field>
             <field name='code'>605.22</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_605')])]"/>
         </record>
         <record id='cuenta605_23' model='account.account.template'>
             <field name='name'>Estímulo al personal</field>
             <field name='code'>605.23</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_605')])]"/>
         </record>
         <record id='cuenta605_24' model='account.account.template'>
             <field name='name'>Previsión social</field>
             <field name='code'>605.24</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_605')])]"/>
         </record>
         <record id='cuenta605_25' model='account.account.template'>
             <field name='name'>Aportaciones para el plan de jubilación</field>
             <field name='code'>605.25</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_605')])]"/>
         </record>
         <record id='cuenta605_26' model='account.account.template'>
             <field name='name'>Otras prestaciones al personal</field>
             <field name='code'>605.26</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_605')])]"/>
         </record>
         <record id='cuenta605_27' model='account.account.template'>
             <field name='name'>Asimilados a salarios</field>
             <field name='code'>605.27</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_605')])]"/>
         </record>
         <record id='cuenta605_28' model='account.account.template'>
             <field name='name'>Cuotas al IMSS</field>
             <field name='code'>605.28</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_605')])]"/>
         </record>
         <record id='cuenta605_29' model='account.account.template'>
             <field name='name'>Aportaciones al infonavit</field>
             <field name='code'>605.29</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_605')])]"/>
         </record>
         <record id='cuenta605_3' model='account.account.template'>
             <field name='name'>Aportaciones al SAR</field>
             <field name='code'>605.30</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_605')])]"/>
         </record>
         <record id='cuenta605_31' model='account.account.template'>
             <field name='name'>Otros costos de mano de obra directa</field>
             <field name='code'>605.31</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta606' model='account.account.template'>
-            <field name='name'>Facilidades administrativas fiscales</field>
-            <field name='code'>606</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_605')])]"/>
         </record>
         <record id='cuenta606_01' model='account.account.template'>
             <field name='name'>Facilidades administrativas fiscales</field>
             <field name='code'>606.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta607' model='account.account.template'>
-            <field name='name'>Participación de los trabajadores en las utilidades</field>
-            <field name='code'>607</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_606')])]"/>
         </record>
         <record id='cuenta607_01' model='account.account.template'>
             <field name='name'>Participación de los trabajadores en las utilidades</field>
             <field name='code'>607.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta608' model='account.account.template'>
-            <field name='name'>Participación en resultados de subsidiarias</field>
-            <field name='code'>608</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_607')])]"/>
         </record>
         <record id='cuenta608_01' model='account.account.template'>
             <field name='name'>Participación en resultados de subsidiarias</field>
             <field name='code'>608.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta609' model='account.account.template'>
-            <field name='name'>Participación en resultados de asociadas</field>
-            <field name='code'>609</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_608')])]"/>
         </record>
         <record id='cuenta609_01' model='account.account.template'>
             <field name='name'>Participación en resultados de asociadas</field>
             <field name='code'>609.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta610' model='account.account.template'>
-            <field name='name'>Participación de los trabajadores en las utilidades diferida</field>
-            <field name='code'>610</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_609')])]"/>
         </record>
         <record id='cuenta610_01' model='account.account.template'>
             <field name='name'>Participación de los trabajadores en las utilidades diferida</field>
             <field name='code'>610.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta611' model='account.account.template'>
-            <field name='name'>Impuesto Sobre la renta</field>
-            <field name='code'>611</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_610')])]"/>
         </record>
         <record id='cuenta611_01' model='account.account.template'>
             <field name='name'>Impuesto Sobre la renta</field>
             <field name='code'>611.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_611')])]"/>
         </record>
         <record id='cuenta611_02' model='account.account.template'>
             <field name='name'>Impuesto Sobre la renta por remanente distribuible</field>
             <field name='code'>611.02</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta612' model='account.account.template'>
-            <field name='name'>Gastos no deducibles para CUFIN</field>
-            <field name='code'>612</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_611')])]"/>
         </record>
         <record id='cuenta612_01' model='account.account.template'>
             <field name='name'>Gastos no deducibles para CUFIN</field>
             <field name='code'>612.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta613' model='account.account.template'>
-            <field name='name'>Depreciación contable</field>
-            <field name='code'>613</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_612')])]"/>
         </record>
         <record id='cuenta613_01' model='account.account.template'>
             <field name='name'>Depreciación de edificios</field>
             <field name='code'>613.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_613')])]"/>
         </record>
         <record id='cuenta613_02' model='account.account.template'>
             <field name='name'>Depreciación de maquinaria y equipo</field>
             <field name='code'>613.02</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_613')])]"/>
         </record>
         <record id='cuenta613_03' model='account.account.template'>
             <field name='name'>Depreciación de automóviles, autobuses, camiones de carga, tractocamiones, montacargas y remolques</field>
             <field name='code'>613.03</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_613')])]"/>
         </record>
         <record id='cuenta613_04' model='account.account.template'>
             <field name='name'>Depreciación de mobiliario y equipo de oficina</field>
             <field name='code'>613.04</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_613')])]"/>
         </record>
         <record id='cuenta613_05' model='account.account.template'>
             <field name='name'>Depreciación de equipo de cómputo</field>
             <field name='code'>613.05</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_613')])]"/>
         </record>
         <record id='cuenta613_06' model='account.account.template'>
             <field name='name'>Depreciación de equipo de comunicación</field>
             <field name='code'>613.06</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_613')])]"/>
         </record>
         <record id='cuenta613_07' model='account.account.template'>
             <field name='name'>Depreciación de activos biológicos, vegetales y semovientes</field>
             <field name='code'>613.07</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_613')])]"/>
         </record>
         <record id='cuenta613_08' model='account.account.template'>
             <field name='name'>Depreciación de otros activos fijos</field>
             <field name='code'>613.08</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_613')])]"/>
         </record>
         <record id='cuenta613_09' model='account.account.template'>
             <field name='name'>Depreciación de ferrocarriles</field>
             <field name='code'>613.09</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_613')])]"/>
         </record>
         <record id='cuenta613_10' model='account.account.template'>
             <field name='name'>Depreciación de embarcaciones</field>
             <field name='code'>613.10</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_613')])]"/>
         </record>
         <record id='cuenta613_11' model='account.account.template'>
             <field name='name'>Depreciación de aviones</field>
             <field name='code'>613.11</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_613')])]"/>
         </record>
         <record id='cuenta613_12' model='account.account.template'>
             <field name='name'>Depreciación de troqueles, moldes, matrices y herramental</field>
             <field name='code'>613.12</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_613')])]"/>
         </record>
         <record id='cuenta613_13' model='account.account.template'>
             <field name='name'>Depreciación de equipo de comunicaciones telefónicas</field>
             <field name='code'>613.13</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_613')])]"/>
         </record>
         <record id='cuenta613_14' model='account.account.template'>
             <field name='name'>Depreciación de equipo de comunicación satelital</field>
             <field name='code'>613.14</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_613')])]"/>
         </record>
         <record id='cuenta613_15' model='account.account.template'>
             <field name='name'>Depreciación de equipo de adaptaciones para personas con capacidades diferentes</field>
             <field name='code'>613.15</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_613')])]"/>
         </record>
         <record id='cuenta613_16' model='account.account.template'>
             <field name='name'>Depreciación de maquinaria y equipo de generación de energía de fuentes renovables o de sistemas de cogeneración de electricidad eficiente</field>
             <field name='code'>613.16</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_613')])]"/>
         </record>
         <record id='cuenta613_17' model='account.account.template'>
             <field name='name'>Depreciación de adaptaciones y mejoras</field>
             <field name='code'>613.17</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_613')])]"/>
         </record>
         <record id='cuenta613_18' model='account.account.template'>
             <field name='name'>Depreciación de otra maquinaria y equipo</field>
             <field name='code'>613.18</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta614' model='account.account.template'>
-            <field name='name'>Amortización contable</field>
-            <field name='code'>614</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_613')])]"/>
         </record>
         <record id='cuenta614_01' model='account.account.template'>
             <field name='name'>Amortización de gastos diferidos</field>
             <field name='code'>614.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_614')])]"/>
         </record>
         <record id='cuenta614_02' model='account.account.template'>
             <field name='name'>Amortización de gastos pre operativos</field>
             <field name='code'>614.02</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_614')])]"/>
         </record>
         <record id='cuenta614_03' model='account.account.template'>
             <field name='name'>Amortización de regalías, asistencia técnica y otros gastos diferidos</field>
             <field name='code'>614.03</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_614')])]"/>
         </record>
         <record id='cuenta614_04' model='account.account.template'>
             <field name='name'>Amortización de activos intangibles</field>
             <field name='code'>614.04</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_614')])]"/>
         </record>
         <record id='cuenta614_05' model='account.account.template'>
             <field name='name'>Amortización de gastos de organización</field>
             <field name='code'>614.05</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_614')])]"/>
         </record>
         <record id='cuenta614_06' model='account.account.template'>
             <field name='name'>Amortización de investigación y desarrollo de mercado</field>
             <field name='code'>614.06</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_614')])]"/>
         </record>
         <record id='cuenta614_07' model='account.account.template'>
             <field name='name'>Amortización de marcas y patentes</field>
             <field name='code'>614.07</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_614')])]"/>
             <field name="user_type_id" ref="account_type_other"/>
         </record>
         <record id='cuenta614_08' model='account.account.template'>
@@ -5839,754 +5897,718 @@ Cuentas del plan
             <field name='code'>614.08</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_614')])]"/>
         </record>
         <record id='cuenta614_09' model='account.account.template'>
             <field name='name'>Amortización de gastos de instalación</field>
             <field name='code'>614.09</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_614')])]"/>
         </record>
         <record id='cuenta614_10' model='account.account.template'>
             <field name='name'>Amortización de otros activos diferidos</field>
             <field name='code'>614.10</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta700' model='account.account.template'>
-            <field name='name'>Resultado integral de financiamiento</field>
-            <field name='code'>700</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta701' model='account.account.template'>
-            <field name='name'>Gastos financieros</field>
-            <field name='code'>701</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_614')])]"/>
         </record>
         <record id='cuenta701_01' model='account.account.template'>
             <field name='name'>Pérdida cambiaria</field>
             <field name='code'>701.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_701')])]"/>
         </record>
         <record id='cuenta701_02' model='account.account.template'>
             <field name='name'>Pérdida cambiaria nacional parte relacionada</field>
             <field name='code'>701.02</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_701')])]"/>
         </record>
         <record id='cuenta701_03' model='account.account.template'>
             <field name='name'>Pérdida cambiaria extranjero parte relacionada</field>
             <field name='code'>701.03</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_701')])]"/>
         </record>
         <record id='cuenta701_04' model='account.account.template'>
             <field name='name'>Intereses a cargo bancario nacional</field>
             <field name='code'>701.04</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_701')])]"/>
         </record>
         <record id='cuenta701_05' model='account.account.template'>
             <field name='name'>Intereses a cargo bancario extranjero</field>
             <field name='code'>701.05</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_701')])]"/>
         </record>
         <record id='cuenta701_06' model='account.account.template'>
             <field name='name'>Intereses a cargo de personas físicas nacional</field>
             <field name='code'>701.06</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_701')])]"/>
         </record>
         <record id='cuenta701_07' model='account.account.template'>
             <field name='name'>Intereses a cargo de personas físicas extranjero</field>
             <field name='code'>701.07</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_701')])]"/>
         </record>
         <record id='cuenta701_08' model='account.account.template'>
             <field name='name'>Intereses a cargo de personas morales nacional</field>
             <field name='code'>701.08</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_701')])]"/>
         </record>
         <record id='cuenta701_09' model='account.account.template'>
             <field name='name'>Intereses a cargo de personas morales extranjero</field>
             <field name='code'>701.09</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_701')])]"/>
         </record>
         <record id='cuenta701_1' model='account.account.template'>
             <field name='name'>Comisiones bancarias</field>
             <field name='code'>701.10</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_701')])]"/>
         </record>
         <record id='cuenta701_11' model='account.account.template'>
             <field name='name'>Otros gastos financieros</field>
             <field name='code'>701.11</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta702' model='account.account.template'>
-            <field name='name'>Productos financieros</field>
-            <field name='code'>702</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_701')])]"/>
         </record>
         <record id='cuenta702_01' model='account.account.template'>
             <field name='name'>Utilidad cambiaria</field>
             <field name='code'>702.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_702')])]"/>
         </record>
         <record id='cuenta702_02' model='account.account.template'>
             <field name='name'>Utilidad cambiaria nacional parte relacionada</field>
             <field name='code'>702.02</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_702')])]"/>
         </record>
         <record id='cuenta702_03' model='account.account.template'>
             <field name='name'>Utilidad cambiaria extranjero parte relacionada</field>
             <field name='code'>702.03</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_702')])]"/>
         </record>
         <record id='cuenta702_04' model='account.account.template'>
             <field name='name'>Intereses a favor bancarios nacional</field>
             <field name='code'>702.04</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_702')])]"/>
         </record>
         <record id='cuenta702_05' model='account.account.template'>
             <field name='name'>Intereses a favor bancarios extranjero</field>
             <field name='code'>702.05</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_702')])]"/>
         </record>
         <record id='cuenta702_06' model='account.account.template'>
             <field name='name'>Intereses a favor de personas físicas nacional</field>
             <field name='code'>702.06</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_702')])]"/>
         </record>
         <record id='cuenta702_07' model='account.account.template'>
             <field name='name'>Intereses a favor de personas físicas extranjero</field>
             <field name='code'>702.07</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_702')])]"/>
         </record>
         <record id='cuenta702_08' model='account.account.template'>
             <field name='name'>Intereses a favor de personas morales nacional</field>
             <field name='code'>702.08</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_702')])]"/>
         </record>
         <record id='cuenta702_09' model='account.account.template'>
             <field name='name'>Intereses a favor de personas morales extranjero</field>
             <field name='code'>702.09</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_702')])]"/>
         </record>
         <record id='cuenta702_10' model='account.account.template'>
             <field name='name'>Otros productos financieros</field>
             <field name='code'>702.10</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta703' model='account.account.template'>
-            <field name='name'>Otros gastos</field>
-            <field name='code'>703</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_702')])]"/>
         </record>
         <record id='cuenta703_01' model='account.account.template'>
             <field name='name'>Pérdida en venta y/o baja de terrenos</field>
             <field name='code'>703.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_703')])]"/>
         </record>
         <record id='cuenta703_02' model='account.account.template'>
             <field name='name'>Pérdida en venta y/o baja de edificios</field>
             <field name='code'>703.02</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_703')])]"/>
         </record>
         <record id='cuenta703_03' model='account.account.template'>
             <field name='name'>Pérdida en venta y/o baja de maquinaria y equipo</field>
             <field name='code'>703.03</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_703')])]"/>
         </record>
         <record id='cuenta703_04' model='account.account.template'>
             <field name='name'>Pérdida en venta y/o baja de automóviles, autobuses, camiones de carga, tractocamiones, montacargas y remolques</field>
             <field name='code'>703.04</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_703')])]"/>
         </record>
         <record id='cuenta703_05' model='account.account.template'>
             <field name='name'>Pérdida en venta y/o baja de mobiliario y equipo de oficina</field>
             <field name='code'>703.05</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_703')])]"/>
         </record>
         <record id='cuenta703_06' model='account.account.template'>
             <field name='name'>Pérdida en venta y/o baja de equipo de cómputo</field>
             <field name='code'>703.06</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_703')])]"/>
         </record>
         <record id='cuenta703_07' model='account.account.template'>
             <field name='name'>Pérdida en venta y/o baja de equipo de comunicación</field>
             <field name='code'>703.07</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_703')])]"/>
         </record>
         <record id='cuenta703_08' model='account.account.template'>
             <field name='name'>Pérdida en venta y/o baja de activos biológicos, vegetales y semovientes</field>
             <field name='code'>703.08</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_703')])]"/>
         </record>
         <record id='cuenta703_09' model='account.account.template'>
             <field name='name'>Pérdida en venta y/o baja de otros activos fijos</field>
             <field name='code'>703.09</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_703')])]"/>
         </record>
         <record id='cuenta703_10' model='account.account.template'>
             <field name='name'>Pérdida en venta y/o baja de ferrocarriles</field>
             <field name='code'>703.10</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_703')])]"/>
         </record>
         <record id='cuenta703_11' model='account.account.template'>
             <field name='name'>Pérdida en venta y/o baja de embarcaciones</field>
             <field name='code'>703.11</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_703')])]"/>
         </record>
         <record id='cuenta703_12' model='account.account.template'>
             <field name='name'>Pérdida en venta y/o baja de aviones</field>
             <field name='code'>703.12</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_703')])]"/>
         </record>
         <record id='cuenta703_13' model='account.account.template'>
             <field name='name'>Pérdida en venta y/o baja de troqueles, moldes, matrices y herramental</field>
             <field name='code'>703.13</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_703')])]"/>
         </record>
         <record id='cuenta703_14' model='account.account.template'>
             <field name='name'>Pérdida en venta y/o baja de equipo de comunicaciones telefónicas</field>
             <field name='code'>703.14</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_703')])]"/>
         </record>
         <record id='cuenta703_15' model='account.account.template'>
             <field name='name'>Pérdida en venta y/o baja de equipo de comunicación satelital</field>
             <field name='code'>703.15</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_703')])]"/>
         </record>
         <record id='cuenta703_16' model='account.account.template'>
             <field name='name'>Pérdida en venta y/o baja de equipo de adaptaciones para personas con capacidades diferentes</field>
             <field name='code'>703.16</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_703')])]"/>
         </record>
         <record id='cuenta703_17' model='account.account.template'>
             <field name='name'>Pérdida en venta y/o baja de maquinaria y equipo de generación de energía de fuentes renovables o de sistemas de cogeneración de electricidad eficiente</field>
             <field name='code'>703.17</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_703')])]"/>
         </record>
         <record id='cuenta703_18' model='account.account.template'>
             <field name='name'>Pérdida en venta y/o baja de otra maquinaria y equipo</field>
             <field name='code'>703.18</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_703')])]"/>
         </record>
         <record id='cuenta703_19' model='account.account.template'>
             <field name='name'>Pérdida por enajenación de acciones</field>
             <field name='code'>703.19</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_703')])]"/>
         </record>
         <record id='cuenta703_20' model='account.account.template'>
             <field name='name'>Pérdida por enajenación de partes sociales</field>
             <field name='code'>703.20</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_703')])]"/>
         </record>
         <record id='cuenta703_21' model='account.account.template'>
             <field name='name'>Otros gastos</field>
             <field name='code'>703.21</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta704' model='account.account.template'>
-            <field name='name'>Otros productos</field>
-            <field name='code'>704</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_703')])]"/>
         </record>
         <record id='cuenta704_01' model='account.account.template'>
             <field name='name'>Ganancia en venta y/o baja de terrenos</field>
             <field name='code'>704.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_704')])]"/>
         </record>
         <record id='cuenta704_02' model='account.account.template'>
             <field name='name'>Ganancia en venta y/o baja de edificios</field>
             <field name='code'>704.02</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_704')])]"/>
         </record>
         <record id='cuenta704_03' model='account.account.template'>
             <field name='name'>Ganancia en venta y/o baja de maquinaria y equipo</field>
             <field name='code'>704.03</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_704')])]"/>
         </record>
         <record id='cuenta704_04' model='account.account.template'>
             <field name='name'>Ganancia en venta y/o baja de automóviles, autobuses, camiones de carga, tractocamiones, montacargas y remolques</field>
             <field name='code'>704.04</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_704')])]"/>
         </record>
         <record id='cuenta704_05' model='account.account.template'>
             <field name='name'>Ganancia en venta y/o baja de mobiliario y equipo de oficina</field>
             <field name='code'>704.05</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_704')])]"/>
         </record>
         <record id='cuenta704_06' model='account.account.template'>
             <field name='name'>Ganancia en venta y/o baja de equipo de cómputo</field>
             <field name='code'>704.06</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_704')])]"/>
         </record>
         <record id='cuenta704_07' model='account.account.template'>
             <field name='name'>Ganancia en venta y/o baja de equipo de comunicación</field>
             <field name='code'>704.07</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_704')])]"/>
         </record>
         <record id='cuenta704_08' model='account.account.template'>
             <field name='name'>Ganancia en venta y/o baja de activos biológicos, vegetales y semovientes</field>
             <field name='code'>704.08</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_704')])]"/>
         </record>
         <record id='cuenta704_09' model='account.account.template'>
             <field name='name'>Ganancia en venta y/o baja de otros activos fijos</field>
             <field name='code'>704.09</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_704')])]"/>
         </record>
         <record id='cuenta704_10' model='account.account.template'>
             <field name='name'>Ganancia en venta y/o baja de ferrocarriles</field>
             <field name='code'>704.10</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_704')])]"/>
         </record>
         <record id='cuenta704_11' model='account.account.template'>
             <field name='name'>Ganancia en venta y/o baja de embarcaciones</field>
             <field name='code'>704.11</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_704')])]"/>
         </record>
         <record id='cuenta704_12' model='account.account.template'>
             <field name='name'>Ganancia en venta y/o baja de aviones</field>
             <field name='code'>704.12</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_704')])]"/>
         </record>
         <record id='cuenta704_13' model='account.account.template'>
             <field name='name'>Ganancia en venta y/o baja de troqueles, moldes, matrices y herramental</field>
             <field name='code'>704.13</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_704')])]"/>
         </record>
         <record id='cuenta704_14' model='account.account.template'>
             <field name='name'>Ganancia en venta y/o baja de equipo de comunicaciones telefónicas</field>
             <field name='code'>704.14</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_704')])]"/>
         </record>
         <record id='cuenta704_15' model='account.account.template'>
             <field name='name'>Ganancia en venta y/o baja de equipo de comunicación satelital</field>
             <field name='code'>704.15</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_704')])]"/>
         </record>
         <record id='cuenta704_16' model='account.account.template'>
             <field name='name'>Ganancia en venta y/o baja de equipo de adaptaciones para personas con capacidades diferentes</field>
             <field name='code'>704.16</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_704')])]"/>
         </record>
         <record id='cuenta704_17' model='account.account.template'>
             <field name='name'>Ganancia en venta de maquinaria y equipo de generación de energía de fuentes renovables o de sistemas de cogeneración de electricidad eficiente</field>
             <field name='code'>704.17</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_704')])]"/>
         </record>
         <record id='cuenta704_18' model='account.account.template'>
             <field name='name'>Ganancia en venta y/o baja de otra maquinaria y equipo</field>
             <field name='code'>704.18</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_704')])]"/>
         </record>
         <record id='cuenta704_19' model='account.account.template'>
             <field name='name'>Ganancia por enajenación de acciones</field>
             <field name='code'>704.19</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_704')])]"/>
         </record>
         <record id='cuenta704_2' model='account.account.template'>
             <field name='name'>Ganancia por enajenación de partes sociales</field>
             <field name='code'>704.20</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_704')])]"/>
         </record>
         <record id='cuenta704_21' model='account.account.template'>
             <field name='name'>Ingresos por estímulos fiscales</field>
             <field name='code'>704.21</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_704')])]"/>
         </record>
         <record id='cuenta704_22' model='account.account.template'>
             <field name='name'>Ingresos por condonación de adeudo</field>
             <field name='code'>704.22</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_704')])]"/>
         </record>
         <record id='cuenta704_23' model='account.account.template'>
             <field name='name'>Otros productos</field>
             <field name='code'>704.23</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta800' model='account.account.template'>
-            <field name='name'>Cuentas de orden</field>
-            <field name='code'>800</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta801' model='account.account.template'>
-            <field name='name'>UFIN del ejercicio</field>
-            <field name='code'>801</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_704')])]"/>
         </record>
         <record id='cuenta801_01' model='account.account.template'>
             <field name='name'>UFIN</field>
             <field name='code'>801.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_801')])]"/>
         </record>
         <record id='cuenta801_02' model='account.account.template'>
             <field name='name'>Contra cuenta UFIN</field>
             <field name='code'>801.02</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta802' model='account.account.template'>
-            <field name='name'>CUFIN del ejercicio</field>
-            <field name='code'>802</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_801')])]"/>
         </record>
         <record id='cuenta802_01' model='account.account.template'>
             <field name='name'>CUFIN</field>
             <field name='code'>802.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_802')])]"/>
         </record>
         <record id='cuenta802_02' model='account.account.template'>
             <field name='name'>Contra cuenta CUFIN</field>
             <field name='code'>802.02</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta803' model='account.account.template'>
-            <field name='name'>CUFIN de ejercicios anteriores</field>
-            <field name='code'>803</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_802')])]"/>
         </record>
         <record id='cuenta803_01' model='account.account.template'>
             <field name='name'>CUFIN de ejercicios anteriores</field>
             <field name='code'>803.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_803')])]"/>
         </record>
         <record id='cuenta803_02' model='account.account.template'>
             <field name='name'>Contra cuenta CUFIN de ejercicios anteriores</field>
             <field name='code'>803.02</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta804' model='account.account.template'>
-            <field name='name'>CUFINRE del ejercicio</field>
-            <field name='code'>804</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_803')])]"/>
         </record>
         <record id='cuenta804_01' model='account.account.template'>
             <field name='name'>CUFINRE</field>
             <field name='code'>804.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_804')])]"/>
         </record>
         <record id='cuenta804_02' model='account.account.template'>
             <field name='name'>Contra cuenta CUFINRE</field>
             <field name='code'>804.02</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta805' model='account.account.template'>
-            <field name='name'>CUFINRE de ejercicios anteriores</field>
-            <field name='code'>805</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_804')])]"/>
         </record>
         <record id='cuenta805_01' model='account.account.template'>
             <field name='name'>CUFINRE de ejercicios anteriores</field>
             <field name='code'>805.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_805')])]"/>
         </record>
         <record id='cuenta805_02' model='account.account.template'>
             <field name='name'>Contra cuenta CUFINRE de ejercicios anteriores</field>
             <field name='code'>805.02</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta806' model='account.account.template'>
-            <field name='name'>CUCA del ejercicio</field>
-            <field name='code'>806</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_805')])]"/>
         </record>
         <record id='cuenta806_01' model='account.account.template'>
             <field name='name'>CUCA</field>
             <field name='code'>806.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_806')])]"/>
         </record>
         <record id='cuenta806_02' model='account.account.template'>
             <field name='name'>Contra cuenta CUCA</field>
             <field name='code'>806.02</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta807' model='account.account.template'>
-            <field name='name'>CUCA de ejercicios anteriores</field>
-            <field name='code'>807</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_806')])]"/>
         </record>
         <record id='cuenta807_01' model='account.account.template'>
             <field name='name'>CUCA de ejercicios anteriores</field>
             <field name='code'>807.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_807')])]"/>
         </record>
         <record id='cuenta807_02' model='account.account.template'>
             <field name='name'>Contra cuenta CUCA de ejercicios anteriores</field>
             <field name='code'>807.02</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta808' model='account.account.template'>
-            <field name='name'>Ajuste anual por inflación acumulable</field>
-            <field name='code'>808</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_807')])]"/>
         </record>
         <record id='cuenta808_01' model='account.account.template'>
             <field name='name'>Ajuste anual por inflación acumulable</field>
             <field name='code'>808.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_808')])]"/>
         </record>
         <record id='cuenta808_02' model='account.account.template'>
             <field name='name'>Acumulación del ajuste anual inflacionario</field>
             <field name='code'>808.02</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta809' model='account.account.template'>
-            <field name='name'>Ajuste anual por inflación deducible</field>
-            <field name='code'>809</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_808')])]"/>
         </record>
         <record id='cuenta809_01' model='account.account.template'>
             <field name='name'>Ajuste anual por inflación deducible</field>
             <field name='code'>809.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_809')])]"/>
         </record>
         <record id='cuenta809_02' model='account.account.template'>
             <field name='name'>Deducción del ajuste anual inflacionario</field>
             <field name='code'>809.02</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta810' model='account.account.template'>
-            <field name='name'>Deducción de inversión</field>
-            <field name='code'>810</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_809')])]"/>
         </record>
         <record id='cuenta810_01' model='account.account.template'>
             <field name='name'>Deducción de inversión</field>
             <field name='code'>810.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_810')])]"/>
         </record>
         <record id='cuenta810_02' model='account.account.template'>
             <field name='name'>Contra cuenta deducción de inversiones</field>
             <field name='code'>810.02</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta811' model='account.account.template'>
-            <field name='name'>Utilidad o pérdida fiscal en venta y/o baja de activo fijo</field>
-            <field name='code'>811</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_810')])]"/>
         </record>
         <record id='cuenta811_01' model='account.account.template'>
             <field name='name'>Utilidad o pérdida fiscal en venta y/o baja de activo fijo</field>
             <field name='code'>811.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_811')])]"/>
         </record>
         <record id='cuenta811_02' model='account.account.template'>
             <field name='name'>Contra cuenta utilidad o pérdida fiscal en venta y/o baja de activo fijo</field>
             <field name='code'>811.02</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta812' model='account.account.template'>
-            <field name='name'>Utilidad o pérdida fiscal en venta acciones o partes sociales</field>
-            <field name='code'>812</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_811')])]"/>
         </record>
         <record id='cuenta812_01' model='account.account.template'>
             <field name='name'>Utilidad o pérdida fiscal en venta acciones o partes sociales</field>
             <field name='code'>812.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_812')])]"/>
         </record>
         <record id='cuenta812_02' model='account.account.template'>
             <field name='name'>Contra cuenta utilidad o pérdida fiscal en venta acciones o partes sociales</field>
             <field name='code'>812.02</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta813' model='account.account.template'>
-            <field name='name'>Pérdidas fiscales pendientes de amortizar actualizadas de ejercicios anteriores</field>
-            <field name='code'>813</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_812')])]"/>
         </record>
         <record id='cuenta813_01' model='account.account.template'>
             <field name='name'>Pérdidas fiscales pendientes de amortizar actualizadas de ejercicios anteriores</field>
             <field name='code'>813.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_813')])]"/>
         </record>
         <record id='cuenta813_02' model='account.account.template'>
             <field name='name'>Actualización de pérdidas fiscales pendientes de amortizar de ejercicios anteriores</field>
             <field name='code'>813.02</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta814' model='account.account.template'>
-            <field name='name'>Mercancías recibidas en consignación</field>
-            <field name='code'>814</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_813')])]"/>
         </record>
         <record id='cuenta814_01' model='account.account.template'>
             <field name='name'>Mercancías recibidas en consignación</field>
             <field name='code'>814.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_814')])]"/>
         </record>
         <record id='cuenta814_02' model='account.account.template'>
             <field name='name'>Consignación de mercancías recibidas</field>
             <field name='code'>814.02</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta815' model='account.account.template'>
-            <field name='name'>Crédito fiscal de IVA e IEPS por la importación de mercancías para empresas certificadas</field>
-            <field name='code'>815</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_814')])]"/>
         </record>
         <record id='cuenta815_01' model='account.account.template'>
             <field name='name'>Crédito fiscal de IVA e IEPS por la importación de mercancías</field>
             <field name='code'>815.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_815')])]"/>
         </record>
         <record id='cuenta815_02' model='account.account.template'>
             <field name='name'>Importación de mercancías con aplicación de crédito fiscal de IVA e IEPS</field>
             <field name='code'>815.02</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta816' model='account.account.template'>
-            <field name='name'>Crédito fiscal de IVA e IEPS por la importación de activos fijos para empresas certificadas</field>
-            <field name='code'>816</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_815')])]"/>
         </record>
         <record id='cuenta816_01' model='account.account.template'>
             <field name='name'>Crédito fiscal de IVA e IEPS por la importación de activo fijo</field>
             <field name='code'>816.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_816')])]"/>
         </record>
         <record id='cuenta816_02' model='account.account.template'>
             <field name='name'>Importación de activo fijo con aplicación de crédito fiscal de IVA e IEPS</field>
             <field name='code'>816.02</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
-        </record>
-        <record id='cuenta899' model='account.account.template'>
-            <field name='name'>Otras cuentas de orden</field>
-            <field name='code'>899</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_816')])]"/>
         </record>
         <record id='cuenta899_01' model='account.account.template'>
             <field name='name'>Otras cuentas de orden</field>
             <field name='code'>899.01</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_899')])]"/>
         </record>
         <record id='cuenta899_02' model='account.account.template'>
             <field name='name'>Contra cuenta otras cuentas de orden</field>
             <field name='code'>899.02</field>
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_899')])]"/>
         </record>
 
         <record id="vauxoo_mx_chart_template" model="account.chart.template">
-            <field name="property_account_receivable_id" ref="cuenta899_02"/>
+            <field name="property_account_receivable_id" ref="cuenta105_01"/>
             <field name="property_account_payable_id" ref="cuenta201_01"/>
             <field name="property_account_expense_categ_id" ref="cuenta501_01"/>
             <field name="property_account_income_categ_id" ref="cuenta401_01"/>

--- a/addons/l10n_mx/data/account_tag.xml
+++ b/addons/l10n_mx/data/account_tag.xml
@@ -1,0 +1,762 @@
+<?xml version="1.0" ?>
+<openerp>
+    <data noupdate="1">
+
+        <record id='account_tag_0' model='account.account.tag'>
+            <field name='name'>Catálogo de cuentas electrónicas MX</field>
+            <field name='color'>1</field>
+            <field name='applicability'>accounts</field>
+        </record>
+        <record id='account_tag_100' model='account.account.tag'>
+            <field name='name'>100 Activo</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_100_01' model='account.account.tag'>
+            <field name='name'>100.1 Activo a corto plazo</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_101' model='account.account.tag'>
+            <field name='name'>101 Caja</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_102' model='account.account.tag'>
+            <field name='name'>102 Bancos</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_103' model='account.account.tag'>
+            <field name='name'>103 Inversiones</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_104' model='account.account.tag'>
+            <field name='name'>104 Otros instrumentos financieros</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_105' model='account.account.tag'>
+            <field name='name'>105 Clientes</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_106' model='account.account.tag'>
+            <field name='name'>106 Cuentas y documentos por cobrar a corto plazo</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_107' model='account.account.tag'>
+            <field name='name'>107 Deudores diversos</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_108' model='account.account.tag'>
+            <field name='name'>108 Estimación de cuentas incobrables</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_109' model='account.account.tag'>
+            <field name='name'>109 Pagos anticipados</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_110' model='account.account.tag'>
+            <field name='name'>110 Subsidio al empleo por aplicar</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_111' model='account.account.tag'>
+            <field name='name'>111 Crédito al diesel por acreditar</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_112' model='account.account.tag'>
+            <field name='name'>112 Otros estímulos</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_113' model='account.account.tag'>
+            <field name='name'>113 Impuestos a favor</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_114' model='account.account.tag'>
+            <field name='name'>114 Pagos provisionales</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_115' model='account.account.tag'>
+            <field name='name'>115 Inventario</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_116' model='account.account.tag'>
+            <field name='name'>116 Estimación de inventarios obsoletos y de lento movimiento</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_117' model='account.account.tag'>
+            <field name='name'>117 Obras en proceso de inmuebles</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_118' model='account.account.tag'>
+            <field name='name'>118 Impuestos acreditables pagados</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_119' model='account.account.tag'>
+            <field name='name'>119 Impuestos acreditables por pagar</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_120' model='account.account.tag'>
+            <field name='name'>120 Anticipo a proveedores</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_121' model='account.account.tag'>
+            <field name='name'>121 Otros activos a corto plazo</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_100_02' model='account.account.tag'>
+            <field name='name'>100.02 Activo a largo plazo</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_151' model='account.account.tag'>
+            <field name='name'>151 Terrenos</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_152' model='account.account.tag'>
+            <field name='name'>152 Edificios</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_153' model='account.account.tag'>
+            <field name='name'>153 Maquinaria y equipo</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_154' model='account.account.tag'>
+            <field name='name'>154 Automóviles, autobuses, camiones de carga, tractocamiones, montacargas y remolques</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_155' model='account.account.tag'>
+            <field name='name'>155 Mobiliario y equipo de oficina</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_156' model='account.account.tag'>
+            <field name='name'>156 Equipo de cómputo</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_157' model='account.account.tag'>
+            <field name='name'>157 Equipo de comunicación</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_158' model='account.account.tag'>
+            <field name='name'>158 Activos biológicos, vegetales y semovientes</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_159' model='account.account.tag'>
+            <field name='name'>159 Obras en proceso de activos fijos</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_160' model='account.account.tag'>
+            <field name='name'>160 Otros activos fijos</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_161' model='account.account.tag'>
+            <field name='name'>161 Ferrocarriles</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_162' model='account.account.tag'>
+            <field name='name'>162 Embarcaciones</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_163' model='account.account.tag'>
+            <field name='name'>163 Aviones</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_164' model='account.account.tag'>
+            <field name='name'>164 Troqueles, moldes, matrices y herramental</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_165' model='account.account.tag'>
+            <field name='name'>165 Equipo de comunicaciones telefónicas</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_166' model='account.account.tag'>
+            <field name='name'>166 Equipo de comunicación satelital</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_167' model='account.account.tag'>
+            <field name='name'>167 Equipo de adaptaciones para personas con capacidades diferentes</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_168' model='account.account.tag'>
+            <field name='name'>168 Maquinaria y equipo de generación de energía de fuentes renovables o de sistemas de cogeneración de electricidad eficiente</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_169' model='account.account.tag'>
+            <field name='name'>169 Otra maquinaria y equipo</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_170' model='account.account.tag'>
+            <field name='name'>170 Adaptaciones y mejoras</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_171' model='account.account.tag'>
+            <field name='name'>171 Depreciación acumulada de activos fijos</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_172' model='account.account.tag'>
+            <field name='name'>172 Pérdida por deterioro acumulado de activos fijos</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_173' model='account.account.tag'>
+            <field name='name'>173 Gastos diferidos</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_174' model='account.account.tag'>
+            <field name='name'>174 Gastos pre operativos</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_175' model='account.account.tag'>
+            <field name='name'>175 Regalías, asistencia técnica y otros gastos diferidos</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_176' model='account.account.tag'>
+            <field name='name'>176 Activos intangibles</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_177' model='account.account.tag'>
+            <field name='name'>177 Gastos de organización</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_178' model='account.account.tag'>
+            <field name='name'>178 Investigación y desarrollo de mercado</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_179' model='account.account.tag'>
+            <field name='name'>179 Marcas y patentes</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_180' model='account.account.tag'>
+            <field name='name'>180 Crédito mercantil</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_181' model='account.account.tag'>
+            <field name='name'>181 Gastos de instalación</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_182' model='account.account.tag'>
+            <field name='name'>182 Otros activos diferidos</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_183' model='account.account.tag'>
+            <field name='name'>183 Amortización acumulada de activos diferidos</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_184' model='account.account.tag'>
+            <field name='name'>184 Depósitos en garantía</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_185' model='account.account.tag'>
+            <field name='name'>185 Impuestos diferidos</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_186' model='account.account.tag'>
+            <field name='name'>186 Cuentas y documentos por cobrar a largo plazo</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_187' model='account.account.tag'>
+            <field name='name'>187 Participación de los trabajadores en las utilidades diferidas</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_188' model='account.account.tag'>
+            <field name='name'>188 Inversiones permanentes en acciones</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_189' model='account.account.tag'>
+            <field name='name'>189 Estimación por deterioro de inversiones permanentes en acciones</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_190' model='account.account.tag'>
+            <field name='name'>190 Otros instrumentos financieros</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_191' model='account.account.tag'>
+            <field name='name'>191 Otros activos a largo plazo</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_200' model='account.account.tag'>
+            <field name='name'>200 Pasivo</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_200_01' model='account.account.tag'>
+            <field name='name'>200.01 Pasivo a corto plazo</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_201' model='account.account.tag'>
+            <field name='name'>201 Proveedores</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_202' model='account.account.tag'>
+            <field name='name'>202 Cuentas por pagar a corto plazo</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_203' model='account.account.tag'>
+            <field name='name'>203 Cobros anticipados a corto plazo</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_204' model='account.account.tag'>
+            <field name='name'>204 Instrumentos financieros a corto plazo</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_205' model='account.account.tag'>
+            <field name='name'>205 Acreedores diversos a corto plazo</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_206' model='account.account.tag'>
+            <field name='name'>206 Anticipo de cliente</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_207' model='account.account.tag'>
+            <field name='name'>207 Impuestos trasladados</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_208' model='account.account.tag'>
+            <field name='name'>208 Impuestos trasladados cobrados</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_209' model='account.account.tag'>
+            <field name='name'>209 Impuestos trasladados no cobrados</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_210' model='account.account.tag'>
+            <field name='name'>210 Provisión de sueldos y salarios por pagar</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_211' model='account.account.tag'>
+            <field name='name'>211 Provisión de contribuciones de seguridad social por pagar</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_212' model='account.account.tag'>
+            <field name='name'>212 Provisión de impuesto estatal sobre nómina por pagar</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_213' model='account.account.tag'>
+            <field name='name'>213 Impuestos y derechos por pagar</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_214' model='account.account.tag'>
+            <field name='name'>214 Dividendos por pagar</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_215' model='account.account.tag'>
+            <field name='name'>215 PTU por pagar</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_216' model='account.account.tag'>
+            <field name='name'>216 Impuestos retenidos</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_217' model='account.account.tag'>
+            <field name='name'>217 Pagos realizados por cuenta de terceros</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_218' model='account.account.tag'>
+            <field name='name'>218 Otros pasivos a corto plazo</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_200_02' model='account.account.tag'>
+            <field name='name'>200.02 Pasivo a largo plazo</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_251' model='account.account.tag'>
+            <field name='name'>251 Acreedores diversos a largo plazo</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_252' model='account.account.tag'>
+            <field name='name'>252 Cuentas por pagar a largo plazo</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_253' model='account.account.tag'>
+            <field name='name'>253 Cobros anticipados a largo plazo</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_254' model='account.account.tag'>
+            <field name='name'>254 Instrumentos financieros a largo plazo</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_255' model='account.account.tag'>
+            <field name='name'>255 Pasivos por beneficios a los empleados a largo plazo</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_256' model='account.account.tag'>
+            <field name='name'>256 Otros pasivos a largo plazo</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_257' model='account.account.tag'>
+            <field name='name'>257 Participación de los trabajadores en las utilidades diferida</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_258' model='account.account.tag'>
+            <field name='name'>258 Obligaciones contraídas de fideicomisos</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_259' model='account.account.tag'>
+            <field name='name'>259 Impuestos diferidos</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_260' model='account.account.tag'>
+            <field name='name'>260 Pasivos diferidos</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_300' model='account.account.tag'>
+            <field name='name'>300 Capital contable</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_301' model='account.account.tag'>
+            <field name='name'>301 Capital social</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_302' model='account.account.tag'>
+            <field name='name'>302 Patrimonio</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_303' model='account.account.tag'>
+            <field name='name'>303 Reserva legal</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_304' model='account.account.tag'>
+            <field name='name'>304 Resultado de ejercicios anteriores</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_305' model='account.account.tag'>
+            <field name='name'>305 Resultado del ejercicio</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_306' model='account.account.tag'>
+            <field name='name'>306 Otras cuentas de capital</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_400' model='account.account.tag'>
+            <field name='name'>400 Ingresos</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_401' model='account.account.tag'>
+            <field name='name'>401 Ingresos</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_402' model='account.account.tag'>
+            <field name='name'>402 Devoluciones, descuentos o bonificaciones sobre ingresos</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_403' model='account.account.tag'>
+            <field name='name'>403 Otros ingresos</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_500' model='account.account.tag'>
+            <field name='name'>500 Costos</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_501' model='account.account.tag'>
+            <field name='name'>501 Costo de venta y/o servicio</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_502' model='account.account.tag'>
+            <field name='name'>502 Compras</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_503' model='account.account.tag'>
+            <field name='name'>503 Devoluciones, descuentos o bonificaciones sobre compras</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_504' model='account.account.tag'>
+            <field name='name'>504 Otras cuentas de costos</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_505' model='account.account.tag'>
+            <field name='name'>505 Costo de activo fijo</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_600' model='account.account.tag'>
+            <field name='name'>600 Gastos</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_601' model='account.account.tag'>
+            <field name='name'>601 Gastos generales</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_602' model='account.account.tag'>
+            <field name='name'>602 Gastos de venta</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_603' model='account.account.tag'>
+            <field name='name'>603 Gastos de administración</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_604' model='account.account.tag'>
+            <field name='name'>604 Gastos de fabricación</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_605' model='account.account.tag'>
+            <field name='name'>605 Mano de obra directa</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_606' model='account.account.tag'>
+            <field name='name'>606 Facilidades administrativas fiscales</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_607' model='account.account.tag'>
+            <field name='name'>607 Participación de los trabajadores en las utilidades</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_608' model='account.account.tag'>
+            <field name='name'>608 Participación en resultados de subsidiarias</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_609' model='account.account.tag'>
+            <field name='name'>609 Participación en resultados de asociadas</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_610' model='account.account.tag'>
+            <field name='name'>610 Participación de los trabajadores en las utilidades diferida</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_611' model='account.account.tag'>
+            <field name='name'>611 Impuesto Sobre la renta</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_612' model='account.account.tag'>
+            <field name='name'>612 Gastos no deducibles para CUFIN</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_613' model='account.account.tag'>
+            <field name='name'>613 Depreciación contable</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_614' model='account.account.tag'>
+            <field name='name'>614 Amortización contable</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_700' model='account.account.tag'>
+            <field name='name'>700 Resultado integral de financiamiento</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_701' model='account.account.tag'>
+            <field name='name'>701 Gastos financieros</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_702' model='account.account.tag'>
+            <field name='name'>702 Productos financieros</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_703' model='account.account.tag'>
+            <field name='name'>703 Otros gastos</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_704' model='account.account.tag'>
+            <field name='name'>704 Otros productos</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_800' model='account.account.tag'>
+            <field name='name'>800 Cuentas de orden</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_801' model='account.account.tag'>
+            <field name='name'>801 UFIN del ejercicio</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_802' model='account.account.tag'>
+            <field name='name'>802 CUFIN del ejercicio</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_803' model='account.account.tag'>
+            <field name='name'>803 CUFIN de ejercicios anteriores</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_804' model='account.account.tag'>
+            <field name='name'>804 CUFINRE del ejercicio</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_805' model='account.account.tag'>
+            <field name='name'>805 CUFINRE de ejercicios anteriores</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_806' model='account.account.tag'>
+            <field name='name'>806 CUCA del ejercicio</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_807' model='account.account.tag'>
+            <field name='name'>807 CUCA de ejercicios anteriores</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_808' model='account.account.tag'>
+            <field name='name'>808 Ajuste anual por inflación acumulable</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_809' model='account.account.tag'>
+            <field name='name'>809 Ajuste anual por inflación deducible</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_810' model='account.account.tag'>
+            <field name='name'>810 Deducción de inversión</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_811' model='account.account.tag'>
+            <field name='name'>811 Utilidad o pérdida fiscal en venta y/o baja de activo fijo</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_812' model='account.account.tag'>
+            <field name='name'>812 Utilidad o pérdida fiscal en venta acciones o partes sociales</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_813' model='account.account.tag'>
+            <field name='name'>813 Pérdidas fiscales pendientes de amortizar actualizadas de ejercicios anteriores</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_814' model='account.account.tag'>
+            <field name='name'>814 Mercancías recibidas en consignación</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_815' model='account.account.tag'>
+            <field name='name'>815 Crédito fiscal de IVA e IEPS por la importación de mercancías para empresas certificadas</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_816' model='account.account.tag'>
+            <field name='name'>816 Crédito fiscal de IVA e IEPS por la importación de activos fijos para empresas certificadas</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+        <record id='account_tag_899' model='account.account.tag'>
+            <field name='name'>899 Otras cuentas de orden</field>
+            <field name='applicability'>accounts</field>
+            <field name='color'>1</field>
+        </record>
+
+    </data>
+</openerp>

--- a/addons/l10n_mx/data/account_tax.xml
+++ b/addons/l10n_mx/data/account_tax.xml
@@ -166,8 +166,8 @@
         <field name="amount">0</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
-        <field name="account_id" ref="cuenta118"/>
-        <field name="refund_account_id" ref="cuenta118"/>
+        <field name="account_id" ref="cuenta118_01"/>
+        <field name="refund_account_id" ref="cuenta118_01"/>
         <field name="tag_ids" eval="[(6,0,[ref('tax_tag_10')])]"/>
     </record>
 
@@ -178,8 +178,8 @@
         <field name="amount">11</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
-        <field name="account_id" ref="cuenta118"/>
-        <field name="refund_account_id" ref="cuenta118"/>
+        <field name="account_id" ref="cuenta118_01"/>
+        <field name="refund_account_id" ref="cuenta118_01"/>
         <field name="tag_ids" eval="[(6,0,[ref('tax_tag_11')])]"/>
     </record>
 
@@ -190,8 +190,8 @@
         <field name="amount">16</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
-        <field name="account_id" ref="cuenta118"/>
-        <field name="refund_account_id" ref="cuenta118"/>
+        <field name="account_id" ref="cuenta118_01"/>
+        <field name="refund_account_id" ref="cuenta118_01"/>
         <field name="tag_ids" eval="[(6,0,[ref('tax_tag_12')])]"/>
     </record>
   </data>


### PR DESCRIPTION
Assigned the account tags with data data in the Mexican chart template.

Created the account tag data based in this [document](http://www.sat.gob.mx/fichas_tematicas/buzon_tributario/Documents/codigo_agrupador.pdf), where each account parent is a new tag in this data.

The name is the concatenation of tag.code + tag.name, because the account.tag model have not the code field.

The green color is assigned to this tags.

Fix account in tax data.