### PR TITLE
[IMP] stock_account: backport to master version to allow get average

### DIFF
--- a/addons/stock_account/stock_account.py
+++ b/addons/stock_account/stock_account.py
@@ -226,7 +226,7 @@ class stock_quant(osv.osv):
             valuation_amount = context.get('force_valuation_amount')
         else:
             if move.product_id.cost_method == 'average':
-                valuation_amount = cost if move.location_id.usage != 'internal' and move.location_dest_id.usage == 'internal' else move.product_id.standard_price
+                valuation_amount = cost if move.location_id.usage == 'supplier' and move.location_dest_id.usage == 'internal' else move.product_id.standard_price
             else:
                 valuation_amount = cost if move.product_id.cost_method == 'real' else move.product_id.standard_price
         #the standard_price of the product may be in another decimal precision, or not compatible with the coinage of


### PR DESCRIPTION
price product when transfer is from 'transit' to 'internal' locations in
moves to inter warehouse

[backport master](https://github.com/odoo/odoo/blob/master/addons/stock_account/models/stock.py#L281)

[Related video in master](https://drive.google.com/file/d/0B1w9gokcJL9hRExtN3lsLWVBbWM/view)
[Related video in current version](https://drive.google.com/file/d/0B1w9gokcJL9hX3JhRTlQUnVXQ0E/view)