### PR TITLE
[IMP] tools: support known "falsy" string values for XML boolean fields

### DIFF
--- a/openerp/tools/convert.py
+++ b/openerp/tools/convert.py
@@ -235,6 +235,10 @@ escape_re = re.compile(r'(?<!\\)/')
 def escape(x):
     return x.replace('\\/', '/')
 
+def str2bool(value):
+    return value.lower() not in ('0', 'false', 'off')
+
+
 class xml_import(object):
     @staticmethod
     def nodeattr2bool(node, attr, default=False):
@@ -243,7 +247,7 @@ class xml_import(object):
         val = node.get(attr).strip()
         if not val:
             return default
-        return val.lower() not in ('0', 'false', 'off')
+        return str2bool(val)
 
     def isnoupdate(self, data_node=None):
         return self.noupdate or (len(data_node) and self.nodeattr2bool(data_node, 'noupdate', False))
@@ -757,6 +761,8 @@ form: module.record_id""" % (xml_id,)
                 if f_name in model._fields:
                     if model._fields[f_name].type == 'integer':
                         f_val = int(f_val)
+                    elif model._fields[f_name].type == 'boolean' and isinstance(f_val, basestring):
+                        f_val = str2bool(f_val)
             res[f_name] = f_val
 
         id = self.pool['ir.model.data']._update(cr, self.uid, rec_model, self.module, res, rec_id or False, not self.isnoupdate(data_node), noupdate=self.isnoupdate(data_node), mode=self.mode, context=rec_context )


### PR DESCRIPTION
Historically, developers had to use the `eval` attribute to set
a False value for boolean fields in XML data files:

    <field name="active" eval="False"/>

This is a source of errors for beginners, who tend to provide
a string value directly, as for char/text fields.
Unfortunately string values always evaluated to `True` booleans:

    <field name="active">False</field> <!-- active == true! -->

This patch adds detection of some well-known falsy strings
(case-insensitive): `0`, `false`, `off`, as similarly supported
for the `noupdate` and `forcecreate` attributes of XML data records.

Closes #13152


**PR dummies:**
- [x] yoytec: https://github.com/Vauxoo/yoytec/pull/1970
- [x] lodigroup: https://github.com/Vauxoo/lodigroup/pull/606
- [x] instance: https://github.com/Vauxoo/instance/pull/309
- [x] wohlert: https://github.com/Vauxoo/wohlert/pull/72