### PR TITLE
[IMP] l10n_mx: Added settings to allow apply by default the VAT

### DIFF
--- a/addons/l10n_mx/__openerp__.py
+++ b/addons/l10n_mx/__openerp__.py
@@ -30,9 +30,11 @@ With this module you will have:
 
 .. SAT: http://www.sat.gob.mx/
     """,
-    "depends": ["account", "base_vat"],
+    "depends": ["account", "base_vat", "account_tax_cash_basis"],
     "demo_xml": [],
     "data": [
+        "data/account_journal.xml",
+        "data/res_company.xml",
         "data/account_tag.xml",
         "data/account_chart.xml",
         "data/account_tax.xml",

--- a/addons/l10n_mx/data/account_chart.xml
+++ b/addons/l10n_mx/data/account_chart.xml
@@ -42,12 +42,6 @@ Cuentas del plan
 <!--
     Cuenta Template
 -->
-        <record id='cuenta100_01' model='account.account.template'>
-            <field name='name'>Activo a corto plazo</field>
-            <field name='code'>100.01</field>
-            <field name="user_type_id" ref="account_type_other"/>
-            <field name="tag_ids" eval="[(6,0,[ref('account_tag_100')])]"/>
-        </record>
         <record id='cuenta101_01' model='account.account.template'>
             <field name='name'>Caja y efectivo</field>
             <field name='code'>101.01</field>
@@ -1384,13 +1378,6 @@ Cuentas del plan
             <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
             <field name="user_type_id" ref="account_type_other"/>
             <field name="tag_ids" eval="[(6,0,[ref('account_tag_190')])]"/>
-        </record>
-        <record id='cuenta200_01' model='account.account.template'>
-            <field name='name'>Pasivo a corto plazo</field>
-            <field name='code'>200.01</field>
-            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-            <field name="user_type_id" ref="account_type_other"/>
-            <field name="tag_ids" eval="[(6,0,[ref('account_tag_200')])]"/>
         </record>
         <record id='cuenta201_01' model='account.account.template'>
             <field name='name'>Proveedores nacionales</field>

--- a/addons/l10n_mx/data/account_journal.xml
+++ b/addons/l10n_mx/data/account_journal.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" ?>
+<openerp>
+    <data noupdate="1">
+
+        <record id="journal_effectively_paid" model="account.journal">
+            <field name="company_id" ref="base.main_company"/>
+            <field name="name">Effectively Paid</field>
+            <field name="code">EP</field>
+            <field name="type">general</field>
+            <field name="show_on_dashboard" eval="True"/>
+        </record>
+
+    </data>
+</openerp>

--- a/addons/l10n_mx/data/account_tag.xml
+++ b/addons/l10n_mx/data/account_tag.xml
@@ -13,7 +13,7 @@
             <field name='color'>1</field>
         </record>
         <record id='account_tag_100_01' model='account.account.tag'>
-            <field name='name'>100.1 Activo a corto plazo</field>
+            <field name='name'>100.01 Activo a corto plazo</field>
             <field name='color'>1</field>
         </record>
         <record id='account_tag_101' model='account.account.tag'>

--- a/addons/l10n_mx/data/account_tax.xml
+++ b/addons/l10n_mx/data/account_tax.xml
@@ -6,10 +6,6 @@
         <field name="name">IVA(0%) VENTAS</field>
         <field name="applicability">taxes</field>
     </record>
-    <record id="tax_tag_02" model="account.account.tag">
-        <field name="name">IVA(11%) VENTAS</field>
-        <field name="applicability">taxes</field>
-    </record>
     <record id="tax_tag_03" model="account.account.tag">
         <field name="name">IVA(16%) VENTAS</field>
         <field name="applicability">taxes</field>
@@ -42,10 +38,6 @@
         <field name="name">IVA(0%) COMPRAS</field>
         <field name="applicability">taxes</field>
     </record>
-    <record id="tax_tag_11" model="account.account.tag">
-        <field name="name">IVA(11%) COMPRAS</field>
-        <field name="applicability">taxes</field>
-    </record>
     <record id="tax_tag_12" model="account.account.tag">
         <field name="name">IVA(16%) COMPRAS</field>
         <field name="applicability">taxes</field>
@@ -58,21 +50,11 @@
         <field name="amount">0</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">sale</field>
-        <field name="account_id" ref="cuenta208_01"/>
-        <field name="refund_account_id" ref="cuenta208_01"/>
+        <field name="account_id" ref="cuenta209_01"/>
+        <field name="refund_account_id" ref="cuenta209_01"/>
         <field name="tag_ids" eval="[(6,0,[ref('tax_tag_01')])]"/>
-    </record>
-
-    <record id="tax11" model="account.tax.template">
-        <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-        <field name="name">IVA(11%) VENTAS</field>
-        <field name="description">ITAX_110-IN</field>
-        <field name="amount">11</field>
-        <field name="amount_type">percent</field>
-        <field name="type_tax_use">sale</field>
-        <field name="account_id" ref="cuenta208_01"/>
-        <field name="refund_account_id" ref="cuenta208_01"/>
-        <field name="tag_ids" eval="[(6,0,[ref('tax_tag_02')])]"/>
+        <field name="use_cash_basis" eval="True"/>
+        <field name="cash_basis_account" ref="cuenta208_01"/>
     </record>
 
     <record id="tax12" model="account.tax.template">
@@ -82,9 +64,11 @@
         <field name="amount">16</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">sale</field>
-        <field name="account_id" ref="cuenta208_01"/>
-        <field name="refund_account_id" ref="cuenta208_01"/>
+        <field name="account_id" ref="cuenta209_01"/>
+        <field name="refund_account_id" ref="cuenta209_01"/>
         <field name="tag_ids" eval="[(6,0,[ref('tax_tag_03')])]"/>
+        <field name="use_cash_basis" eval="True"/>
+        <field name="cash_basis_account" ref="cuenta208_01"/>
     </record>
 
     <record id="tax1" model="account.tax.template">
@@ -94,9 +78,11 @@
         <field name="amount">-4</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
-        <field name="account_id" ref="cuenta216_12"/>
-        <field name="refund_account_id" ref="cuenta216_12"/>
+        <field name="account_id" ref="cuenta216_10"/>
+        <field name="refund_account_id" ref="cuenta216_10"/>
         <field name="tag_ids" eval="[(6,0,[ref('tax_tag_04')])]"/>
+        <field name="use_cash_basis" eval="True"/>
+        <field name="cash_basis_account" ref="cuenta216_10"/>
     </record>
 
     <record id="tax2" model="account.tax.template">
@@ -109,6 +95,8 @@
         <field name="account_id" ref="cuenta216_10"/>
         <field name="refund_account_id" ref="cuenta216_10"/>
         <field name="tag_ids" eval="[(6,0,[ref('tax_tag_05')])]"/>
+        <field name="use_cash_basis" eval="True"/>
+        <field name="cash_basis_account" ref="cuenta216_10"/>
     </record>
 
     <record id="tax3" model="account.tax.template">
@@ -121,6 +109,8 @@
         <field name="account_id" ref="cuenta216_03"/>
         <field name="refund_account_id" ref="cuenta216_03"/>
         <field name="tag_ids" eval="[(6,0,[ref('tax_tag_06')])]"/>
+        <field name="use_cash_basis" eval="True"/>
+        <field name="cash_basis_account" ref="cuenta216_03"/>
     </record>
 
     <record id="tax5" model="account.tax.template">
@@ -133,6 +123,8 @@
         <field name="account_id" ref="cuenta216_04"/>
         <field name="refund_account_id" ref="cuenta216_04"/>
         <field name="tag_ids" eval="[(6,0,[ref('tax_tag_07')])]"/>
+        <field name="use_cash_basis" eval="True"/>
+        <field name="cash_basis_account" ref="cuenta216_04"/>
     </record>
 
     <record id="tax7" model="account.tax.template">
@@ -142,9 +134,11 @@
         <field name="amount">-10.67</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
-        <field name="account_id" ref="cuenta216_03"/>
-        <field name="refund_account_id" ref="cuenta216_03"/>
+        <field name="account_id" ref="cuenta216_10"/>
+        <field name="refund_account_id" ref="cuenta216_10"/>
         <field name="tag_ids" eval="[(6,0,[ref('tax_tag_08')])]"/>
+        <field name="use_cash_basis" eval="True"/>
+        <field name="cash_basis_account" ref="cuenta216_10"/>
     </record>
 
     <record id="tax8" model="account.tax.template">
@@ -157,6 +151,8 @@
         <field name="account_id" ref="cuenta216_10"/>
         <field name="refund_account_id" ref="cuenta216_10"/>
         <field name="tag_ids" eval="[(6,0,[ref('tax_tag_09')])]"/>
+        <field name="use_cash_basis" eval="True"/>
+        <field name="cash_basis_account" ref="cuenta216_10"/>
     </record>
 
     <record id="tax13" model="account.tax.template">
@@ -166,21 +162,11 @@
         <field name="amount">0</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
-        <field name="account_id" ref="cuenta118_01"/>
-        <field name="refund_account_id" ref="cuenta118_01"/>
+        <field name="account_id" ref="cuenta119_01"/>
+        <field name="refund_account_id" ref="cuenta119_01"/>
         <field name="tag_ids" eval="[(6,0,[ref('tax_tag_10')])]"/>
-    </record>
-
-    <record id="tax10" model="account.tax.template">
-        <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-        <field name="name">IVA(11%) COMPRAS</field>
-        <field name="description">ITAX_110-OUT</field>
-        <field name="amount">11</field>
-        <field name="amount_type">percent</field>
-        <field name="type_tax_use">purchase</field>
-        <field name="account_id" ref="cuenta118_01"/>
-        <field name="refund_account_id" ref="cuenta118_01"/>
-        <field name="tag_ids" eval="[(6,0,[ref('tax_tag_11')])]"/>
+        <field name="use_cash_basis" eval="True"/>
+        <field name="cash_basis_account" ref="cuenta118_01"/>
     </record>
 
     <record id="tax14" model="account.tax.template">
@@ -190,9 +176,11 @@
         <field name="amount">16</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">purchase</field>
-        <field name="account_id" ref="cuenta118_01"/>
-        <field name="refund_account_id" ref="cuenta118_01"/>
+        <field name="account_id" ref="cuenta119_01"/>
+        <field name="refund_account_id" ref="cuenta119_01"/>
         <field name="tag_ids" eval="[(6,0,[ref('tax_tag_12')])]"/>
+        <field name="use_cash_basis" eval="True"/>
+        <field name="cash_basis_account" ref="cuenta118_01"/>
     </record>
   </data>
 </openerp>

--- a/addons/l10n_mx/data/res_company.xml
+++ b/addons/l10n_mx/data/res_company.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data noupdate="0">
+        <record id="base.main_company" model="res.company">
+            <field name="tax_cash_basis_journal_id" ref="journal_effectively_paid"/>
+        </record>
+    </data>
+</openerp>

--- a/addons/l10n_mx/models/__init__.py
+++ b/addons/l10n_mx/models/__init__.py
@@ -2,4 +2,4 @@
 # Copyright 2016 Vauxoo (https://www.vauxoo.com) <info@vauxoo.com>
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
-from . import models
+from . import chart_template

--- a/addons/l10n_mx/models/chart_template.py
+++ b/addons/l10n_mx/models/chart_template.py
@@ -1,0 +1,91 @@
+# coding: utf-8
+# Copyright 2016 Vauxoo (https://www.vauxoo.com) <info@vauxoo.com>
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+from openerp import models, fields, api
+
+
+class AccountTaxTemplate(models.Model):
+    _inherit = 'account.tax.template'
+
+    use_cash_basis = fields.Boolean(
+        help='Select this if the tax should use cash basis, which will '
+        'create an entry for this tax on a given account during '
+        'reconciliation')
+    cash_basis_account = fields.Many2one(
+        'account.account.template', string='Tax Received Account',
+        ondelete='restrict',
+        help='Account use when creating entry for tax cash basis')
+
+    def _get_tax_vals(self, company):
+        """ This method add in dictionnary of all the values for the tax that
+        will be created if will be assigned the cash basis account.
+        """
+        self.ensure_one()
+        res = super(AccountTaxTemplate, self)._get_tax_vals(company)
+        res.update({
+            'use_cash_basis': self.use_cash_basis,
+        })
+        return res
+
+    @api.multi
+    def _generate_tax(self, company):
+        """ This method update the return that generate taxes from templates.
+            :param company: the company for which the taxes should be created
+                from templates in self
+            :returns: {
+                'tax_template_to_tax': mapping between tax template and the
+                    newly generated taxes corresponding,
+                'account_dict': dictionary containing a to-do list with all
+                    the accounts to assign on new taxes
+            }
+        """
+        res = super(AccountTaxTemplate, self)._generate_tax(company)
+        for tax in self:
+            res.get('account_dict', {}).get(tax.id, {}).update({
+                'cash_basis_account': tax.cash_basis_account.id})
+        return res
+
+
+class AccountChartTemplate(models.Model):
+    _inherit = "account.chart.template"
+
+    @api.multi
+    def _load_template(
+            self, company, code_digits=None, transfer_account_id=None,
+            account_ref=None, taxes_ref=None):
+        """ Generate all the objects from the templates
+            :param company: company the wizard is running for
+            :param code_digits: number of digits the accounts code should have
+                in the COA
+            :param transfer_account_id: reference to the account template
+                that will be used as intermediary account for transfers between
+                2 liquidity accounts
+            :param acc_ref: Mapping between ids of account templates and real
+                accounts created from them
+            :param taxes_ref: Mapping between ids of tax templates and real
+                taxes created from them
+            :returns: tuple with a dictionary containing
+                * the mapping between the account template ids and the ids of
+                    the real accounts that have been generated
+                    from them, as first item,
+                * a similar dictionary for mapping the tax templates and taxes,
+                    as second item,
+            :rtype: tuple(dict, dict, dict)
+            inherited to write the cash_basis_account in the created taxes
+        """
+        self.ensure_one()
+        accounts, taxes = super(AccountChartTemplate, self)._load_template(
+            company, code_digits=code_digits,
+            transfer_account_id=transfer_account_id, account_ref=account_ref,
+            taxes_ref=taxes_ref)
+        if account_ref is None:
+            account_ref = {}
+        account_tax_obj = self.env['account.tax']
+
+        for tax in self.tax_template_ids:
+            account_tax_obj.browse(taxes.get(tax.id)).write({
+                'cash_basis_account': account_ref.get(
+                    tax.cash_basis_account.id, False),
+            })
+        return accounts, taxes


### PR DESCRIPTION
Effectively Paid in the Mexican instances:

- Dependency to account_tax_cash_basis added, because this is the module
  that have the functionality to generate the new movements.
- Added data required by new module to generate the movements of VAT
  Effectively Paid.
- Fixed bad accounts and tags.
- Removed TAX by 11%, because since 2015 that tax was changed by 16%.
- Fix the account mapping to taxes.
- Inherited methods to assign the accounts needed in the taxes to IVA
  Effectively Paid.

The accounts was assigned with base to this [document](https://docs.google.com/spreadsheets/d/1FXyU0fgDadAWmnAiau6lbgI9AdaO2HQN5w0YgM2FYnQ/edit#gid=0)