### PR TITLE
[IMP] l10n_mx: Remove configuration to Use Cash Basis

### DIFF
--- a/addons/l10n_mx/data/account_chart.xml
+++ b/addons/l10n_mx/data/account_chart.xml
@@ -2015,6 +2015,13 @@ Cuentas del plan
             <field name="user_type_id" ref="account_type_other"/>
             <field name="tag_ids" eval="[(6,0,[ref('account_tag_216')])]"/>
         </record>
+        <record id='cuenta216_13' model='account.account.template'>
+            <field name='name'>Impuestos retenidos de iva efectivamente pagados</field>
+            <field name='code'>216.13</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_216')])]"/>
+        </record>
         <record id='cuenta217_01' model='account.account.template'>
             <field name='name'>Pagos realizados por cuenta de terceros</field>
             <field name='code'>217.01</field>

--- a/addons/l10n_mx/data/account_tax.xml
+++ b/addons/l10n_mx/data/account_tax.xml
@@ -109,8 +109,6 @@
         <field name="account_id" ref="cuenta216_03"/>
         <field name="refund_account_id" ref="cuenta216_03"/>
         <field name="tag_ids" eval="[(6,0,[ref('tax_tag_06')])]"/>
-        <field name="use_cash_basis" eval="True"/>
-        <field name="cash_basis_account" ref="cuenta216_03"/>
     </record>
 
     <record id="tax5" model="account.tax.template">
@@ -123,8 +121,6 @@
         <field name="account_id" ref="cuenta216_04"/>
         <field name="refund_account_id" ref="cuenta216_04"/>
         <field name="tag_ids" eval="[(6,0,[ref('tax_tag_07')])]"/>
-        <field name="use_cash_basis" eval="True"/>
-        <field name="cash_basis_account" ref="cuenta216_04"/>
     </record>
 
     <record id="tax7" model="account.tax.template">

--- a/addons/l10n_mx/data/account_tax.xml
+++ b/addons/l10n_mx/data/account_tax.xml
@@ -82,7 +82,7 @@
         <field name="refund_account_id" ref="cuenta216_10"/>
         <field name="tag_ids" eval="[(6,0,[ref('tax_tag_04')])]"/>
         <field name="use_cash_basis" eval="True"/>
-        <field name="cash_basis_account" ref="cuenta216_10"/>
+        <field name="cash_basis_account" ref="cuenta216_13"/>
     </record>
 
     <record id="tax2" model="account.tax.template">
@@ -96,7 +96,7 @@
         <field name="refund_account_id" ref="cuenta216_10"/>
         <field name="tag_ids" eval="[(6,0,[ref('tax_tag_05')])]"/>
         <field name="use_cash_basis" eval="True"/>
-        <field name="cash_basis_account" ref="cuenta216_10"/>
+        <field name="cash_basis_account" ref="cuenta216_13"/>
     </record>
 
     <record id="tax3" model="account.tax.template">
@@ -134,7 +134,7 @@
         <field name="refund_account_id" ref="cuenta216_10"/>
         <field name="tag_ids" eval="[(6,0,[ref('tax_tag_08')])]"/>
         <field name="use_cash_basis" eval="True"/>
-        <field name="cash_basis_account" ref="cuenta216_10"/>
+        <field name="cash_basis_account" ref="cuenta216_13"/>
     </record>
 
     <record id="tax8" model="account.tax.template">
@@ -148,7 +148,7 @@
         <field name="refund_account_id" ref="cuenta216_10"/>
         <field name="tag_ids" eval="[(6,0,[ref('tax_tag_09')])]"/>
         <field name="use_cash_basis" eval="True"/>
-        <field name="cash_basis_account" ref="cuenta216_10"/>
+        <field name="cash_basis_account" ref="cuenta216_13"/>
     </record>
 
     <record id="tax13" model="account.tax.template">


### PR DESCRIPTION
The ISR retentions not must be have configuration to Use Cash Basis, nor
Tax Received Account, was removed that configuration from the taxes
data.

Added account to tax effectively paid in retentions, this account is not
found in the SAT chart template, but is needed.

Assigned the new account in the taxes for retentions.