### PR TITLE
[IMP] l10n_mx: Changed Mexican Chart Template

### DIFF
--- a/addons/l10n_mx/__init__.py
+++ b/addons/l10n_mx/__init__.py
@@ -1,2 +1,4 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import models

--- a/addons/l10n_mx/__manifest__.py
+++ b/addons/l10n_mx/__manifest__.py
@@ -30,10 +30,13 @@ With this module you will have:
 
 .. SAT: http://www.sat.gob.mx/
     """,
-    "depends": ["account", "base_vat"],
+    "depends": ["account", "base_vat", "account_tax_cash_basis"],
     "data": [
+        "data/account_tag_data.xml",
         "data/l10n_mx_chart_data.xml",
         "data/account_tax_data.xml",
+        "data/l10n_mx_account_journa_data.xml",
+        "data/res_company_data.xml",
         "data/account_chart_template_data.yml",
     ],
 }

--- a/addons/l10n_mx/data/account_tag_data.xml
+++ b/addons/l10n_mx/data/account_tag_data.xml
@@ -1,0 +1,5382 @@
+<?xml version="1.0" ?>
+<odoo>
+    <data noupdate="1">
+
+            <record id='account_tag_100' model='account.account.tag'>
+                <field name='name'>100 Activo</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_100_01' model='account.account.tag'>
+                <field name='name'>100.01 Activo a corto plazo</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_101' model='account.account.tag'>
+                <field name='name'>101 Caja</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_101_01' model='account.account.tag'>
+                <field name='name'>101.01 Caja y efectivo</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_102' model='account.account.tag'>
+                <field name='name'>102 Bancos</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_102_01' model='account.account.tag'>
+                <field name='name'>102.01 Bancos nacionales</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_102_02' model='account.account.tag'>
+                <field name='name'>102.02 Bancos extranjeros</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_103' model='account.account.tag'>
+                <field name='name'>103 Inversiones</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_103_01' model='account.account.tag'>
+                <field name='name'>103.01 Inversiones temporales</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_103_02' model='account.account.tag'>
+                <field name='name'>103.02 Inversiones en fideicomisos</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_103_03' model='account.account.tag'>
+                <field name='name'>103.03 Otras inversiones</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_104' model='account.account.tag'>
+                <field name='name'>104 Otros instrumentos financieros</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_104_01' model='account.account.tag'>
+                <field name='name'>104.01 Otros instrumentos financieros</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_105' model='account.account.tag'>
+                <field name='name'>105 Clientes</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_105_01' model='account.account.tag'>
+                <field name='name'>105.01 Clientes nacionales</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_105_02' model='account.account.tag'>
+                <field name='name'>105.02 Clientes extranjeros</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_105_03' model='account.account.tag'>
+                <field name='name'>105.03 Clientes nacionales parte relacionada</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_105_04' model='account.account.tag'>
+                <field name='name'>105.04 Clientes extranjeros parte relacionada</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_106' model='account.account.tag'>
+                <field name='name'>106 Cuentas y documentos por cobrar a corto plazo</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_106_01' model='account.account.tag'>
+                <field name='name'>106.01 Cuentas y documentos por cobrar a corto plazo nacional</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_106_02' model='account.account.tag'>
+                <field name='name'>106.02 Cuentas y documentos por cobrar a corto plazo extranjero</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_106_03' model='account.account.tag'>
+                <field name='name'>106.03 Cuentas y documentos por cobrar a corto plazo nacional parte relacionada</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_106_04' model='account.account.tag'>
+                <field name='name'>106.04 Cuentas y documentos por cobrar a corto plazo extranjero parte relacionada</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_106_05' model='account.account.tag'>
+                <field name='name'>106.05 Intereses por cobrar a corto plazo nacional</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_106_06' model='account.account.tag'>
+                <field name='name'>106.06 Intereses por cobrar a corto plazo extranjero</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_106_07' model='account.account.tag'>
+                <field name='name'>106.07 Intereses por cobrar a corto plazo nacional parte relacionada</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_106_08' model='account.account.tag'>
+                <field name='name'>106.08 Intereses por cobrar a corto plazo extranjero parte relacionada</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_106_09' model='account.account.tag'>
+                <field name='name'>106.09 Otras cuentas y documentos por cobrar a corto plazo</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_106_10' model='account.account.tag'>
+                <field name='name'>106.10 Otras cuentas y documentos por cobrar a corto plazo parte relacionada</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_107' model='account.account.tag'>
+                <field name='name'>107 Deudores diversos</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_107_01' model='account.account.tag'>
+                <field name='name'>107.01 Funcionarios y empleados</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_107_02' model='account.account.tag'>
+                <field name='name'>107.02 Socios y accionistas</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_107_03' model='account.account.tag'>
+                <field name='name'>107.03 Partes relacionadas nacionales</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_107_04' model='account.account.tag'>
+                <field name='name'>107.04 Partes relacionadas extranjeros</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_107_05' model='account.account.tag'>
+                <field name='name'>107.05 Otros deudores diversos</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_108' model='account.account.tag'>
+                <field name='name'>108 Estimación de cuentas incobrables</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_108_01' model='account.account.tag'>
+                <field name='name'>108.01 Estimación de cuentas incobrables nacional</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_108_02' model='account.account.tag'>
+                <field name='name'>108.02 Estimación de cuentas incobrables extranjero</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_108_03' model='account.account.tag'>
+                <field name='name'>108.03 Estimación de cuentas incobrables nacional parte relacionada</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_108_04' model='account.account.tag'>
+                <field name='name'>108.04 Estimación de cuentas incobrables extranjero parte relacionada</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_109' model='account.account.tag'>
+                <field name='name'>109 Pagos anticipados</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_109_01' model='account.account.tag'>
+                <field name='name'>109.01 Seguros y fianzas pagados por anticipado nacional</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_109_02' model='account.account.tag'>
+                <field name='name'>109.02 Seguros y fianzas pagados por anticipado extranjero</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_109_03' model='account.account.tag'>
+                <field name='name'>109.03 Seguros y fianzas pagados por anticipado nacional parte relacionada</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_109_04' model='account.account.tag'>
+                <field name='name'>109.04 Seguros y fianzas pagados por anticipado extranjero parte relacionada</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_109_05' model='account.account.tag'>
+                <field name='name'>109.05 Rentas pagados por anticipado nacional</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_109_06' model='account.account.tag'>
+                <field name='name'>109.06 Rentas pagados por anticipado extranjero</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_109_07' model='account.account.tag'>
+                <field name='name'>109.07 Rentas pagados por anticipado nacional parte relacionada</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_109_08' model='account.account.tag'>
+                <field name='name'>109.08 Rentas pagados por anticipado extranjero parte relacionada</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_109_09' model='account.account.tag'>
+                <field name='name'>109.09 Intereses pagados por anticipado nacional</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_109_10' model='account.account.tag'>
+                <field name='name'>109.10 Intereses pagados por anticipado extranjero</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_109_11' model='account.account.tag'>
+                <field name='name'>109.11 Intereses pagados por anticipado nacional parte relacionada</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_109_12' model='account.account.tag'>
+                <field name='name'>109.12 Intereses pagados por anticipado extranjero parte relacionada</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_109_13' model='account.account.tag'>
+                <field name='name'>109.13 Factoraje financiero pagados por anticipado nacional</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_109_14' model='account.account.tag'>
+                <field name='name'>109.14 Factoraje financiero pagados por anticipado extranjero</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_109_15' model='account.account.tag'>
+                <field name='name'>109.15 Factoraje financiero pagados por anticipado nacional parte relacionada</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_109_16' model='account.account.tag'>
+                <field name='name'>109.16 Factoraje financiero pagados por anticipado extranjero parte relacionada</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_109_17' model='account.account.tag'>
+                <field name='name'>109.17 Arrendamiento financiero pagados por anticipado nacional</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_109_18' model='account.account.tag'>
+                <field name='name'>109.18 Arrendamiento financiero pagados por anticipado extranjero</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_109_19' model='account.account.tag'>
+                <field name='name'>109.19 Arrendamiento financiero pagados por anticipado nacional parte relacionada</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_109_20' model='account.account.tag'>
+                <field name='name'>109.20 Arrendamiento financiero pagados por anticipado extranjero parte relacionada</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_109_21' model='account.account.tag'>
+                <field name='name'>109.21 Pérdida por deterioro de pagos anticipados</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_109_22' model='account.account.tag'>
+                <field name='name'>109.22 Derechos fiduciarios</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_109_23' model='account.account.tag'>
+                <field name='name'>109.23 Otros pagos anticipados</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_110' model='account.account.tag'>
+                <field name='name'>110 Subsidio al empleo por aplicar</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_110_01' model='account.account.tag'>
+                <field name='name'>110.01 Subsidio al empleo por aplicar</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_111' model='account.account.tag'>
+                <field name='name'>111 Crédito al diesel por acreditar</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_111_01' model='account.account.tag'>
+                <field name='name'>111.01 Crédito al diesel por acreditar</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_112' model='account.account.tag'>
+                <field name='name'>112 Otros estímulos</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_112_01' model='account.account.tag'>
+                <field name='name'>112.01 Otros estímulos</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_113' model='account.account.tag'>
+                <field name='name'>113 Impuestos a favor</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_113_01' model='account.account.tag'>
+                <field name='name'>113.01 IVA a favor</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_113_02' model='account.account.tag'>
+                <field name='name'>113.02 ISR a favor</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_113_03' model='account.account.tag'>
+                <field name='name'>113.03 IETU a favor</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_113_04' model='account.account.tag'>
+                <field name='name'>113.04 IDE a favor</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_113_05' model='account.account.tag'>
+                <field name='name'>113.05 IA a favor</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_113_06' model='account.account.tag'>
+                <field name='name'>113.06 Subsidio al empleo</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_113_07' model='account.account.tag'>
+                <field name='name'>113.07 Pago de lo indebido</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_113_08' model='account.account.tag'>
+                <field name='name'>113.08 Otros impuestos a favor</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_114' model='account.account.tag'>
+                <field name='name'>114 Pagos provisionales</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_114_01' model='account.account.tag'>
+                <field name='name'>114.01 Pagos provisionales de ISR</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_115' model='account.account.tag'>
+                <field name='name'>115 Inventario</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_115_01' model='account.account.tag'>
+                <field name='name'>115.01 Inventario</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_115_02' model='account.account.tag'>
+                <field name='name'>115.02 Materia prima y materiales</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_115_03' model='account.account.tag'>
+                <field name='name'>115.03 Producción en proceso</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_115_04' model='account.account.tag'>
+                <field name='name'>115.04 Productos terminados</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_115_05' model='account.account.tag'>
+                <field name='name'>115.05 Mercancías en tránsito</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_115_06' model='account.account.tag'>
+                <field name='name'>115.06 Mercancías en poder de terceros</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_115_07' model='account.account.tag'>
+                <field name='name'>115.07 Otros</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_116' model='account.account.tag'>
+                <field name='name'>116 Estimación de inventarios obsoletos y de lento movimiento</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_116_01' model='account.account.tag'>
+                <field name='name'>116.01 Estimación de inventarios obsoletos y de lento movimiento</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_117' model='account.account.tag'>
+                <field name='name'>117 Obras en proceso de inmuebles</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_117_01' model='account.account.tag'>
+                <field name='name'>117.01 Obras en proceso de inmuebles</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_118' model='account.account.tag'>
+                <field name='name'>118 Impuestos acreditables pagados</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_118_01' model='account.account.tag'>
+                <field name='name'>118.01 IVA acreditable pagado</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_118_02' model='account.account.tag'>
+                <field name='name'>118.02 IVA acreditable de importación pagado</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_118_03' model='account.account.tag'>
+                <field name='name'>118.03 IEPS acreditable pagado</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_118_04' model='account.account.tag'>
+                <field name='name'>118.04 IEPS pagado en importación</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_119' model='account.account.tag'>
+                <field name='name'>119 Impuestos acreditables por pagar</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_119_01' model='account.account.tag'>
+                <field name='name'>119.01 IVA pendiente de pago</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_119_02' model='account.account.tag'>
+                <field name='name'>119.02 IVA de importación pendiente de pago</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_119_03' model='account.account.tag'>
+                <field name='name'>119.03 IEPS pendiente de pago</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_119_04' model='account.account.tag'>
+                <field name='name'>119.04 IEPS pendiente de pago en importación</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_120' model='account.account.tag'>
+                <field name='name'>120 Anticipo a proveedores</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_120_01' model='account.account.tag'>
+                <field name='name'>120.01 Anticipo a proveedores nacional</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_120_02' model='account.account.tag'>
+                <field name='name'>120.02 Anticipo a proveedores extranjero</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_120_03' model='account.account.tag'>
+                <field name='name'>120.03 Anticipo a proveedores nacional parte relacionada</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_120_04' model='account.account.tag'>
+                <field name='name'>120.04 Anticipo a proveedores extranjero parte relacionada</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_121' model='account.account.tag'>
+                <field name='name'>121 Otros activos a corto plazo</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_121_01' model='account.account.tag'>
+                <field name='name'>121.01 Otros activos a corto plazo</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_100_02' model='account.account.tag'>
+                <field name='name'>100.02 Activo a largo plazo</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_151' model='account.account.tag'>
+                <field name='name'>151 Terrenos</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_151_01' model='account.account.tag'>
+                <field name='name'>151.01 Terrenos</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_152' model='account.account.tag'>
+                <field name='name'>152 Edificios</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_152_01' model='account.account.tag'>
+                <field name='name'>152.01 Edificios</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_153' model='account.account.tag'>
+                <field name='name'>153 Maquinaria y equipo</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_153_01' model='account.account.tag'>
+                <field name='name'>153.01 Maquinaria y equipo</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_154' model='account.account.tag'>
+                <field name='name'>154 Automóviles, autobuses, camiones de carga, tractocamiones, montacargas y remolques</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_154_01' model='account.account.tag'>
+                <field name='name'>154.01 Automóviles, autobuses, camiones de carga, tractocamiones, montacargas y remolques</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_155' model='account.account.tag'>
+                <field name='name'>155 Mobiliario y equipo de oficina</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_155_01' model='account.account.tag'>
+                <field name='name'>155.01 Mobiliario y equipo de oficina</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_156' model='account.account.tag'>
+                <field name='name'>156 Equipo de cómputo</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_156_01' model='account.account.tag'>
+                <field name='name'>156.01 Equipo de cómputo</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_157' model='account.account.tag'>
+                <field name='name'>157 Equipo de comunicación</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_157_01' model='account.account.tag'>
+                <field name='name'>157.01 Equipo de comunicación</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_158' model='account.account.tag'>
+                <field name='name'>158 Activos biológicos, vegetales y semovientes</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_158_01' model='account.account.tag'>
+                <field name='name'>158.01 Activos biológicos, vegetales y semovientes</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_159' model='account.account.tag'>
+                <field name='name'>159 Obras en proceso de activos fijos</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_159_01' model='account.account.tag'>
+                <field name='name'>159.01 Obras en proceso de activos fijos</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_160' model='account.account.tag'>
+                <field name='name'>160 Otros activos fijos</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_160_01' model='account.account.tag'>
+                <field name='name'>160.01 Otros activos fijos</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_161' model='account.account.tag'>
+                <field name='name'>161 Ferrocarriles</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_161_01' model='account.account.tag'>
+                <field name='name'>161.01 Ferrocarriles</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_162' model='account.account.tag'>
+                <field name='name'>162 Embarcaciones</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_162_01' model='account.account.tag'>
+                <field name='name'>162.01 Embarcaciones</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_163' model='account.account.tag'>
+                <field name='name'>163 Aviones</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_163_01' model='account.account.tag'>
+                <field name='name'>163.01 Aviones</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_164' model='account.account.tag'>
+                <field name='name'>164 Troqueles, moldes, matrices y herramental</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_164_01' model='account.account.tag'>
+                <field name='name'>164.01 Troqueles, moldes, matrices y herramental</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_165' model='account.account.tag'>
+                <field name='name'>165 Equipo de comunicaciones telefónicas</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_165_01' model='account.account.tag'>
+                <field name='name'>165.01 Equipo de comunicaciones telefónicas</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_166' model='account.account.tag'>
+                <field name='name'>166 Equipo de comunicación satelital</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_166_01' model='account.account.tag'>
+                <field name='name'>166.01 Equipo de comunicación satelital</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_167' model='account.account.tag'>
+                <field name='name'>167 Equipo de adaptaciones para personas con capacidades diferentes</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_167_01' model='account.account.tag'>
+                <field name='name'>167.01 Equipo de adaptaciones para personas con capacidades diferentes</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_168' model='account.account.tag'>
+                <field name='name'>168 Maquinaria y equipo de generación de energía de fuentes renovables o de sistemas de cogeneración de electricidad eficiente</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_168_01' model='account.account.tag'>
+                <field name='name'>168.01 Maquinaria y equipo de generación de energía de fuentes renovables o de sistemas de cogeneración de electricidad eficiente</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_169' model='account.account.tag'>
+                <field name='name'>169 Otra maquinaria y equipo</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_169_01' model='account.account.tag'>
+                <field name='name'>169.01 Otra maquinaria y equipo</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_170' model='account.account.tag'>
+                <field name='name'>170 Adaptaciones y mejoras</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_170_01' model='account.account.tag'>
+                <field name='name'>170.01 Adaptaciones y mejoras</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_171' model='account.account.tag'>
+                <field name='name'>171 Depreciación acumulada de activos fijos</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_171_01' model='account.account.tag'>
+                <field name='name'>171.01 Depreciación acumulada de edificios</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_171_02' model='account.account.tag'>
+                <field name='name'>171.02 Depreciación acumulada de maquinaria y equipo</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_171_03' model='account.account.tag'>
+                <field name='name'>171.03 Depreciación acumulada de automóviles, autobuses, camiones de carga, tractocamiones, montacargas y remolques</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_171_04' model='account.account.tag'>
+                <field name='name'>171.04 Depreciación acumulada de mobiliario y equipo de oficina</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_171_05' model='account.account.tag'>
+                <field name='name'>171.05 Depreciación acumulada de equipo de cómputo</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_171_06' model='account.account.tag'>
+                <field name='name'>171.06 Depreciación acumulada de equipo de comunicación</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_171_07' model='account.account.tag'>
+                <field name='name'>171.07 Depreciación acumulada de activos biológicos, vegetales y semovientes</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_171_08' model='account.account.tag'>
+                <field name='name'>171.08 Depreciación acumulada de otros activos fijos</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_171_09' model='account.account.tag'>
+                <field name='name'>171.09 Depreciación acumulada de ferrocarriles</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_171_10' model='account.account.tag'>
+                <field name='name'>171.10 Depreciación acumulada de embarcaciones</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_171_11' model='account.account.tag'>
+                <field name='name'>171.11 Depreciación acumulada de aviones</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_171_12' model='account.account.tag'>
+                <field name='name'>171.12 Depreciación acumulada de troqueles, moldes, matrices y herramental</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_171_13' model='account.account.tag'>
+                <field name='name'>171.13 Depreciación acumulada de equipo de comunicaciones telefónicas</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_171_14' model='account.account.tag'>
+                <field name='name'>171.14 Depreciación acumulada de equipo de comunicación satelital</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_171_15' model='account.account.tag'>
+                <field name='name'>171.15 Depreciación acumulada de equipo de adaptaciones para personas con capacidades diferentes</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_171_16' model='account.account.tag'>
+                <field name='name'>171.16 Depreciación acumulada de maquinaria y equipo de generación de energía de fuentes renovables o de sistemas de cogeneración de electricidad eficiente</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_171_17' model='account.account.tag'>
+                <field name='name'>171.17 Depreciación acumulada de adaptaciones y mejoras</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_171_18' model='account.account.tag'>
+                <field name='name'>171.18 Depreciación acumulada de otra maquinaria y equipo</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_172' model='account.account.tag'>
+                <field name='name'>172 Pérdida por deterioro acumulado de activos fijos</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_172_01' model='account.account.tag'>
+                <field name='name'>172.01 Pérdida por deterioro acumulado de edificios</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_172_02' model='account.account.tag'>
+                <field name='name'>172.02 Pérdida por deterioro acumulado de maquinaria y equipo</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_172_03' model='account.account.tag'>
+                <field name='name'>172.03 Pérdida por deterioro acumulado de automóviles, autobuses, camiones de carga, tractocamiones, montacargas y remolques</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_172_04' model='account.account.tag'>
+                <field name='name'>172.04 Pérdida por deterioro acumulado de mobiliario y equipo de oficina</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_172_05' model='account.account.tag'>
+                <field name='name'>172.05 Pérdida por deterioro acumulado de equipo de cómputo</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_172_06' model='account.account.tag'>
+                <field name='name'>172.06 Pérdida por deterioro acumulado de equipo de comunicación</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_172_07' model='account.account.tag'>
+                <field name='name'>172.07 Pérdida por deterioro acumulado de activos biológicos, vegetales y semovientes</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_172_08' model='account.account.tag'>
+                <field name='name'>172.08 Pérdida por deterioro acumulado de otros activos fijos</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_172_09' model='account.account.tag'>
+                <field name='name'>172.09 Pérdida por deterioro acumulado de ferrocarriles</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_172_10' model='account.account.tag'>
+                <field name='name'>172.10 Pérdida por deterioro acumulado de embarcaciones</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_172_11' model='account.account.tag'>
+                <field name='name'>172.11 Pérdida por deterioro acumulado de aviones</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_172_12' model='account.account.tag'>
+                <field name='name'>172.12 Pérdida por deterioro acumulado de troqueles, moldes, matrices y herramental</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_172_13' model='account.account.tag'>
+                <field name='name'>172.13 Pérdida por deterioro acumulado de equipo de comunicaciones telefónicas</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_172_14' model='account.account.tag'>
+                <field name='name'>172.14 Pérdida por deterioro acumulado de equipo de comunicación satelital</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_172_15' model='account.account.tag'>
+                <field name='name'>172.15 Pérdida por deterioro acumulado de equipo de adaptaciones para personas con capacidades diferentes</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_172_16' model='account.account.tag'>
+                <field name='name'>172.16 Pérdida por deterioro acumulado de maquinaria y equipo de generación de energía de fuentes renovables o de sistemas de cogeneración de electricidad eficiente</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_172_17' model='account.account.tag'>
+                <field name='name'>172.17 Pérdida por deterioro acumulado de adaptaciones y mejoras</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_172_18' model='account.account.tag'>
+                <field name='name'>172.18 Pérdida por deterioro acumulado de otra maquinaria y equipo</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_173' model='account.account.tag'>
+                <field name='name'>173 Gastos diferidos</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_173_01' model='account.account.tag'>
+                <field name='name'>173.01 Gastos diferidos</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_174' model='account.account.tag'>
+                <field name='name'>174 Gastos pre operativos</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_174_01' model='account.account.tag'>
+                <field name='name'>174.01 Gastos pre operativos</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_175' model='account.account.tag'>
+                <field name='name'>175 Regalías, asistencia técnica y otros gastos diferidos</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_175_01' model='account.account.tag'>
+                <field name='name'>175.01 Regalías, asistencia técnica y otros gastos diferidos</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_176' model='account.account.tag'>
+                <field name='name'>176 Activos intangibles</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_176_01' model='account.account.tag'>
+                <field name='name'>176.01 Activos intangibles</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_177' model='account.account.tag'>
+                <field name='name'>177 Gastos de organización</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_177_01' model='account.account.tag'>
+                <field name='name'>177.01 Gastos de organización</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_178' model='account.account.tag'>
+                <field name='name'>178 Investigación y desarrollo de mercado</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_178_01' model='account.account.tag'>
+                <field name='name'>178.01 Investigación y desarrollo de mercado</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_179' model='account.account.tag'>
+                <field name='name'>179 Marcas y patentes</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_179_01' model='account.account.tag'>
+                <field name='name'>179.01 Marcas y patentes</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_180' model='account.account.tag'>
+                <field name='name'>180 Crédito mercantil</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_180_01' model='account.account.tag'>
+                <field name='name'>180.01 Crédito mercantil</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_181' model='account.account.tag'>
+                <field name='name'>181 Gastos de instalación</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_181_01' model='account.account.tag'>
+                <field name='name'>181.01 Gastos de instalación</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_182' model='account.account.tag'>
+                <field name='name'>182 Otros activos diferidos</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_182_01' model='account.account.tag'>
+                <field name='name'>182.01 Otros activos diferidos</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_183' model='account.account.tag'>
+                <field name='name'>183 Amortización acumulada de activos diferidos</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_183_01' model='account.account.tag'>
+                <field name='name'>183.01 Amortización acumulada de gastos diferidos</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_183_02' model='account.account.tag'>
+                <field name='name'>183.02 Amortización acumulada de gastos pre operativos</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_183_03' model='account.account.tag'>
+                <field name='name'>183.03 Amortización acumulada de regalías, asistencia técnica y otros gastos diferidos</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_183_04' model='account.account.tag'>
+                <field name='name'>183.04 Amortización acumulada de activos intangibles</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_183_05' model='account.account.tag'>
+                <field name='name'>183.05 Amortización acumulada de gastos de organización</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_183_06' model='account.account.tag'>
+                <field name='name'>183.06 Amortización acumulada de investigación y desarrollo de mercado</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_183_07' model='account.account.tag'>
+                <field name='name'>183.07 Amortización acumulada de marcas y patentes</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_183_08' model='account.account.tag'>
+                <field name='name'>183.08 Amortización acumulada de crédito mercantil</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_183_09' model='account.account.tag'>
+                <field name='name'>183.09 Amortización acumulada de gastos de instalación</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_183_10' model='account.account.tag'>
+                <field name='name'>183.10 Amortización acumulada de otros activos diferidos</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_184' model='account.account.tag'>
+                <field name='name'>184 Depósitos en garantía</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_184_01' model='account.account.tag'>
+                <field name='name'>184.01 Depósitos de fianzas</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_184_02' model='account.account.tag'>
+                <field name='name'>184.02 Depósitos de arrendamiento de bienes inmuebles</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_184_03' model='account.account.tag'>
+                <field name='name'>184.03 Otros depósitos en garantía</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_185' model='account.account.tag'>
+                <field name='name'>185 Impuestos diferidos</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_185_01' model='account.account.tag'>
+                <field name='name'>185.01 Impuestos diferidos ISR</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_186' model='account.account.tag'>
+                <field name='name'>186 Cuentas y documentos por cobrar a largo plazo</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_186_01' model='account.account.tag'>
+                <field name='name'>186.01 Cuentas y documentos por cobrar a largo plazo nacional</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_186_02' model='account.account.tag'>
+                <field name='name'>186.02 Cuentas y documentos por cobrar a largo plazo extranjero</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_186_03' model='account.account.tag'>
+                <field name='name'>186.03 Cuentas y documentos por cobrar a largo plazo nacional parte relacionada</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_186_04' model='account.account.tag'>
+                <field name='name'>186.04 Cuentas y documentos por cobrar a largo plazo extranjero parte relacionada</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_186_05' model='account.account.tag'>
+                <field name='name'>186.05 Intereses por cobrar a largo plazo nacional</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_186_06' model='account.account.tag'>
+                <field name='name'>186.06 Intereses por cobrar a largo plazo extranjero</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_186_07' model='account.account.tag'>
+                <field name='name'>186.07 Intereses por cobrar a largo plazo nacional parte relacionada</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_186_08' model='account.account.tag'>
+                <field name='name'>186.08 Intereses por cobrar a largo plazo extranjero parte relacionada</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_186_09' model='account.account.tag'>
+                <field name='name'>186.09 Otras cuentas y documentos por cobrar a largo plazo</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_186_10' model='account.account.tag'>
+                <field name='name'>186.10 Otras cuentas y documentos por cobrar a largo plazo parte relacionada</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_187' model='account.account.tag'>
+                <field name='name'>187 Participación de los trabajadores en las utilidades diferidas</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_187_01' model='account.account.tag'>
+                <field name='name'>187.01 Participación de los trabajadores en las utilidades diferidas</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_188' model='account.account.tag'>
+                <field name='name'>188 Inversiones permanentes en acciones</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_188_01' model='account.account.tag'>
+                <field name='name'>188.01 Inversiones a largo plazo en subsidiarias</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_188_02' model='account.account.tag'>
+                <field name='name'>188.02 Inversiones a largo plazo en asociadas</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_188_03' model='account.account.tag'>
+                <field name='name'>188.03 Otras inversiones permanentes en acciones</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_189' model='account.account.tag'>
+                <field name='name'>189 Estimación por deterioro de inversiones permanentes en acciones</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_189_01' model='account.account.tag'>
+                <field name='name'>189.01 Estimación por deterioro de inversiones permanentes en acciones</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_190' model='account.account.tag'>
+                <field name='name'>190 Otros instrumentos financieros</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_190_01' model='account.account.tag'>
+                <field name='name'>190.01 Otros instrumentos financieros</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_191' model='account.account.tag'>
+                <field name='name'>191 Otros activos a largo plazo</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_191_01' model='account.account.tag'>
+                <field name='name'>191.01 Otros activos a largo plazo</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_200' model='account.account.tag'>
+                <field name='name'>200 Pasivo</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_200_01' model='account.account.tag'>
+                <field name='name'>200.01 Pasivo a corto plazo</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_201' model='account.account.tag'>
+                <field name='name'>201 Proveedores</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_201_01' model='account.account.tag'>
+                <field name='name'>201.01 Proveedores nacionales</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_201_02' model='account.account.tag'>
+                <field name='name'>201.02 Proveedores extranjeros</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_201_03' model='account.account.tag'>
+                <field name='name'>201.03 Proveedores nacionales parte relacionada</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_201_04' model='account.account.tag'>
+                <field name='name'>201.04 Proveedores extranjeros parte relacionada</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_202' model='account.account.tag'>
+                <field name='name'>202 Cuentas por pagar a corto plazo</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_202_01' model='account.account.tag'>
+                <field name='name'>202.01 Documentos por pagar bancario y financiero nacional</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_202_02' model='account.account.tag'>
+                <field name='name'>202.02 Documentos por pagar bancario y financiero extranjero</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_202_03' model='account.account.tag'>
+                <field name='name'>202.03 Documentos y cuentas por pagar a corto plazo nacional</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_202_04' model='account.account.tag'>
+                <field name='name'>202.04 Documentos y cuentas por pagar a corto plazo extranjero</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_202_05' model='account.account.tag'>
+                <field name='name'>202.05 Documentos y cuentas por pagar a corto plazo nacional parte relacionada</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_202_06' model='account.account.tag'>
+                <field name='name'>202.06 Documentos y cuentas por pagar a corto plazo extranjero parte relacionada</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_202_07' model='account.account.tag'>
+                <field name='name'>202.07 Intereses por pagar a corto plazo nacional</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_202_08' model='account.account.tag'>
+                <field name='name'>202.08 Intereses por pagar a corto plazo extranjero</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_202_09' model='account.account.tag'>
+                <field name='name'>202.09 Intereses por pagar a corto plazo nacional parte relacionada</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_202_10' model='account.account.tag'>
+                <field name='name'>202.10 Intereses por pagar a corto plazo extranjero parte relacionada</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_202_11' model='account.account.tag'>
+                <field name='name'>202.11 Dividendo por pagar nacional</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_202_12' model='account.account.tag'>
+                <field name='name'>202.12 Dividendo por pagar extranjero</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_203' model='account.account.tag'>
+                <field name='name'>203 Cobros anticipados a corto plazo</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_203_01' model='account.account.tag'>
+                <field name='name'>203.01 Rentas cobradas por anticipado a corto plazo nacional</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_203_02' model='account.account.tag'>
+                <field name='name'>203.02 Rentas cobradas por anticipado a corto plazo extranjero</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_203_03' model='account.account.tag'>
+                <field name='name'>203.03 Rentas cobradas por anticipado a corto plazo nacional parte relacionada</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_203_04' model='account.account.tag'>
+                <field name='name'>203.04 Rentas cobradas por anticipado a corto plazo extranjero parte relacionada</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_203_05' model='account.account.tag'>
+                <field name='name'>203.05 Intereses cobrados por anticipado a corto plazo nacional</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_203_06' model='account.account.tag'>
+                <field name='name'>203.06 Intereses cobrados por anticipado a corto plazo extranjero</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_203_07' model='account.account.tag'>
+                <field name='name'>203.07 Intereses cobrados por anticipado a corto plazo nacional parte relacionada</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_203_08' model='account.account.tag'>
+                <field name='name'>203.08 Intereses cobrados por anticipado a corto plazo extranjero parte relacionada</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_203_09' model='account.account.tag'>
+                <field name='name'>203.09 Factoraje financiero cobrados por anticipado a corto plazo nacional</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_203_10' model='account.account.tag'>
+                <field name='name'>203.10 Factoraje financiero cobrados por anticipado a corto plazo extranjero</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_203_11' model='account.account.tag'>
+                <field name='name'>203.11 Factoraje financiero cobrados por anticipado a corto plazo nacional parte relacionada</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_203_12' model='account.account.tag'>
+                <field name='name'>203.12 Factoraje financiero cobrados por anticipado a corto plazo extranjero parte relacionada</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_203_13' model='account.account.tag'>
+                <field name='name'>203.13 Arrendamiento financiero cobrados por anticipado a corto plazo nacional</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_203_14' model='account.account.tag'>
+                <field name='name'>203.14 Arrendamiento financiero cobrados por anticipado a corto plazo extranjero</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_203_15' model='account.account.tag'>
+                <field name='name'>203.15 Arrendamiento financiero cobrados por anticipado a corto plazo nacional parte relacionada</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_203_16' model='account.account.tag'>
+                <field name='name'>203.16 Arrendamiento financiero cobrados por anticipado a corto plazo extranjero parte relacionada</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_203_17' model='account.account.tag'>
+                <field name='name'>203.17 Derechos fiduciarios</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_203_18' model='account.account.tag'>
+                <field name='name'>203.18 Otros cobros anticipados</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_204' model='account.account.tag'>
+                <field name='name'>204 Instrumentos financieros a corto plazo</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_204_01' model='account.account.tag'>
+                <field name='name'>204.01 Instrumentos financieros a corto plazo</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_205' model='account.account.tag'>
+                <field name='name'>205 Acreedores diversos a corto plazo</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_205_01' model='account.account.tag'>
+                <field name='name'>205.01 Socios, accionistas o representante legal</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_205_02' model='account.account.tag'>
+                <field name='name'>205.02 Acreedores diversos a corto plazo nacional</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_205_03' model='account.account.tag'>
+                <field name='name'>205.03 Acreedores diversos a corto plazo extranjero</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_205_04' model='account.account.tag'>
+                <field name='name'>205.04 Acreedores diversos a corto plazo nacional parte relacionada</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_205_05' model='account.account.tag'>
+                <field name='name'>205.05 Acreedores diversos a corto plazo extranjero parte relacionada</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_205_06' model='account.account.tag'>
+                <field name='name'>205.06 Otros acreedores diversos a corto plazo</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_206' model='account.account.tag'>
+                <field name='name'>206 Anticipo de cliente</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_206_01' model='account.account.tag'>
+                <field name='name'>206.01 Anticipo de cliente nacional</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_206_02' model='account.account.tag'>
+                <field name='name'>206.02 Anticipo de cliente extranjero</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_206_03' model='account.account.tag'>
+                <field name='name'>206.03 Anticipo de cliente nacional parte relacionada</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_206_04' model='account.account.tag'>
+                <field name='name'>206.04 Anticipo de cliente extranjero parte relacionada</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_206_05' model='account.account.tag'>
+                <field name='name'>206.05 Otros anticipos de clientes</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_207' model='account.account.tag'>
+                <field name='name'>207 Impuestos trasladados</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_207_01' model='account.account.tag'>
+                <field name='name'>207.01 IVA trasladado</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_207_02' model='account.account.tag'>
+                <field name='name'>207.02 IEPS trasladado</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_208' model='account.account.tag'>
+                <field name='name'>208 Impuestos trasladados cobrados</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_208_01' model='account.account.tag'>
+                <field name='name'>208.01 IVA trasladado cobrado</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_208_02' model='account.account.tag'>
+                <field name='name'>208.02 IEPS trasladado cobrado</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_209' model='account.account.tag'>
+                <field name='name'>209 Impuestos trasladados no cobrados</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_209_01' model='account.account.tag'>
+                <field name='name'>209.01 IVA trasladado no cobrado</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_209_02' model='account.account.tag'>
+                <field name='name'>209.02 IEPS trasladado no cobrado</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_210' model='account.account.tag'>
+                <field name='name'>210 Provisión de sueldos y salarios por pagar</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_210_01' model='account.account.tag'>
+                <field name='name'>210.01 Provisión de sueldos y salarios por pagar</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_210_02' model='account.account.tag'>
+                <field name='name'>210.02 Provisión de vacaciones por pagar</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_210_03' model='account.account.tag'>
+                <field name='name'>210.03 Provisión de aguinaldo por pagar</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_210_04' model='account.account.tag'>
+                <field name='name'>210.04 Provisión de fondo de ahorro por pagar</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_210_05' model='account.account.tag'>
+                <field name='name'>210.05 Provisión de asimilados a salarios por pagar</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_210_06' model='account.account.tag'>
+                <field name='name'>210.06 Provisión de anticipos o remanentes por distribuir</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_210_07' model='account.account.tag'>
+                <field name='name'>210.07 Provisión de otros sueldos y salarios por pagar</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_211' model='account.account.tag'>
+                <field name='name'>211 Provisión de contribuciones de seguridad social por pagar</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_211_01' model='account.account.tag'>
+                <field name='name'>211.01 Provisión de IMSS patronal por pagar</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_211_02' model='account.account.tag'>
+                <field name='name'>211.02 Provisión de SAR por pagar</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_211_03' model='account.account.tag'>
+                <field name='name'>211.03 Provisión de infonavit por pagar</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_212' model='account.account.tag'>
+                <field name='name'>212 Provisión de impuesto estatal sobre nómina por pagar</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_212_01' model='account.account.tag'>
+                <field name='name'>212.01 Provisión de impuesto estatal sobre nómina por pagar</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_213' model='account.account.tag'>
+                <field name='name'>213 Impuestos y derechos por pagar</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_213_01' model='account.account.tag'>
+                <field name='name'>213.01 IVA por pagar</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_213_02' model='account.account.tag'>
+                <field name='name'>213.02 IEPS por pagar</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_213_03' model='account.account.tag'>
+                <field name='name'>213.03 ISR por pagar</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_213_04' model='account.account.tag'>
+                <field name='name'>213.04 Impuesto estatal sobre nómina por pagar</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_213_05' model='account.account.tag'>
+                <field name='name'>213.05 Impuesto estatal y municipal por pagar</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_213_06' model='account.account.tag'>
+                <field name='name'>213.06 Derechos por pagar</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_213_07' model='account.account.tag'>
+                <field name='name'>213.07 Otros impuestos por pagar</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_214' model='account.account.tag'>
+                <field name='name'>214 Dividendos por pagar</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_214_01' model='account.account.tag'>
+                <field name='name'>214.01 Dividendos por pagar</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_215' model='account.account.tag'>
+                <field name='name'>215 PTU por pagar</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_215_01' model='account.account.tag'>
+                <field name='name'>215.01 PTU por pagar</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_215_02' model='account.account.tag'>
+                <field name='name'>215.02 PTU por pagar de ejercicios anteriores</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_215_03' model='account.account.tag'>
+                <field name='name'>215.03 Provisión de PTU por pagar</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_216' model='account.account.tag'>
+                <field name='name'>216 Impuestos retenidos</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_216_01' model='account.account.tag'>
+                <field name='name'>216.01 Impuestos retenidos de ISR por sueldos y salarios</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_216_02' model='account.account.tag'>
+                <field name='name'>216.02 Impuestos retenidos de ISR por asimilados a salarios</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_216_03' model='account.account.tag'>
+                <field name='name'>216.03 Impuestos retenidos de ISR por arrendamiento</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_216_04' model='account.account.tag'>
+                <field name='name'>216.04 Impuestos retenidos de ISR por servicios profesionales</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_216_05' model='account.account.tag'>
+                <field name='name'>216.05 Impuestos retenidos de ISR por dividendos</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_216_06' model='account.account.tag'>
+                <field name='name'>216.06 Impuestos retenidos de ISR por intereses</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_216_07' model='account.account.tag'>
+                <field name='name'>216.07 Impuestos retenidos de ISR por pagos al extranjero</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_216_08' model='account.account.tag'>
+                <field name='name'>216.08 Impuestos retenidos de ISR por venta de acciones</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_216_09' model='account.account.tag'>
+                <field name='name'>216.09 Impuestos retenidos de ISR por venta de partes sociales</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_216_10' model='account.account.tag'>
+                <field name='name'>216.10 Impuestos retenidos de IVA</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_216_11' model='account.account.tag'>
+                <field name='name'>216.11 Retenciones de IMSS a los trabajadores</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_216_12' model='account.account.tag'>
+                <field name='name'>216.12 Otras impuestos retenidos</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_217' model='account.account.tag'>
+                <field name='name'>217 Pagos realizados por cuenta de terceros</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_217_01' model='account.account.tag'>
+                <field name='name'>217.01 Pagos realizados por cuenta de terceros</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_218' model='account.account.tag'>
+                <field name='name'>218 Otros pasivos a corto plazo</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_218_01' model='account.account.tag'>
+                <field name='name'>218.01 Otros pasivos a corto plazo</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_200_02' model='account.account.tag'>
+                <field name='name'>200.02 Pasivo a largo plazo</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_251' model='account.account.tag'>
+                <field name='name'>251 Acreedores diversos a largo plazo</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_251_01' model='account.account.tag'>
+                <field name='name'>251.01 Socios, accionistas o representante legal</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_251_02' model='account.account.tag'>
+                <field name='name'>251.02 Acreedores diversos a largo plazo nacional</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_251_03' model='account.account.tag'>
+                <field name='name'>251.03 Acreedores diversos a largo plazo extranjero</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_251_04' model='account.account.tag'>
+                <field name='name'>251.04 Acreedores diversos a largo plazo nacional parte relacionada</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_251_05' model='account.account.tag'>
+                <field name='name'>251.05 Acreedores diversos a largo plazo extranjero parte relacionada</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_251_06' model='account.account.tag'>
+                <field name='name'>251.06 Otros acreedores diversos a largo plazo</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_252' model='account.account.tag'>
+                <field name='name'>252 Cuentas por pagar a largo plazo</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_252_01' model='account.account.tag'>
+                <field name='name'>252.01 Documentos bancarios y financieros por pagar a largo plazo nacional</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_252_02' model='account.account.tag'>
+                <field name='name'>252.02 Documentos bancarios y financieros por pagar a largo plazo extranjero</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_252_03' model='account.account.tag'>
+                <field name='name'>252.03 Documentos y cuentas por pagar a largo plazo nacional</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_252_04' model='account.account.tag'>
+                <field name='name'>252.04 Documentos y cuentas por pagar a largo plazo extranjero</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_252_05' model='account.account.tag'>
+                <field name='name'>252.05 Documentos y cuentas por pagar a largo plazo nacional parte relacionada</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_252_06' model='account.account.tag'>
+                <field name='name'>252.06 Documentos y cuentas por pagar a largo plazo extranjero parte relacionada</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_252_07' model='account.account.tag'>
+                <field name='name'>252.07 Hipotecas por pagar a largo plazo nacional</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_252_08' model='account.account.tag'>
+                <field name='name'>252.08 Hipotecas por pagar a largo plazo extranjero</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_252_09' model='account.account.tag'>
+                <field name='name'>252.09 Hipotecas por pagar a largo plazo nacional parte relacionada</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_252_10' model='account.account.tag'>
+                <field name='name'>252.10 Hipotecas por pagar a largo plazo extranjero parte relacionada</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_252_11' model='account.account.tag'>
+                <field name='name'>252.11 Intereses por pagar a largo plazo nacional</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_252_12' model='account.account.tag'>
+                <field name='name'>252.12 Intereses por pagar a largo plazo extranjero</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_252_13' model='account.account.tag'>
+                <field name='name'>252.13 Intereses por pagar a largo plazo nacional parte relacionada</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_252_14' model='account.account.tag'>
+                <field name='name'>252.14 Intereses por pagar a largo plazo extranjero parte relacionada</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_252_15' model='account.account.tag'>
+                <field name='name'>252.15 Dividendos por pagar nacionales</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_252_16' model='account.account.tag'>
+                <field name='name'>252.16 Dividendos por pagar extranjeros</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_252_17' model='account.account.tag'>
+                <field name='name'>252.17 Otras cuentas y documentos por pagar a largo plazo</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_253' model='account.account.tag'>
+                <field name='name'>253 Cobros anticipados a largo plazo</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_253_01' model='account.account.tag'>
+                <field name='name'>253.01 Rentas cobradas por anticipado a largo plazo nacional</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_253_02' model='account.account.tag'>
+                <field name='name'>253.02 Rentas cobradas por anticipado a largo plazo extranjero</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_253_03' model='account.account.tag'>
+                <field name='name'>253.03 Rentas cobradas por anticipado a largo plazo nacional parte relacionada</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_253_04' model='account.account.tag'>
+                <field name='name'>253.04 Rentas cobradas por anticipado a largo plazo extranjero parte relacionada</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_253_05' model='account.account.tag'>
+                <field name='name'>253.05 Intereses cobrados por anticipado a largo plazo nacional</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_253_06' model='account.account.tag'>
+                <field name='name'>253.06 Intereses cobrados por anticipado a largo plazo extranjero</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_253_07' model='account.account.tag'>
+                <field name='name'>253.07 Intereses cobrados por anticipado a largo plazo nacional parte relacionada</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_253_08' model='account.account.tag'>
+                <field name='name'>253.08 Intereses cobrados por anticipado a largo plazo extranjero parte relacionada</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_253_09' model='account.account.tag'>
+                <field name='name'>253.09 Factoraje financiero cobrados por anticipado a largo plazo nacional</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_253_10' model='account.account.tag'>
+                <field name='name'>253.10 Factoraje financiero cobrados por anticipado a largo plazo extranjero</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_253_11' model='account.account.tag'>
+                <field name='name'>253.11 Factoraje financiero cobrados por anticipado a largo plazo nacional parte relacionada</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_253_12' model='account.account.tag'>
+                <field name='name'>253.12 Factoraje financiero cobrados por anticipado a largo plazo extranjero parte relacionada</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_253_13' model='account.account.tag'>
+                <field name='name'>253.13 Arrendamiento financiero cobrados por anticipado a largo plazo nacional</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_253_14' model='account.account.tag'>
+                <field name='name'>253.14 Arrendamiento financiero cobrados por anticipado a largo plazo extranjero</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_253_15' model='account.account.tag'>
+                <field name='name'>253.15 Arrendamiento financiero cobrados por anticipado a largo plazo nacional parte relacionada</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_253_16' model='account.account.tag'>
+                <field name='name'>253.16 Arrendamiento financiero cobrados por anticipado a largo plazo extranjero parte relacionada</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_253_17' model='account.account.tag'>
+                <field name='name'>253.17 Derechos fiduciarios</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_253_18' model='account.account.tag'>
+                <field name='name'>253.18 Otros cobros anticipados</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_254' model='account.account.tag'>
+                <field name='name'>254 Instrumentos financieros a largo plazo</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_254_01' model='account.account.tag'>
+                <field name='name'>254.01 Instrumentos financieros a largo plazo</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_255' model='account.account.tag'>
+                <field name='name'>255 Pasivos por beneficios a los empleados a largo plazo</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_255_01' model='account.account.tag'>
+                <field name='name'>255.01 Pasivos por beneficios a los empleados a largo plazo</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_256' model='account.account.tag'>
+                <field name='name'>256 Otros pasivos a largo plazo</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_256_01' model='account.account.tag'>
+                <field name='name'>256.01 Otros pasivos a largo plazo</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_257' model='account.account.tag'>
+                <field name='name'>257 Participación de los trabajadores en las utilidades diferida</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_257_01' model='account.account.tag'>
+                <field name='name'>257.01 Participación de los trabajadores en las utilidades diferida</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_258' model='account.account.tag'>
+                <field name='name'>258 Obligaciones contraídas de fideicomisos</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_258_01' model='account.account.tag'>
+                <field name='name'>258.01 Obligaciones contraídas de fideicomisos</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_259' model='account.account.tag'>
+                <field name='name'>259 Impuestos diferidos</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_259_01' model='account.account.tag'>
+                <field name='name'>259.01 ISR diferido</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_259_02' model='account.account.tag'>
+                <field name='name'>259.02 ISR por dividendo diferido</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_259_03' model='account.account.tag'>
+                <field name='name'>259.03 Otros impuestos diferidos</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_260' model='account.account.tag'>
+                <field name='name'>260 Pasivos diferidos</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_260_01' model='account.account.tag'>
+                <field name='name'>260.01 Pasivos diferidos</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_300' model='account.account.tag'>
+                <field name='name'>300 Capital contable</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_301' model='account.account.tag'>
+                <field name='name'>301 Capital social</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_301_01' model='account.account.tag'>
+                <field name='name'>301.01 Capital fijo</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_301_02' model='account.account.tag'>
+                <field name='name'>301.02 Capital variable</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_301_03' model='account.account.tag'>
+                <field name='name'>301.03 Aportaciones para futuros aumentos de capital</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_301_04' model='account.account.tag'>
+                <field name='name'>301.04 Prima en suscripción de acciones</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_301_05' model='account.account.tag'>
+                <field name='name'>301.05 Prima en suscripción de partes sociales</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_302' model='account.account.tag'>
+                <field name='name'>302 Patrimonio</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_302_01' model='account.account.tag'>
+                <field name='name'>302.01 Patrimonio</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_302_02' model='account.account.tag'>
+                <field name='name'>302.02 Aportación patrimonial</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_302_03' model='account.account.tag'>
+                <field name='name'>302.03 Déficit o remanente del ejercicio</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_303' model='account.account.tag'>
+                <field name='name'>303 Reserva legal</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_303_01' model='account.account.tag'>
+                <field name='name'>303.01 Reserva legal</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_304' model='account.account.tag'>
+                <field name='name'>304 Resultado de ejercicios anteriores</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_304_01' model='account.account.tag'>
+                <field name='name'>304.01 Utilidad de ejercicios anteriores</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_304_02' model='account.account.tag'>
+                <field name='name'>304.02 Pérdida de ejercicios anteriores</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_304_03' model='account.account.tag'>
+                <field name='name'>304.03 Resultado integral de ejercicios anteriores</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_304_04' model='account.account.tag'>
+                <field name='name'>304.04 Déficit o remanente de ejercicio anteriores</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_305' model='account.account.tag'>
+                <field name='name'>305 Resultado del ejercicio</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_305_01' model='account.account.tag'>
+                <field name='name'>305.01 Utilidad del ejercicio</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_305_02' model='account.account.tag'>
+                <field name='name'>305.02 Pérdida del ejercicio</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_305_03' model='account.account.tag'>
+                <field name='name'>305.03 Resultado integral</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_306' model='account.account.tag'>
+                <field name='name'>306 Otras cuentas de capital</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_306_01' model='account.account.tag'>
+                <field name='name'>306.01 Otras cuentas de capital</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_400' model='account.account.tag'>
+                <field name='name'>400 Ingresos</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_401' model='account.account.tag'>
+                <field name='name'>401 Ingresos</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_401_01' model='account.account.tag'>
+                <field name='name'>401.01 Ventas y/o servicios gravados a la tasa general</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_401_02' model='account.account.tag'>
+                <field name='name'>401.02 Ventas y/o servicios gravados a la tasa general de contado</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_401_03' model='account.account.tag'>
+                <field name='name'>401.03 Ventas y/o servicios gravados a la tasa general a crédito</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_401_04' model='account.account.tag'>
+                <field name='name'>401.04 Ventas y/o servicios gravados al 0%</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_401_05' model='account.account.tag'>
+                <field name='name'>401.05 Ventas y/o servicios gravados al 0% de contado</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_401_06' model='account.account.tag'>
+                <field name='name'>401.06 Ventas y/o servicios gravados al 0% a crédito</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_401_07' model='account.account.tag'>
+                <field name='name'>401.07 Ventas y/o servicios exentos</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_401_08' model='account.account.tag'>
+                <field name='name'>401.08 Ventas y/o servicios exentos de contado</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_401_09' model='account.account.tag'>
+                <field name='name'>401.09 Ventas y/o servicios exentos a crédito</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_401_10' model='account.account.tag'>
+                <field name='name'>401.10 Ventas y/o servicios gravados a la tasa general nacionales partes relacionadas</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_401_11' model='account.account.tag'>
+                <field name='name'>401.11 Ventas y/o servicios gravados a la tasa general extranjeros partes relacionadas</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_401_12' model='account.account.tag'>
+                <field name='name'>401.12 Ventas y/o servicios gravados al 0% nacionales partes relacionadas</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_401_13' model='account.account.tag'>
+                <field name='name'>401.13 Ventas y/o servicios gravados al 0% extranjeros partes relacionadas</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_401_14' model='account.account.tag'>
+                <field name='name'>401.14 Ventas y/o servicios exentos nacionales partes relacionadas</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_401_15' model='account.account.tag'>
+                <field name='name'>401.15 Ventas y/o servicios exentos extranjeros partes relacionadas</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_401_16' model='account.account.tag'>
+                <field name='name'>401.16 Ingresos por servicios administrativos</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_401_17' model='account.account.tag'>
+                <field name='name'>401.17 Ingresos por servicios administrativos nacionales partes relacionadas</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_401_18' model='account.account.tag'>
+                <field name='name'>401.18 Ingresos por servicios administrativos extranjeros partes relacionadas</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_401_19' model='account.account.tag'>
+                <field name='name'>401.19 Ingresos por servicios profesionales</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_401_20' model='account.account.tag'>
+                <field name='name'>401.20 Ingresos por servicios profesionales nacionales partes relacionadas</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_401_21' model='account.account.tag'>
+                <field name='name'>401.21 Ingresos por servicios profesionales extranjeros partes relacionadas</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_401_22' model='account.account.tag'>
+                <field name='name'>401.22 Ingresos por arrendamiento</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_401_23' model='account.account.tag'>
+                <field name='name'>401.23 Ingresos por arrendamiento nacionales partes relacionadas</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_401_24' model='account.account.tag'>
+                <field name='name'>401.24 Ingresos por arrendamiento extranjeros partes relacionadas</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_401_25' model='account.account.tag'>
+                <field name='name'>401.25 Ingresos por exportación</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_401_26' model='account.account.tag'>
+                <field name='name'>401.26 Ingresos por comisiones</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_401_27' model='account.account.tag'>
+                <field name='name'>401.27 Ingresos por maquila</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_401_28' model='account.account.tag'>
+                <field name='name'>401.28 Ingresos por coordinados</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_401_29' model='account.account.tag'>
+                <field name='name'>401.29 Ingresos por regalías</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_401_30' model='account.account.tag'>
+                <field name='name'>401.30 Ingresos por asistencia técnica</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_401_31' model='account.account.tag'>
+                <field name='name'>401.31 Ingresos por donativos</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_401_32' model='account.account.tag'>
+                <field name='name'>401.32 Ingresos por intereses (actividad propia)</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_401_33' model='account.account.tag'>
+                <field name='name'>401.33 Ingresos de copropiedad</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_401_34' model='account.account.tag'>
+                <field name='name'>401.34 Ingresos por fideicomisos</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_401_35' model='account.account.tag'>
+                <field name='name'>401.35 Ingresos por factoraje financiero</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_401_36' model='account.account.tag'>
+                <field name='name'>401.36 Ingresos por arrendamiento financiero</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_401_37' model='account.account.tag'>
+                <field name='name'>401.37 Ingresos de extranjeros con establecimiento en el país</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_401_38' model='account.account.tag'>
+                <field name='name'>401.38 Otros ingresos propios</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_402' model='account.account.tag'>
+                <field name='name'>402 Devoluciones, descuentos o bonificaciones sobre ingresos</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_402_01' model='account.account.tag'>
+                <field name='name'>402.01 Devoluciones, descuentos o bonificaciones sobre ventas y/o servicios a la tasa general</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_402_02' model='account.account.tag'>
+                <field name='name'>402.02 Devoluciones, descuentos o bonificaciones sobre ventas y/o servicios al 0%</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_402_03' model='account.account.tag'>
+                <field name='name'>402.03 Devoluciones, descuentos o bonificaciones sobre ventas y/o servicios exentos</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_402_04' model='account.account.tag'>
+                <field name='name'>402.04 Devoluciones, descuentos o bonificaciones de otros ingresos</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_403' model='account.account.tag'>
+                <field name='name'>403 Otros ingresos</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_403_01' model='account.account.tag'>
+                <field name='name'>403.01 Otros Ingresos</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_403_02' model='account.account.tag'>
+                <field name='name'>403.02 Otros ingresos nacionales parte relacionada</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_403_03' model='account.account.tag'>
+                <field name='name'>403.03 Otros ingresos extranjeros parte relacionada</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_403_04' model='account.account.tag'>
+                <field name='name'>403.04 Ingresos por operaciones discontinuas</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_403_05' model='account.account.tag'>
+                <field name='name'>403.05 Ingresos por condonación de adeudo</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_500' model='account.account.tag'>
+                <field name='name'>500 Costos</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_501' model='account.account.tag'>
+                <field name='name'>501 Costo de venta y/o servicio</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_501_01' model='account.account.tag'>
+                <field name='name'>501.01 Costo de venta</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_501_02' model='account.account.tag'>
+                <field name='name'>501.02 Costo de servicios (Mano de obra)</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_501_03' model='account.account.tag'>
+                <field name='name'>501.03 Materia prima directa utilizada para la producción</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_501_04' model='account.account.tag'>
+                <field name='name'>501.04 Materia prima consumida en el proceso productivo</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_501_05' model='account.account.tag'>
+                <field name='name'>501.05 Mano de obra directa consumida</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_501_06' model='account.account.tag'>
+                <field name='name'>501.06 Mano de obra directa</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_501_07' model='account.account.tag'>
+                <field name='name'>501.07 Cargos indirectos de producción</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_501_08' model='account.account.tag'>
+                <field name='name'>501.08 Otros conceptos de costo</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_502' model='account.account.tag'>
+                <field name='name'>502 Compras</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_502_01' model='account.account.tag'>
+                <field name='name'>502.01 Compras nacionales</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_502_02' model='account.account.tag'>
+                <field name='name'>502.02 Compras nacionales parte relacionada</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_502_03' model='account.account.tag'>
+                <field name='name'>502.03 Compras de Importación</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_502_04' model='account.account.tag'>
+                <field name='name'>502.04 Compras de Importación partes relacionadas</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_503' model='account.account.tag'>
+                <field name='name'>503 Devoluciones, descuentos o bonificaciones sobre compras</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_503_01' model='account.account.tag'>
+                <field name='name'>503.01 Devoluciones, descuentos o bonificaciones sobre compras</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_504' model='account.account.tag'>
+                <field name='name'>504 Otras cuentas de costos</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_504_01' model='account.account.tag'>
+                <field name='name'>504.01 Gastos indirectos de fabricación</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_504_02' model='account.account.tag'>
+                <field name='name'>504.02 Gastos indirectos de fabricación de partes relacionadas nacionales</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_504_03' model='account.account.tag'>
+                <field name='name'>504.03 Gastos indirectos de fabricación de partes relacionadas extranjeras</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_504_04' model='account.account.tag'>
+                <field name='name'>504.04 Otras cuentas de costos incurridos</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_504_05' model='account.account.tag'>
+                <field name='name'>504.05 Otras cuentas de costos incurridos con partes relacionadas nacionales</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_504_06' model='account.account.tag'>
+                <field name='name'>504.06 Otras cuentas de costos incurridos con partes relacionadas extranjeras</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_504_07' model='account.account.tag'>
+                <field name='name'>504.07 Depreciación de edificios</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_504_08' model='account.account.tag'>
+                <field name='name'>504.08 Depreciación de maquinaria y equipo</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_504_09' model='account.account.tag'>
+                <field name='name'>504.09 Depreciación de automóviles, autobuses, camiones de carga, tractocamiones, montacargas y remolques</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_504_10' model='account.account.tag'>
+                <field name='name'>504.10 Depreciación de mobiliario y equipo de oficina</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_504_11' model='account.account.tag'>
+                <field name='name'>504.11 Depreciación de equipo de cómputo</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_504_12' model='account.account.tag'>
+                <field name='name'>504.12 Depreciación de equipo de comunicación</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_504_13' model='account.account.tag'>
+                <field name='name'>504.13 Depreciación de activos biológicos, vegetales y semovientes</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_504_14' model='account.account.tag'>
+                <field name='name'>504.14 Depreciación de otros activos fijos</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_504_15' model='account.account.tag'>
+                <field name='name'>504.15 Depreciación de ferrocarriles</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_504_16' model='account.account.tag'>
+                <field name='name'>504.16 Depreciación de embarcaciones</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_504_17' model='account.account.tag'>
+                <field name='name'>504.17 Depreciación de aviones</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_504_18' model='account.account.tag'>
+                <field name='name'>504.18 Depreciación de troqueles, moldes, matrices y herramental</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_504_19' model='account.account.tag'>
+                <field name='name'>504.19 Depreciación de equipo de comunicaciones telefónicas</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_504_20' model='account.account.tag'>
+                <field name='name'>504.20 Depreciación de equipo de comunicación satelital</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_504_21' model='account.account.tag'>
+                <field name='name'>504.21 Depreciación de equipo de adaptaciones para personas con capacidades diferentes</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_504_22' model='account.account.tag'>
+                <field name='name'>504.22 Depreciación de maquinaria y equipo de generación de energía de fuentes renovables o de sistemas de cogeneración de electricidad eficiente</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_504_23' model='account.account.tag'>
+                <field name='name'>504.23 Depreciación de adaptaciones y mejoras</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_504_24' model='account.account.tag'>
+                <field name='name'>504.24 Depreciación de otra maquinaria y equipo</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_504_25' model='account.account.tag'>
+                <field name='name'>504.25 Otras cuentas de costos</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_505' model='account.account.tag'>
+                <field name='name'>505 Costo de activo fijo</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_505_01' model='account.account.tag'>
+                <field name='name'>505.01 Costo por venta de activo fijo</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_505_02' model='account.account.tag'>
+                <field name='name'>505.02 Costo por baja de activo fijo</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_600' model='account.account.tag'>
+                <field name='name'>600 Gastos</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_601' model='account.account.tag'>
+                <field name='name'>601 Gastos generales</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_601_01' model='account.account.tag'>
+                <field name='name'>601.01 Sueldos y salarios</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_601_02' model='account.account.tag'>
+                <field name='name'>601.02 Compensaciones</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_601_03' model='account.account.tag'>
+                <field name='name'>601.03 Tiempos extras</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_601_04' model='account.account.tag'>
+                <field name='name'>601.04 Premios de asistencia</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_601_05' model='account.account.tag'>
+                <field name='name'>601.05 Premios de puntualidad</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_601_06' model='account.account.tag'>
+                <field name='name'>601.06 Vacaciones</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_601_07' model='account.account.tag'>
+                <field name='name'>601.07 Prima vacacional</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_601_08' model='account.account.tag'>
+                <field name='name'>601.08 Prima dominical</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_601_09' model='account.account.tag'>
+                <field name='name'>601.09 Días festivos</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_601_10' model='account.account.tag'>
+                <field name='name'>601.10 Gratificaciones</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_601_11' model='account.account.tag'>
+                <field name='name'>601.11 Primas de antigüedad</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_601_12' model='account.account.tag'>
+                <field name='name'>601.12 Aguinaldo</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_601_13' model='account.account.tag'>
+                <field name='name'>601.13 Indemnizaciones</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_601_14' model='account.account.tag'>
+                <field name='name'>601.14 Destajo</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_601_15' model='account.account.tag'>
+                <field name='name'>601.15 Despensa</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_601_16' model='account.account.tag'>
+                <field name='name'>601.16 Transporte</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_601_17' model='account.account.tag'>
+                <field name='name'>601.17 Servicio médico</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_601_18' model='account.account.tag'>
+                <field name='name'>601.18 Ayuda en gastos funerarios</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_601_19' model='account.account.tag'>
+                <field name='name'>601.19 Fondo de ahorro</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_601_20' model='account.account.tag'>
+                <field name='name'>601.20 Cuotas sindicales</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_601_21' model='account.account.tag'>
+                <field name='name'>601.21 PTU</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_601_22' model='account.account.tag'>
+                <field name='name'>601.22 Estímulo al personal</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_601_23' model='account.account.tag'>
+                <field name='name'>601.23 Previsión social</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_601_24' model='account.account.tag'>
+                <field name='name'>601.24 Aportaciones para el plan de jubilación</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_601_25' model='account.account.tag'>
+                <field name='name'>601.25 Otras prestaciones al personal</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_601_26' model='account.account.tag'>
+                <field name='name'>601.26 Cuotas al IMSS</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_601_27' model='account.account.tag'>
+                <field name='name'>601.27 Aportaciones al infonavit</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_601_28' model='account.account.tag'>
+                <field name='name'>601.28 Aportaciones al SAR</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_601_29' model='account.account.tag'>
+                <field name='name'>601.29 Impuesto estatal sobre nóminas</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_601_30' model='account.account.tag'>
+                <field name='name'>601.30 Otras aportaciones</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_601_31' model='account.account.tag'>
+                <field name='name'>601.31 Asimilados a salarios</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_601_32' model='account.account.tag'>
+                <field name='name'>601.32 Servicios administrativos</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_601_33' model='account.account.tag'>
+                <field name='name'>601.33 Servicios administrativos partes relacionadas</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_601_34' model='account.account.tag'>
+                <field name='name'>601.34 Honorarios a personas físicas residentes nacionales</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_601_35' model='account.account.tag'>
+                <field name='name'>601.35 Honorarios a personas físicas residentes nacionales partes relacionadas</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_601_36' model='account.account.tag'>
+                <field name='name'>601.36 Honorarios a personas físicas residentes del extranjero</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_601_37' model='account.account.tag'>
+                <field name='name'>601.37 Honorarios a personas físicas residentes del extranjero partes relacionadas</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_601_38' model='account.account.tag'>
+                <field name='name'>601.38 Honorarios a personas morales residentes nacionales</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_601_39' model='account.account.tag'>
+                <field name='name'>601.39 Honorarios a personas morales residentes nacionales partes relacionadas</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_601_40' model='account.account.tag'>
+                <field name='name'>601.40 Honorarios a personas morales residentes del extranjero</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_601_41' model='account.account.tag'>
+                <field name='name'>601.41 Honorarios a personas morales residentes del extranjero partes relacionadas</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_601_42' model='account.account.tag'>
+                <field name='name'>601.42 Honorarios aduanales personas físicas</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_601_43' model='account.account.tag'>
+                <field name='name'>601.43 Honorarios aduanales personas morales</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_601_44' model='account.account.tag'>
+                <field name='name'>601.44 Honorarios al consejo de administración</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_601_45' model='account.account.tag'>
+                <field name='name'>601.45 Arrendamiento a personas físicas residentes nacionales</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_601_46' model='account.account.tag'>
+                <field name='name'>601.46 Arrendamiento a personas morales residentes nacionales</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_601_47' model='account.account.tag'>
+                <field name='name'>601.47 Arrendamiento a residentes del extranjero</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_601_48' model='account.account.tag'>
+                <field name='name'>601.48 Combustibles y lubricantes</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_601_49' model='account.account.tag'>
+                <field name='name'>601.49 Viáticos y gastos de viaje</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_601_50' model='account.account.tag'>
+                <field name='name'>601.50 Teléfono, internet</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_601_51' model='account.account.tag'>
+                <field name='name'>601.51 Agua</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_601_52' model='account.account.tag'>
+                <field name='name'>601.52 Energía eléctrica</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_601_53' model='account.account.tag'>
+                <field name='name'>601.53 Vigilancia y seguridad</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_601_54' model='account.account.tag'>
+                <field name='name'>601.54 Limpieza</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_601_55' model='account.account.tag'>
+                <field name='name'>601.55 Papelería y artículos de oficina</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_601_56' model='account.account.tag'>
+                <field name='name'>601.56 Mantenimiento y conservación</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_601_57' model='account.account.tag'>
+                <field name='name'>601.57 Seguros y fianzas</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_601_58' model='account.account.tag'>
+                <field name='name'>601.58 Otros impuestos y derechos</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_601_59' model='account.account.tag'>
+                <field name='name'>601.59 Recargos fiscales</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_601_60' model='account.account.tag'>
+                <field name='name'>601.60 Cuotas y suscripciones</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_601_61' model='account.account.tag'>
+                <field name='name'>601.61 Propaganda y publicidad</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_601_62' model='account.account.tag'>
+                <field name='name'>601.62 Capacitación al personal</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_601_63' model='account.account.tag'>
+                <field name='name'>601.63 Donativos y ayudas</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_601_64' model='account.account.tag'>
+                <field name='name'>601.64 Asistencia técnica</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_601_65' model='account.account.tag'>
+                <field name='name'>601.65 Regalías sujetas a otros porcentajes</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_601_66' model='account.account.tag'>
+                <field name='name'>601.66 Regalías sujetas al 5%</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_601_67' model='account.account.tag'>
+                <field name='name'>601.67 Regalías sujetas al 10%</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_601_68' model='account.account.tag'>
+                <field name='name'>601.68 Regalías sujetas al 15%</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_601_69' model='account.account.tag'>
+                <field name='name'>601.69 Regalías sujetas al 25%</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_601_70' model='account.account.tag'>
+                <field name='name'>601.70 Regalías sujetas al 30%</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_601_71' model='account.account.tag'>
+                <field name='name'>601.71 Regalías sin retención</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_601_72' model='account.account.tag'>
+                <field name='name'>601.72 Fletes y acarreos</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_601_73' model='account.account.tag'>
+                <field name='name'>601.73 Gastos de importación</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_601_74' model='account.account.tag'>
+                <field name='name'>601.74 Comisiones sobre ventas</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_601_75' model='account.account.tag'>
+                <field name='name'>601.75 Comisiones por tarjetas de crédito</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_601_76' model='account.account.tag'>
+                <field name='name'>601.76 Patentes y marcas</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_601_77' model='account.account.tag'>
+                <field name='name'>601.77 Uniformes</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_601_78' model='account.account.tag'>
+                <field name='name'>601.78 Prediales</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_601_79' model='account.account.tag'>
+                <field name='name'>601.79 Gastos generales de urbanización</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_601_80' model='account.account.tag'>
+                <field name='name'>601.80 Gastos generales de construcción</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_601_81' model='account.account.tag'>
+                <field name='name'>601.81 Fletes del extranjero</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_601_82' model='account.account.tag'>
+                <field name='name'>601.82 Recolección de bienes del sector agropecuario y/o ganadero</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_601_83' model='account.account.tag'>
+                <field name='name'>601.83 Gastos no deducibles (sin requisitos fiscales)</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_601_84' model='account.account.tag'>
+                <field name='name'>601.84 Otros gastos generales</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_602' model='account.account.tag'>
+                <field name='name'>602 Gastos de venta</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_602_01' model='account.account.tag'>
+                <field name='name'>602.01 Sueldos y salarios</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_602_02' model='account.account.tag'>
+                <field name='name'>602.02 Compensaciones</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_602_03' model='account.account.tag'>
+                <field name='name'>602.03 Tiempos extras</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_602_04' model='account.account.tag'>
+                <field name='name'>602.04 Premios de asistencia</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_602_05' model='account.account.tag'>
+                <field name='name'>602.05 Premios de puntualidad</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_602_06' model='account.account.tag'>
+                <field name='name'>602.06 Vacaciones</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_602_07' model='account.account.tag'>
+                <field name='name'>602.07 Prima vacacional</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_602_08' model='account.account.tag'>
+                <field name='name'>602.08 Prima dominical</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_602_09' model='account.account.tag'>
+                <field name='name'>602.09 Días festivos</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_602_10' model='account.account.tag'>
+                <field name='name'>602.10 Gratificaciones</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_602_11' model='account.account.tag'>
+                <field name='name'>602.11 Primas de antigüedad</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_602_12' model='account.account.tag'>
+                <field name='name'>602.12 Aguinaldo</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_602_13' model='account.account.tag'>
+                <field name='name'>602.13 Indemnizaciones</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_602_14' model='account.account.tag'>
+                <field name='name'>602.14 Destajo</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_602_15' model='account.account.tag'>
+                <field name='name'>602.15 Despensa</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_602_16' model='account.account.tag'>
+                <field name='name'>602.16 Transporte</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_602_17' model='account.account.tag'>
+                <field name='name'>602.17 Servicio médico</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_602_18' model='account.account.tag'>
+                <field name='name'>602.18 Ayuda en gastos funerarios</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_602_19' model='account.account.tag'>
+                <field name='name'>602.19 Fondo de ahorro</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_602_20' model='account.account.tag'>
+                <field name='name'>602.20 Cuotas sindicales</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_602_21' model='account.account.tag'>
+                <field name='name'>602.21 PTU</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_602_22' model='account.account.tag'>
+                <field name='name'>602.22 Estímulo al personal</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_602_23' model='account.account.tag'>
+                <field name='name'>602.23 Previsión social</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_602_24' model='account.account.tag'>
+                <field name='name'>602.24 Aportaciones para el plan de jubilación</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_602_25' model='account.account.tag'>
+                <field name='name'>602.25 Otras prestaciones al personal</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_602_26' model='account.account.tag'>
+                <field name='name'>602.26 Cuotas al IMSS</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_602_27' model='account.account.tag'>
+                <field name='name'>602.27 Aportaciones al infonavit</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_602_28' model='account.account.tag'>
+                <field name='name'>602.28 Aportaciones al SAR</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_602_29' model='account.account.tag'>
+                <field name='name'>602.29 Impuesto estatal sobre nóminas</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_602_30' model='account.account.tag'>
+                <field name='name'>602.30 Otras aportaciones</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_602_31' model='account.account.tag'>
+                <field name='name'>602.31 Asimilados a salarios</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_602_32' model='account.account.tag'>
+                <field name='name'>602.32 Servicios administrativos</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_602_33' model='account.account.tag'>
+                <field name='name'>602.33 Servicios administrativos partes relacionadas</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_602_34' model='account.account.tag'>
+                <field name='name'>602.34 Honorarios a personas físicas residentes nacionales</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_602_35' model='account.account.tag'>
+                <field name='name'>602.35 Honorarios a personas físicas residentes nacionales partes relacionadas</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_602_36' model='account.account.tag'>
+                <field name='name'>602.36 Honorarios a personas físicas residentes del extranjero</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_602_37' model='account.account.tag'>
+                <field name='name'>602.37 Honorarios a personas físicas residentes del extranjero partes relacionadas</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_602_38' model='account.account.tag'>
+                <field name='name'>602.38 Honorarios a personas morales residentes nacionales</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_602_39' model='account.account.tag'>
+                <field name='name'>602.39 Honorarios a personas morales residentes nacionales partes relacionadas</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_602_40' model='account.account.tag'>
+                <field name='name'>602.40 Honorarios a personas morales residentes del extranjero</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_602_41' model='account.account.tag'>
+                <field name='name'>602.41 Honorarios a personas morales residentes del extranjero partes relacionadas</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_602_42' model='account.account.tag'>
+                <field name='name'>602.42 Honorarios aduanales personas físicas</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_602_43' model='account.account.tag'>
+                <field name='name'>602.43 Honorarios aduanales personas morales</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_602_44' model='account.account.tag'>
+                <field name='name'>602.44 Honorarios al consejo de administración</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_602_45' model='account.account.tag'>
+                <field name='name'>602.45 Arrendamiento a personas físicas residentes nacionales</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_602_46' model='account.account.tag'>
+                <field name='name'>602.46 Arrendamiento a personas morales residentes nacionales</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_602_47' model='account.account.tag'>
+                <field name='name'>602.47 Arrendamiento a residentes del extranjero</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_602_48' model='account.account.tag'>
+                <field name='name'>602.48 Combustibles y lubricantes</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_602_49' model='account.account.tag'>
+                <field name='name'>602.49 Viáticos y gastos de viaje</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_602_50' model='account.account.tag'>
+                <field name='name'>602.50 Teléfono, internet</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_602_51' model='account.account.tag'>
+                <field name='name'>602.51 Agua</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_602_52' model='account.account.tag'>
+                <field name='name'>602.52 Energía eléctrica</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_602_53' model='account.account.tag'>
+                <field name='name'>602.53 Vigilancia y seguridad</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_602_54' model='account.account.tag'>
+                <field name='name'>602.54 Limpieza</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_602_55' model='account.account.tag'>
+                <field name='name'>602.55 Papelería y artículos de oficina</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_602_56' model='account.account.tag'>
+                <field name='name'>602.56 Mantenimiento y conservación</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_602_57' model='account.account.tag'>
+                <field name='name'>602.57 Seguros y fianzas</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_602_58' model='account.account.tag'>
+                <field name='name'>602.58 Otros impuestos y derechos</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_602_59' model='account.account.tag'>
+                <field name='name'>602.59 Recargos fiscales</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_602_60' model='account.account.tag'>
+                <field name='name'>602.60 Cuotas y suscripciones</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_602_61' model='account.account.tag'>
+                <field name='name'>602.61 Propaganda y publicidad</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_602_62' model='account.account.tag'>
+                <field name='name'>602.62 Capacitación al personal</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_602_63' model='account.account.tag'>
+                <field name='name'>602.63 Donativos y ayudas</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_602_64' model='account.account.tag'>
+                <field name='name'>602.64 Asistencia técnica</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_602_65' model='account.account.tag'>
+                <field name='name'>602.65 Regalías sujetas a otros porcentajes</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_602_66' model='account.account.tag'>
+                <field name='name'>602.66 Regalías sujetas al 5%</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_602_67' model='account.account.tag'>
+                <field name='name'>602.67 Regalías sujetas al 10%</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_602_68' model='account.account.tag'>
+                <field name='name'>602.68 Regalías sujetas al 15%</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_602_69' model='account.account.tag'>
+                <field name='name'>602.69 Regalías sujetas al 25%</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_602_70' model='account.account.tag'>
+                <field name='name'>602.70 Regalías sujetas al 30%</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_602_71' model='account.account.tag'>
+                <field name='name'>602.71 Regalías sin retención</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_602_72' model='account.account.tag'>
+                <field name='name'>602.72 Fletes y acarreos</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_602_73' model='account.account.tag'>
+                <field name='name'>602.73 Gastos de importación</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_602_74' model='account.account.tag'>
+                <field name='name'>602.74 Comisiones sobre ventas</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_602_75' model='account.account.tag'>
+                <field name='name'>602.75 Comisiones por tarjetas de crédito</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_602_76' model='account.account.tag'>
+                <field name='name'>602.76 Patentes y marcas</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_602_77' model='account.account.tag'>
+                <field name='name'>602.77 Uniformes</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_602_78' model='account.account.tag'>
+                <field name='name'>602.78 Prediales</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_602_79' model='account.account.tag'>
+                <field name='name'>602.79 Gastos de venta de urbanización</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_602_80' model='account.account.tag'>
+                <field name='name'>602.80 Gastos de venta de construcción</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_602_81' model='account.account.tag'>
+                <field name='name'>602.81 Fletes del extranjero</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_602_82' model='account.account.tag'>
+                <field name='name'>602.82 Recolección de bienes del sector agropecuario y/o ganadero</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_602_83' model='account.account.tag'>
+                <field name='name'>602.83 Gastos no deducibles (sin requisitos fiscales)</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_602_84' model='account.account.tag'>
+                <field name='name'>602.84 Otros gastos de venta</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_603' model='account.account.tag'>
+                <field name='name'>603 Gastos de administración</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_603_01' model='account.account.tag'>
+                <field name='name'>603.01 Sueldos y salarios</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_603_02' model='account.account.tag'>
+                <field name='name'>603.02 Compensaciones</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_603_03' model='account.account.tag'>
+                <field name='name'>603.03 Tiempos extras</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_603_04' model='account.account.tag'>
+                <field name='name'>603.04 Premios de asistencia</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_603_05' model='account.account.tag'>
+                <field name='name'>603.05 Premios de puntualidad</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_603_06' model='account.account.tag'>
+                <field name='name'>603.06 Vacaciones</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_603_07' model='account.account.tag'>
+                <field name='name'>603.07 Prima vacacional</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_603_08' model='account.account.tag'>
+                <field name='name'>603.08 Prima dominical</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_603_09' model='account.account.tag'>
+                <field name='name'>603.09 Días festivos</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_603_10' model='account.account.tag'>
+                <field name='name'>603.10 Gratificaciones</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_603_11' model='account.account.tag'>
+                <field name='name'>603.11 Primas de antigüedad</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_603_12' model='account.account.tag'>
+                <field name='name'>603.12 Aguinaldo</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_603_13' model='account.account.tag'>
+                <field name='name'>603.13 Indemnizaciones</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_603_14' model='account.account.tag'>
+                <field name='name'>603.14 Destajo</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_603_15' model='account.account.tag'>
+                <field name='name'>603.15 Despensa</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_603_16' model='account.account.tag'>
+                <field name='name'>603.16 Transporte</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_603_17' model='account.account.tag'>
+                <field name='name'>603.17 Servicio médico</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_603_18' model='account.account.tag'>
+                <field name='name'>603.18 Ayuda en gastos funerarios</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_603_19' model='account.account.tag'>
+                <field name='name'>603.19 Fondo de ahorro</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_603_20' model='account.account.tag'>
+                <field name='name'>603.20 Cuotas sindicales</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_603_21' model='account.account.tag'>
+                <field name='name'>603.21 PTU</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_603_22' model='account.account.tag'>
+                <field name='name'>603.22 Estímulo al personal</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_603_23' model='account.account.tag'>
+                <field name='name'>603.23 Previsión social</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_603_24' model='account.account.tag'>
+                <field name='name'>603.24 Aportaciones para el plan de jubilación</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_603_25' model='account.account.tag'>
+                <field name='name'>603.25 Otras prestaciones al personal</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_603_26' model='account.account.tag'>
+                <field name='name'>603.26 Cuotas al IMSS</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_603_27' model='account.account.tag'>
+                <field name='name'>603.27 Aportaciones al infonavit</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_603_28' model='account.account.tag'>
+                <field name='name'>603.28 Aportaciones al SAR</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_603_29' model='account.account.tag'>
+                <field name='name'>603.29 Impuesto estatal sobre nóminas</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_603_30' model='account.account.tag'>
+                <field name='name'>603.30 Otras aportaciones</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_603_31' model='account.account.tag'>
+                <field name='name'>603.31 Asimilados a salarios</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_603_32' model='account.account.tag'>
+                <field name='name'>603.32 Servicios administrativos</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_603_33' model='account.account.tag'>
+                <field name='name'>603.33 Servicios administrativos partes relacionadas</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_603_34' model='account.account.tag'>
+                <field name='name'>603.34 Honorarios a personas físicas residentes nacionales</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_603_35' model='account.account.tag'>
+                <field name='name'>603.35 Honorarios a personas físicas residentes nacionales partes relacionadas</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_603_36' model='account.account.tag'>
+                <field name='name'>603.36 Honorarios a personas físicas residentes del extranjero</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_603_37' model='account.account.tag'>
+                <field name='name'>603.37 Honorarios a personas físicas residentes del extranjero partes relacionadas</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_603_38' model='account.account.tag'>
+                <field name='name'>603.38 Honorarios a personas morales residentes nacionales</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_603_39' model='account.account.tag'>
+                <field name='name'>603.39 Honorarios a personas morales residentes nacionales partes relacionadas</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_603_40' model='account.account.tag'>
+                <field name='name'>603.40 Honorarios a personas morales residentes del extranjero</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_603_41' model='account.account.tag'>
+                <field name='name'>603.41 Honorarios a personas morales residentes del extranjero partes relacionadas</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_603_42' model='account.account.tag'>
+                <field name='name'>603.42 Honorarios aduanales personas físicas</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_603_43' model='account.account.tag'>
+                <field name='name'>603.43 Honorarios aduanales personas morales</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_603_44' model='account.account.tag'>
+                <field name='name'>603.44 Honorarios al consejo de administración</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_603_45' model='account.account.tag'>
+                <field name='name'>603.45 Arrendamiento a personas físicas residentes nacionales</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_603_46' model='account.account.tag'>
+                <field name='name'>603.46 Arrendamiento a personas morales residentes nacionales</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_603_47' model='account.account.tag'>
+                <field name='name'>603.47 Arrendamiento a residentes del extranjero</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_603_48' model='account.account.tag'>
+                <field name='name'>603.48 Combustibles y lubricantes</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_603_49' model='account.account.tag'>
+                <field name='name'>603.49 Viáticos y gastos de viaje</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_603_50' model='account.account.tag'>
+                <field name='name'>603.50 Teléfono, internet</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_603_51' model='account.account.tag'>
+                <field name='name'>603.51 Agua</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_603_52' model='account.account.tag'>
+                <field name='name'>603.52 Energía eléctrica</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_603_53' model='account.account.tag'>
+                <field name='name'>603.53 Vigilancia y seguridad</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_603_54' model='account.account.tag'>
+                <field name='name'>603.54 Limpieza</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_603_55' model='account.account.tag'>
+                <field name='name'>603.55 Papelería y artículos de oficina</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_603_56' model='account.account.tag'>
+                <field name='name'>603.56 Mantenimiento y conservación</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_603_57' model='account.account.tag'>
+                <field name='name'>603.57 Seguros y fianzas</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_603_58' model='account.account.tag'>
+                <field name='name'>603.58 Otros impuestos y derechos</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_603_59' model='account.account.tag'>
+                <field name='name'>603.59 Recargos fiscales</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_603_60' model='account.account.tag'>
+                <field name='name'>603.60 Cuotas y suscripciones</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_603_61' model='account.account.tag'>
+                <field name='name'>603.61 Propaganda y publicidad</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_603_62' model='account.account.tag'>
+                <field name='name'>603.62 Capacitación al personal</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_603_63' model='account.account.tag'>
+                <field name='name'>603.63 Donativos y ayudas</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_603_64' model='account.account.tag'>
+                <field name='name'>603.64 Asistencia técnica</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_603_65' model='account.account.tag'>
+                <field name='name'>Regalías sujetas a otros porcentajes</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_603_66' model='account.account.tag'>
+                <field name='name'>603.66 Regalías sujetas al 5%</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_603_67' model='account.account.tag'>
+                <field name='name'>603.67 Regalías sujetas al 10%</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_603_68' model='account.account.tag'>
+                <field name='name'>603.68 Regalías sujetas al 15%</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_603_69' model='account.account.tag'>
+                <field name='name'>603.69 Regalías sujetas al 25%</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_603_70' model='account.account.tag'>
+                <field name='name'>603.70 Regalías sujetas al 30%</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_603_71' model='account.account.tag'>
+                <field name='name'>603.71 Regalías sin retención</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_603_72' model='account.account.tag'>
+                <field name='name'>603.72 Fletes y acarreos</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_603_73' model='account.account.tag'>
+                <field name='name'>603.73 Gastos de importación</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_603_74' model='account.account.tag'>
+                <field name='name'>603.74 Patentes y marcas</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_603_75' model='account.account.tag'>
+                <field name='name'>603.75 Uniformes</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_603_76' model='account.account.tag'>
+                <field name='name'>603.76 Prediales</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_603_77' model='account.account.tag'>
+                <field name='name'>603.77 Gastos de administración de urbanización</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_603_78' model='account.account.tag'>
+                <field name='name'>603.78 Gastos de administración de construcción</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_603_79' model='account.account.tag'>
+                <field name='name'>603.79 Fletes del extranjero</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_603_80' model='account.account.tag'>
+                <field name='name'>603.80 Recolección de bienes del sector agropecuario y/o ganadero</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_603_81' model='account.account.tag'>
+                <field name='name'>603.81 Gastos no deducibles (sin requisitos fiscales)</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_603_82' model='account.account.tag'>
+                <field name='name'>603.82 Otros gastos de administración</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_604' model='account.account.tag'>
+                <field name='name'>604 Gastos de fabricación</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_604_01' model='account.account.tag'>
+                <field name='name'>604.01 Sueldos y salarios</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_604_02' model='account.account.tag'>
+                <field name='name'>604.02 Compensaciones</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_604_03' model='account.account.tag'>
+                <field name='name'>604.03 Tiempos extras</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_604_04' model='account.account.tag'>
+                <field name='name'>604.04 Premios de asistencia</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_604_05' model='account.account.tag'>
+                <field name='name'>604.05 Premios de puntualidad</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_604_06' model='account.account.tag'>
+                <field name='name'>604.06 Vacaciones</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_604_07' model='account.account.tag'>
+                <field name='name'>604.07 Prima vacacional</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_604_08' model='account.account.tag'>
+                <field name='name'>604.08 Prima dominical</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_604_09' model='account.account.tag'>
+                <field name='name'>604.09 Días festivos</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_604_10' model='account.account.tag'>
+                <field name='name'>604.10 Gratificaciones</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_604_11' model='account.account.tag'>
+                <field name='name'>604.11 Primas de antigüedad</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_604_12' model='account.account.tag'>
+                <field name='name'>604.12 Aguinaldo</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_604_13' model='account.account.tag'>
+                <field name='name'>604.13 Indemnizaciones</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_604_14' model='account.account.tag'>
+                <field name='name'>604.14 Destajo</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_604_15' model='account.account.tag'>
+                <field name='name'>604.15 Despensa</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_604_16' model='account.account.tag'>
+                <field name='name'>604.16 Transporte</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_604_17' model='account.account.tag'>
+                <field name='name'>604.17 Servicio médico</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_604_18' model='account.account.tag'>
+                <field name='name'>604.18 Ayuda en gastos funerarios</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_604_19' model='account.account.tag'>
+                <field name='name'>604.19 Fondo de ahorro</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_604_20' model='account.account.tag'>
+                <field name='name'>604.20 Cuotas sindicales</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_604_21' model='account.account.tag'>
+                <field name='name'>604.21 PTU</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_604_22' model='account.account.tag'>
+                <field name='name'>604.22 Estímulo al personal</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_604_23' model='account.account.tag'>
+                <field name='name'>604.23 Previsión social</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_604_24' model='account.account.tag'>
+                <field name='name'>604.24 Aportaciones para el plan de jubilación</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_604_25' model='account.account.tag'>
+                <field name='name'>604.25 Otras prestaciones al personal</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_604_26' model='account.account.tag'>
+                <field name='name'>604.26 Cuotas al IMSS</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_604_27' model='account.account.tag'>
+                <field name='name'>604.27 Aportaciones al infonavit</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_604_28' model='account.account.tag'>
+                <field name='name'>604.28 Aportaciones al SAR</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_604_29' model='account.account.tag'>
+                <field name='name'>604.29 Impuesto estatal sobre nóminas</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_604_30' model='account.account.tag'>
+                <field name='name'>604.30 Otras aportaciones</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_604_31' model='account.account.tag'>
+                <field name='name'>604.31 Asimilados a salarios</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_604_32' model='account.account.tag'>
+                <field name='name'>604.32 Servicios administrativos</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_604_33' model='account.account.tag'>
+                <field name='name'>604.33 Servicios administrativos partes relacionadas</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_604_34' model='account.account.tag'>
+                <field name='name'>604.34 Honorarios a personas físicas residentes nacionales</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_604_35' model='account.account.tag'>
+                <field name='name'>604.35 Honorarios a personas físicas residentes nacionales partes relacionadas</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_604_36' model='account.account.tag'>
+                <field name='name'>604.36 Honorarios a personas físicas residentes del extranjero</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_604_37' model='account.account.tag'>
+                <field name='name'>604.37 Honorarios a personas físicas residentes del extranjero partes relacionadas</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_604_38' model='account.account.tag'>
+                <field name='name'>604.38 Honorarios a personas morales residentes nacionales</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_604_39' model='account.account.tag'>
+                <field name='name'>604.39 Honorarios a personas morales residentes nacionales partes relacionadas</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_604_40' model='account.account.tag'>
+                <field name='name'>604.40 Honorarios a personas morales residentes del extranjero</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_604_41' model='account.account.tag'>
+                <field name='name'>604.41 Honorarios a personas morales residentes del extranjero partes relacionadas</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_604_42' model='account.account.tag'>
+                <field name='name'>604.42 Honorarios aduanales personas físicas</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_604_43' model='account.account.tag'>
+                <field name='name'>604.43 Honorarios aduanales personas morales</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_604_44' model='account.account.tag'>
+                <field name='name'>604.44 Honorarios al consejo de administración</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_604_45' model='account.account.tag'>
+                <field name='name'>604.45 Arrendamiento a personas físicas residentes nacionales</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_604_46' model='account.account.tag'>
+                <field name='name'>604.46 Arrendamiento a personas morales residentes nacionales</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_604_47' model='account.account.tag'>
+                <field name='name'>604.47 Arrendamiento a residentes del extranjero</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_604_48' model='account.account.tag'>
+                <field name='name'>604.48 Combustibles y lubricantes</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_604_49' model='account.account.tag'>
+                <field name='name'>604.49 Viáticos y gastos de viaje</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_604_50' model='account.account.tag'>
+                <field name='name'>604.50 Teléfono, internet</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_604_51' model='account.account.tag'>
+                <field name='name'>604.51 Agua</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_604_52' model='account.account.tag'>
+                <field name='name'>604.52 Energía eléctrica</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_604_53' model='account.account.tag'>
+                <field name='name'>604.53 Vigilancia y seguridad</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_604_54' model='account.account.tag'>
+                <field name='name'>604.54 Limpieza</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_604_55' model='account.account.tag'>
+                <field name='name'>604.55 Papelería y artículos de oficina</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_604_56' model='account.account.tag'>
+                <field name='name'>604.56 Mantenimiento y conservación</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_604_57' model='account.account.tag'>
+                <field name='name'>604.57 Seguros y fianzas</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_604_58' model='account.account.tag'>
+                <field name='name'>604.58 Otros impuestos y derechos</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_604_59' model='account.account.tag'>
+                <field name='name'>604.59 Recargos fiscales</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_604_60' model='account.account.tag'>
+                <field name='name'>604.60 Cuotas y suscripciones</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_604_61' model='account.account.tag'>
+                <field name='name'>604.61 Propaganda y publicidad</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_604_62' model='account.account.tag'>
+                <field name='name'>604.62 Capacitación al personal</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_604_63' model='account.account.tag'>
+                <field name='name'>604.63 Donativos y ayudas</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_604_64' model='account.account.tag'>
+                <field name='name'>604.64 Asistencia técnica</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_604_65' model='account.account.tag'>
+                <field name='name'>604.65 Regalías sujetas a otros porcentajes</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_604_66' model='account.account.tag'>
+                <field name='name'>604.66 Regalías sujetas al 5%</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_604_67' model='account.account.tag'>
+                <field name='name'>604.67 Regalías sujetas al 10%</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_604_68' model='account.account.tag'>
+                <field name='name'>604.68 Regalías sujetas al 15%</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_604_69' model='account.account.tag'>
+                <field name='name'>604.69 Regalías sujetas al 25%</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_604_70' model='account.account.tag'>
+                <field name='name'>604.70 Regalías sujetas al 30%</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_604_71' model='account.account.tag'>
+                <field name='name'>604.71 Regalías sin retención</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_604_72' model='account.account.tag'>
+                <field name='name'>604.72 Fletes y acarreos</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_604_73' model='account.account.tag'>
+                <field name='name'>604.73 Gastos de importación</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_604_74' model='account.account.tag'>
+                <field name='name'>604.74 Patentes y marcas</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_604_75' model='account.account.tag'>
+                <field name='name'>604.75 Uniformes</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_604_76' model='account.account.tag'>
+                <field name='name'>604.76 Prediales</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_604_77' model='account.account.tag'>
+                <field name='name'>604.77 Gastos de fabricación de urbanización</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_604_78' model='account.account.tag'>
+                <field name='name'>604.78 Gastos de fabricación de construcción</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_604_79' model='account.account.tag'>
+                <field name='name'>604.79 Fletes del extranjero</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_604_80' model='account.account.tag'>
+                <field name='name'>604.80 Recolección de bienes del sector agropecuario y/o ganadero</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_604_81' model='account.account.tag'>
+                <field name='name'>604.81 Gastos no deducibles (sin requisitos fiscales)</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_604_82' model='account.account.tag'>
+                <field name='name'>604.82 Otros gastos de fabricación</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_605' model='account.account.tag'>
+                <field name='name'>605 Mano de obra directa</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_605_01' model='account.account.tag'>
+                <field name='name'>605.01 Mano de obra</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_605_02' model='account.account.tag'>
+                <field name='name'>605.02 Sueldos y Salarios</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_605_03' model='account.account.tag'>
+                <field name='name'>605.03 Compensaciones</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_605_04' model='account.account.tag'>
+                <field name='name'>605.04 Tiempos extras</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_605_05' model='account.account.tag'>
+                <field name='name'>605.05 Premios de asistencia</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_605_06' model='account.account.tag'>
+                <field name='name'>605.06 Premios de puntualidad</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_605_07' model='account.account.tag'>
+                <field name='name'>605.07 Vacaciones</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_605_08' model='account.account.tag'>
+                <field name='name'>605.08 Prima vacacional</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_605_09' model='account.account.tag'>
+                <field name='name'>605.09 Prima dominical</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_605_10' model='account.account.tag'>
+                <field name='name'>605.10 Días festivos</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_605_11' model='account.account.tag'>
+                <field name='name'>605.11 Gratificaciones</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_605_12' model='account.account.tag'>
+                <field name='name'>605.12 Primas de antigüedad</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_605_13' model='account.account.tag'>
+                <field name='name'>605.13 Aguinaldo</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_605_14' model='account.account.tag'>
+                <field name='name'>605.14 Indemnizaciones</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_605_15' model='account.account.tag'>
+                <field name='name'>605.15 Destajo</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_605_16' model='account.account.tag'>
+                <field name='name'>605.16 Despensa</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_605_17' model='account.account.tag'>
+                <field name='name'>605.17 Transporte</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_605_18' model='account.account.tag'>
+                <field name='name'>605.18 Servicio médico</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_605_19' model='account.account.tag'>
+                <field name='name'>605.19 Ayuda en gastos funerarios</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_605_20' model='account.account.tag'>
+                <field name='name'>605.20 Fondo de ahorro</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_605_21' model='account.account.tag'>
+                <field name='name'>605.21 Cuotas sindicales</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_605_22' model='account.account.tag'>
+                <field name='name'>605.22 PTU</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_605_23' model='account.account.tag'>
+                <field name='name'>605.23 Estímulo al personal</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_605_24' model='account.account.tag'>
+                <field name='name'>605.24 Previsión social</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_605_25' model='account.account.tag'>
+                <field name='name'>605.25 Aportaciones para el plan de jubilación</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_605_26' model='account.account.tag'>
+                <field name='name'>605.26 Otras prestaciones al personal</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_605_27' model='account.account.tag'>
+                <field name='name'>605.27 Asimilados a salarios</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_605_28' model='account.account.tag'>
+                <field name='name'>605.28 Cuotas al IMSS</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_605_29' model='account.account.tag'>
+                <field name='name'>605.29 Aportaciones al infonavit</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_605_30' model='account.account.tag'>
+                <field name='name'>605.30 Aportaciones al SAR</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_605_31' model='account.account.tag'>
+                <field name='name'>605.31 Otros costos de mano de obra directa</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_606' model='account.account.tag'>
+                <field name='name'>606 Facilidades administrativas fiscales</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_606_01' model='account.account.tag'>
+                <field name='name'>606.01 Facilidades administrativas fiscales</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_607' model='account.account.tag'>
+                <field name='name'>607 Participación de los trabajadores en las utilidades</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_607_01' model='account.account.tag'>
+                <field name='name'>607.01 Participación de los trabajadores en las utilidades</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_608' model='account.account.tag'>
+                <field name='name'>608 Participación en resultados de subsidiarias</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_608_01' model='account.account.tag'>
+                <field name='name'>608.01 Participación en resultados de subsidiarias</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_609' model='account.account.tag'>
+                <field name='name'>609 Participación en resultados de asociadas</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_609_01' model='account.account.tag'>
+                <field name='name'>609.01 Participación en resultados de asociadas</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_610' model='account.account.tag'>
+                <field name='name'>610 Participación de los trabajadores en las utilidades diferida</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_610_01' model='account.account.tag'>
+                <field name='name'>610.01 Participación de los trabajadores en las utilidades diferida</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_611' model='account.account.tag'>
+                <field name='name'>611 Impuesto Sobre la renta</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_611_01' model='account.account.tag'>
+                <field name='name'>611.01 Impuesto Sobre la renta</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_611_02' model='account.account.tag'>
+                <field name='name'>611.02 Impuesto Sobre la renta por remanente distribuible</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_612' model='account.account.tag'>
+                <field name='name'>612 Gastos no deducibles para CUFIN</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_612_01' model='account.account.tag'>
+                <field name='name'>612.01 Gastos no deducibles para CUFIN</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_613' model='account.account.tag'>
+                <field name='name'>613 Depreciación contable</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_613_01' model='account.account.tag'>
+                <field name='name'>613.01 Depreciación de edificios</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_613_02' model='account.account.tag'>
+                <field name='name'>613.02 Depreciación de maquinaria y equipo</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_613_03' model='account.account.tag'>
+                <field name='name'>613.03 Depreciación de automóviles, autobuses, camiones de carga, tractocamiones, montacargas y remolques</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_613_04' model='account.account.tag'>
+                <field name='name'>613.04 Depreciación de mobiliario y equipo de oficina</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_613_05' model='account.account.tag'>
+                <field name='name'>613.05 Depreciación de equipo de cómputo</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_613_06' model='account.account.tag'>
+                <field name='name'>613.06 Depreciación de equipo de comunicación</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_613_07' model='account.account.tag'>
+                <field name='name'>613.07 Depreciación de activos biológicos, vegetales y semovientes</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_613_08' model='account.account.tag'>
+                <field name='name'>613.08 Depreciación de otros activos fijos</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_613_09' model='account.account.tag'>
+                <field name='name'>613.09 Depreciación de ferrocarriles</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_613_10' model='account.account.tag'>
+                <field name='name'>613.10 Depreciación de embarcaciones</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_613_11' model='account.account.tag'>
+                <field name='name'>613.11 Depreciación de aviones</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_613_12' model='account.account.tag'>
+                <field name='name'>613.12 Depreciación de troqueles, moldes, matrices y herramental</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_613_13' model='account.account.tag'>
+                <field name='name'>613.13 Depreciación de equipo de comunicaciones telefónicas</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_613_14' model='account.account.tag'>
+                <field name='name'>613.14 Depreciación de equipo de comunicación satelital</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_613_15' model='account.account.tag'>
+                <field name='name'>613.15 Depreciación de equipo de adaptaciones para personas con capacidades diferentes</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_613_16' model='account.account.tag'>
+                <field name='name'>613.16 Depreciación de maquinaria y equipo de generación de energía de fuentes renovables o de sistemas de cogeneración de electricidad eficiente</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_613_17' model='account.account.tag'>
+                <field name='name'>613.17 Depreciación de adaptaciones y mejoras</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_613_18' model='account.account.tag'>
+                <field name='name'>613.18 Depreciación de otra maquinaria y equipo</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_614' model='account.account.tag'>
+                <field name='name'>614 Amortización contable</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_614_01' model='account.account.tag'>
+                <field name='name'>614.01 Amortización de gastos diferidos</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_614_02' model='account.account.tag'>
+                <field name='name'>614.02 Amortización de gastos pre operativos</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_614_03' model='account.account.tag'>
+                <field name='name'>614.03 Amortización de regalías, asistencia técnica y otros gastos diferidos</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_614_04' model='account.account.tag'>
+                <field name='name'>614.04 Amortización de activos intangibles</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_614_05' model='account.account.tag'>
+                <field name='name'>614.05 Amortización de gastos de organización</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_614_06' model='account.account.tag'>
+                <field name='name'>614.06 Amortización de investigación y desarrollo de mercado</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_614_07' model='account.account.tag'>
+                <field name='name'>614.07 Amortización de marcas y patentes</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_614_08' model='account.account.tag'>
+                <field name='name'>614.08 Amortización de crédito mercantil</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_614_09' model='account.account.tag'>
+                <field name='name'>614.09 Amortización de gastos de instalación</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_614_10' model='account.account.tag'>
+                <field name='name'>614.10 Amortización de otros activos diferidos</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_700' model='account.account.tag'>
+                <field name='name'>700 Resultado integral de financiamiento</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_701' model='account.account.tag'>
+                <field name='name'>701 Gastos financieros</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_701_01' model='account.account.tag'>
+                <field name='name'>701.01 Pérdida cambiaria</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_701_02' model='account.account.tag'>
+                <field name='name'>701.02 Pérdida cambiaria nacional parte relacionada</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_701_03' model='account.account.tag'>
+                <field name='name'>701.03 Pérdida cambiaria extranjero parte relacionada</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_701_04' model='account.account.tag'>
+                <field name='name'>701.04 Intereses a cargo bancario nacional</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_701_05' model='account.account.tag'>
+                <field name='name'>701.05 Intereses a cargo bancario extranjero</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_701_06' model='account.account.tag'>
+                <field name='name'>701.06 Intereses a cargo de personas físicas nacional</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_701_07' model='account.account.tag'>
+                <field name='name'>701.07 Intereses a cargo de personas físicas extranjero</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_701_08' model='account.account.tag'>
+                <field name='name'>701.08 Intereses a cargo de personas morales nacional</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_701_09' model='account.account.tag'>
+                <field name='name'>701.09 Intereses a cargo de personas morales extranjero</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_701_10' model='account.account.tag'>
+                <field name='name'>701.10 Comisiones bancarias</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_701_11' model='account.account.tag'>
+                <field name='name'>701.11 Otros gastos financieros</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_702' model='account.account.tag'>
+                <field name='name'>702 Productos financieros</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_702_01' model='account.account.tag'>
+                <field name='name'>702.01 Utilidad cambiaria</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_702_02' model='account.account.tag'>
+                <field name='name'>702.02 Utilidad cambiaria nacional parte relacionada</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_702_03' model='account.account.tag'>
+                <field name='name'>702.03 Utilidad cambiaria extranjero parte relacionada</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_702_04' model='account.account.tag'>
+                <field name='name'>702.04 Intereses a favor bancarios nacional</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_702_05' model='account.account.tag'>
+                <field name='name'>702.05 Intereses a favor bancarios extranjero</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_702_06' model='account.account.tag'>
+                <field name='name'>702.06 Intereses a favor de personas físicas nacional</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_702_07' model='account.account.tag'>
+                <field name='name'>702.07 Intereses a favor de personas físicas extranjero</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_702_08' model='account.account.tag'>
+                <field name='name'>702.08 Intereses a favor de personas morales nacional</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_702_09' model='account.account.tag'>
+                <field name='name'>702.10 Intereses a favor de personas morales extranjero</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_702_10' model='account.account.tag'>
+                <field name='name'>702.10 Otros productos financieros</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_703' model='account.account.tag'>
+                <field name='name'>703 Otros gastos</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_703_01' model='account.account.tag'>
+                <field name='name'>703.01 Pérdida en venta y/o baja de terrenos</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_703_02' model='account.account.tag'>
+                <field name='name'>703.02 Pérdida en venta y/o baja de edificios</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_703_03' model='account.account.tag'>
+                <field name='name'>703.03 Pérdida en venta y/o baja de maquinaria y equipo</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_703_04' model='account.account.tag'>
+                <field name='name'>703.04 Pérdida en venta y/o baja de automóviles, autobuses, camiones de carga, tractocamiones, montacargas y remolques</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_703_05' model='account.account.tag'>
+                <field name='name'>703.05 Pérdida en venta y/o baja de mobiliario y equipo de oficina</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_703_06' model='account.account.tag'>
+                <field name='name'>703.06 Pérdida en venta y/o baja de equipo de cómputo</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_703_07' model='account.account.tag'>
+                <field name='name'>703.07 Pérdida en venta y/o baja de equipo de comunicación</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_703_08' model='account.account.tag'>
+                <field name='name'>703.08 Pérdida en venta y/o baja de activos biológicos, vegetales y semovientes</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_703_09' model='account.account.tag'>
+                <field name='name'>703.09 Pérdida en venta y/o baja de otros activos fijos</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_703_10' model='account.account.tag'>
+                <field name='name'>703.10 Pérdida en venta y/o baja de ferrocarriles</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_703_11' model='account.account.tag'>
+                <field name='name'>703.11 Pérdida en venta y/o baja de embarcaciones</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_703_12' model='account.account.tag'>
+                <field name='name'>703.12 Pérdida en venta y/o baja de aviones</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_703_13' model='account.account.tag'>
+                <field name='name'>703.13 Pérdida en venta y/o baja de troqueles, moldes, matrices y herramental</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_703_14' model='account.account.tag'>
+                <field name='name'>703.14 Pérdida en venta y/o baja de equipo de comunicaciones telefónicas</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_703_15' model='account.account.tag'>
+                <field name='name'>703.15  Pérdida en venta y/o baja de equipo de comunicación satelital</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_703_16' model='account.account.tag'>
+                <field name='name'>703.16 Pérdida en venta y/o baja de equipo de adaptaciones para personas con capacidades diferentes</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_703_17' model='account.account.tag'>
+                <field name='name'>703.17 Pérdida en venta y/o baja de maquinaria y equipo de generación de energía de fuentes renovables o de sistemas de cogeneración de electricidad eficiente</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_703_18' model='account.account.tag'>
+                <field name='name'>703.18 Pérdida en venta y/o baja de otra maquinaria y equipo</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_703_19' model='account.account.tag'>
+                <field name='name'>703.19 Pérdida por enajenación de acciones</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_703_20' model='account.account.tag'>
+                <field name='name'>703.20 Pérdida por enajenación de partes sociales</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_703_21' model='account.account.tag'>
+                <field name='name'>703.21 Otros gastos</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_704' model='account.account.tag'>
+                <field name='name'>704 Otros productos</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_704_01' model='account.account.tag'>
+                <field name='name'>704.01 Ganancia en venta y/o baja de terrenos</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_704_02' model='account.account.tag'>
+                <field name='name'>704.02 Ganancia en venta y/o baja de edificios</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_704_03' model='account.account.tag'>
+                <field name='name'>704.03 Ganancia en venta y/o baja de maquinaria y equipo</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_704_04' model='account.account.tag'>
+                <field name='name'>704.04 Ganancia en venta y/o baja de automóviles, autobuses, camiones de carga, tractocamiones, montacargas y remolques</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_704_05' model='account.account.tag'>
+                <field name='name'>704.05 Ganancia en venta y/o baja de mobiliario y equipo de oficina</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_704_06' model='account.account.tag'>
+                <field name='name'>704.06 Ganancia en venta y/o baja de equipo de cómputo</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_704_07' model='account.account.tag'>
+                <field name='name'>704.07 Ganancia en venta y/o baja de equipo de comunicación</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_704_08' model='account.account.tag'>
+                <field name='name'>704.08 Ganancia en venta y/o baja de activos biológicos, vegetales y semovientes</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_704_09' model='account.account.tag'>
+                <field name='name'>704.09 Ganancia en venta y/o baja de otros activos fijos</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_704_10' model='account.account.tag'>
+                <field name='name'>704.10 Ganancia en venta y/o baja de ferrocarriles</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_704_11' model='account.account.tag'>
+                <field name='name'>704.11 Ganancia en venta y/o baja de embarcaciones</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_704_12' model='account.account.tag'>
+                <field name='name'>704.12 Ganancia en venta y/o baja de aviones</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_704_13' model='account.account.tag'>
+                <field name='name'>704.13 Ganancia en venta y/o baja de troqueles, moldes, matrices y herramental</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_704_14' model='account.account.tag'>
+                <field name='name'>704.14 Ganancia en venta y/o baja de equipo de comunicaciones telefónicas</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_704_15' model='account.account.tag'>
+                <field name='name'>704.15 Ganancia en venta y/o baja de equipo de comunicación satelital</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_704_16' model='account.account.tag'>
+                <field name='name'>704.16 Ganancia en venta y/o baja de equipo de adaptaciones para personas con capacidades diferentes</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_704_17' model='account.account.tag'>
+                <field name='name'>704.17 Ganancia en venta de maquinaria y equipo de generación de energía de fuentes renovables o de sistemas de cogeneración de electricidad eficiente</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_704_18' model='account.account.tag'>
+                <field name='name'>704.18 Ganancia en venta y/o baja de otra maquinaria y equipo</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_704_19' model='account.account.tag'>
+                <field name='name'>704.19 Ganancia por enajenación de acciones</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_704_20' model='account.account.tag'>
+                <field name='name'>704.20 Ganancia por enajenación de partes sociales</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_704_21' model='account.account.tag'>
+                <field name='name'>704.21 Ingresos por estímulos fiscales</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_704_22' model='account.account.tag'>
+                <field name='name'>704.22 Ingresos por condonación de adeudo</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_704_23' model='account.account.tag'>
+                <field name='name'>704.23 Otros productos</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_800' model='account.account.tag'>
+                <field name='name'>800 Cuentas de orden</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_801' model='account.account.tag'>
+                <field name='name'>801 UFIN del ejercicio</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_801_01' model='account.account.tag'>
+                <field name='name'>801.01 UFIN</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_801_02' model='account.account.tag'>
+                <field name='name'>801.02 Contra cuenta UFIN</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_802' model='account.account.tag'>
+                <field name='name'>802 CUFIN del ejercicio</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_802_01' model='account.account.tag'>
+                <field name='name'>802.01 CUFIN</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_802_02' model='account.account.tag'>
+                <field name='name'>802.02 Contra cuenta CUFIN</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_803' model='account.account.tag'>
+                <field name='name'>803 CUFIN de ejercicios anteriores</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_803_01' model='account.account.tag'>
+                <field name='name'>803.01 CUFIN de ejercicios anteriores</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_803_02' model='account.account.tag'>
+                <field name='name'>803.02 Contra cuenta CUFIN de ejercicios anteriores</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_804' model='account.account.tag'>
+                <field name='name'>804 CUFINRE del ejercicio</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_804_01' model='account.account.tag'>
+                <field name='name'>804.01 CUFINRE</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_804_02' model='account.account.tag'>
+                <field name='name'>804.02 Contra cuenta CUFINRE</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_805' model='account.account.tag'>
+                <field name='name'>805 CUFINRE de ejercicios anteriores</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_805_01' model='account.account.tag'>
+                <field name='name'>805.01 CUFINRE de ejercicios anteriores</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_805_02' model='account.account.tag'>
+                <field name='name'>805.02 Contra cuenta CUFINRE de ejercicios anteriores</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_806' model='account.account.tag'>
+                <field name='name'>806 CUCA del ejercicio</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_806_01' model='account.account.tag'>
+                <field name='name'>806.01 CUCA</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_806_02' model='account.account.tag'>
+                <field name='name'>806.02 Contra cuenta CUCA</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_807' model='account.account.tag'>
+                <field name='name'>807 CUCA de ejercicios anteriores</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_807_01' model='account.account.tag'>
+                <field name='name'>807.01 CUCA de ejercicios anteriores</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_807_02' model='account.account.tag'>
+                <field name='name'>807.02 Contra cuenta CUCA de ejercicios anteriores</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_808' model='account.account.tag'>
+                <field name='name'>808 Ajuste anual por inflación acumulable</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_808_01' model='account.account.tag'>
+                <field name='name'>808.01 Ajuste anual por inflación acumulable</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_808_02' model='account.account.tag'>
+                <field name='name'>808.02 Acumulación del ajuste anual inflacionario</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_809' model='account.account.tag'>
+                <field name='name'>809 Ajuste anual por inflación deducible</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_809_01' model='account.account.tag'>
+                <field name='name'>809.01 Ajuste anual por inflación deducible</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_809_02' model='account.account.tag'>
+                <field name='name'>809.02 Deducción del ajuste anual inflacionario</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_810' model='account.account.tag'>
+                <field name='name'>810 Deducción de inversión</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_810_01' model='account.account.tag'>
+                <field name='name'>810.01 Deducción de inversión</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_810_02' model='account.account.tag'>
+                <field name='name'>810.02 Contra cuenta deducción de inversiones</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_811' model='account.account.tag'>
+                <field name='name'>811 Utilidad o pérdida fiscal en venta y/o baja de activo fijo</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_811_01' model='account.account.tag'>
+                <field name='name'>811.01 Utilidad o pérdida fiscal en venta y/o baja de activo fijo</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_811_02' model='account.account.tag'>
+                <field name='name'>811.02 Contra cuenta utilidad o pérdida fiscal en venta y/o baja de activo fijo</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_812' model='account.account.tag'>
+                <field name='name'>812 Utilidad o pérdida fiscal en venta acciones o partes sociales</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_812_01' model='account.account.tag'>
+                <field name='name'>812.01 Utilidad o pérdida fiscal en venta acciones o partes sociales</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_812_02' model='account.account.tag'>
+                <field name='name'>812.02 Contra cuenta utilidad o pérdida fiscal en venta acciones o partes sociales</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_813' model='account.account.tag'>
+                <field name='name'>813 Pérdidas fiscales pendientes de amortizar actualizadas de ejercicios anteriores</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_813_01' model='account.account.tag'>
+                <field name='name'>813.01 Pérdidas fiscales pendientes de amortizar actualizadas de ejercicios anteriores</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_813_02' model='account.account.tag'>
+                <field name='name'>813.02 Actualización de pérdidas fiscales pendientes de amortizar de ejercicios anteriores</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_814' model='account.account.tag'>
+                <field name='name'>814 Mercancías recibidas en consignación</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_814_01' model='account.account.tag'>
+                <field name='name'>814.01 Mercancías recibidas en consignación</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_814_02' model='account.account.tag'>
+                <field name='name'>814.02 Consignación de mercancías recibidas</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_815' model='account.account.tag'>
+                <field name='name'>815 Crédito fiscal de IVA e IEPS por la importación de mercancías para empresas certificadas</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_815_01' model='account.account.tag'>
+                <field name='name'>815.01 Crédito fiscal de IVA e IEPS por la importación de mercancías</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_815_02' model='account.account.tag'>
+                <field name='name'>815.02 Importación de mercancías con aplicación de crédito fiscal de IVA e IEPS</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_816' model='account.account.tag'>
+                <field name='name'>816 Crédito fiscal de IVA e IEPS por la importación de activos fijos para empresas certificadas</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_816_01' model='account.account.tag'>
+                <field name='name'>816.01 Crédito fiscal de IVA e IEPS por la importación de activo fijo</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_816_02' model='account.account.tag'>
+                <field name='name'>816.02 Importación de activo fijo con aplicación de crédito fiscal de IVA e IEPS</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_899' model='account.account.tag'>
+                <field name='name'>899 Otras cuentas de orden</field>
+                <field name='color'>1</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_899_01' model='account.account.tag'>
+                <field name='name'>899.01 Otras cuentas de orden</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+            <record id='account_tag_899_02' model='account.account.tag'>
+                <field name='name'>899.02 Contra cuenta otras cuentas de orden</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+            </record>
+
+    </data>
+</odoo>

--- a/addons/l10n_mx/data/account_tax_data.xml
+++ b/addons/l10n_mx/data/account_tax_data.xml
@@ -6,10 +6,6 @@
         <field name="name">IVA(0%) VENTAS</field>
         <field name="applicability">taxes</field>
     </record>
-    <record id="tax_tag_02" model="account.account.tag">
-        <field name="name">IVA(11%) VENTAS</field>
-        <field name="applicability">taxes</field>
-    </record>
     <record id="tax_tag_03" model="account.account.tag">
         <field name="name">IVA(16%) VENTAS</field>
         <field name="applicability">taxes</field>
@@ -42,157 +38,145 @@
         <field name="name">IVA(0%) COMPRAS</field>
         <field name="applicability">taxes</field>
     </record>
-    <record id="tax_tag_11" model="account.account.tag">
-        <field name="name">IVA(11%) COMPRAS</field>
-        <field name="applicability">taxes</field>
-    </record>
     <record id="tax_tag_12" model="account.account.tag">
         <field name="name">IVA(16%) COMPRAS</field>
         <field name="applicability">taxes</field>
     </record>
 
-	<record id="tax9" model="account.tax.template">   
-        <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>   
+    <record id="tax9" model="account.tax.template">
+        <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
         <field name="name">IVA(0%) VENTAS</field>
         <field name="description">ITAX_010-IN</field>
-		<field name="amount">0</field>
-		<field name="amount_type">percent</field>
-		<field name="type_tax_use">sale</field>
-        <field name="account_id" ref="cuenta2202113000"/>
-        <field name="refund_account_id" ref="cuenta2202113000"/>
+        <field name="amount">0</field>
+        <field name="amount_type">percent</field>
+        <field name="type_tax_use">sale</field>
+        <field name="account_id" ref="cuenta209_01"/>
+        <field name="refund_account_id" ref="cuenta209_01"/>
         <field name="tag_ids" eval="[(6,0,[ref('tax_tag_01')])]"/>
-	</record>
+        <field name="use_cash_basis" eval="True"/>
+        <field name="cash_basis_account" ref="cuenta208_01"/>
+    </record>
 
-	<record id="tax11" model="account.tax.template">   
-        <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>   
-        <field name="name">IVA(11%) VENTAS</field>
-        <field name="description">ITAX_110-IN</field>
-		<field name="amount">11</field>
-		<field name="amount_type">percent</field>
-		<field name="type_tax_use">sale</field>
-        <field name="account_id" ref="cuenta2202113000"/>
-        <field name="refund_account_id" ref="cuenta2202113000"/>
-        <field name="tag_ids" eval="[(6,0,[ref('tax_tag_02')])]"/>
-	</record>
-
-	<record id="tax12" model="account.tax.template">   
-        <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>   
+    <record id="tax12" model="account.tax.template">
+        <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
         <field name="name">IVA(16%) VENTAS</field>
         <field name="description">ITAX_160-IN</field>
-		<field name="amount">16</field>
-		<field name="amount_type">percent</field>
-		<field name="type_tax_use">sale</field>
-        <field name="account_id" ref="cuenta2202113000"/>
-        <field name="refund_account_id" ref="cuenta2202113000"/>
+        <field name="amount">16</field>
+        <field name="amount_type">percent</field>
+        <field name="type_tax_use">sale</field>
+        <field name="account_id" ref="cuenta209_01"/>
+        <field name="refund_account_id" ref="cuenta209_01"/>
         <field name="tag_ids" eval="[(6,0,[ref('tax_tag_03')])]"/>
-	</record>
+        <field name="use_cash_basis" eval="True"/>
+        <field name="cash_basis_account" ref="cuenta208_01"/>
+    </record>
 
-	<record id="tax1" model="account.tax.template">   
-        <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>   
+    <record id="tax1" model="account.tax.template">
+        <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
         <field name="name">RET IVA FLETES 4%</field>
         <field name="description">ITAXR_04-OUT</field>
-		<field name="amount">-4</field>
-		<field name="amount_type">percent</field>
-		<field name="type_tax_use">purchase</field>
-        <field name="account_id" ref="cuenta2201112000"/>
-        <field name="refund_account_id" ref="cuenta2201112000"/>
+        <field name="amount">-4</field>
+        <field name="amount_type">percent</field>
+        <field name="type_tax_use">purchase</field>
+        <field name="account_id" ref="cuenta216_10"/>
+        <field name="refund_account_id" ref="cuenta216_10"/>
         <field name="tag_ids" eval="[(6,0,[ref('tax_tag_04')])]"/>
-	</record>
+        <field name="use_cash_basis" eval="True"/>
+        <field name="cash_basis_account" ref="cuenta216_13"/>
+    </record>
 
-	<record id="tax2" model="account.tax.template">   
-        <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>   
+    <record id="tax2" model="account.tax.template">
+        <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
         <field name="name">RET IVA ARRENDAMIENTO 10%</field>
         <field name="description">ITAXR_10-OUT</field>
-		<field name="amount">-10</field>
-		<field name="amount_type">percent</field>
-		<field name="type_tax_use">purchase</field>
-        <field name="account_id" ref="cuenta2201117000"/>
-        <field name="refund_account_id" ref="cuenta2201117000"/>
+        <field name="amount">-10</field>
+        <field name="amount_type">percent</field>
+        <field name="type_tax_use">purchase</field>
+        <field name="account_id" ref="cuenta216_10"/>
+        <field name="refund_account_id" ref="cuenta216_10"/>
         <field name="tag_ids" eval="[(6,0,[ref('tax_tag_05')])]"/>
-	</record>
+        <field name="use_cash_basis" eval="True"/>
+        <field name="cash_basis_account" ref="cuenta216_13"/>
+    </record>
 
-	<record id="tax3" model="account.tax.template">   
-        <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>   
+    <record id="tax3" model="account.tax.template">
+        <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
         <field name="name">RET ISR ARRENDAMIENTO 10%</field>
         <field name="description">ITAXA_10-OUT</field>
-		<field name="amount">-10</field>
-		<field name="amount_type">percent</field>
-		<field name="type_tax_use">purchase</field>
-        <field name="account_id" ref="cuenta2201116000"/>
-        <field name="refund_account_id" ref="cuenta2201116000"/>
+        <field name="amount">-10</field>
+        <field name="amount_type">percent</field>
+        <field name="type_tax_use">purchase</field>
+        <field name="account_id" ref="cuenta216_03"/>
+        <field name="refund_account_id" ref="cuenta216_03"/>
         <field name="tag_ids" eval="[(6,0,[ref('tax_tag_06')])]"/>
-	</record>
+    </record>
 
-	<record id="tax5" model="account.tax.template">   
-        <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>   
+    <record id="tax5" model="account.tax.template">
+        <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
         <field name="name">RET ISR HONORARIOS 10%</field>
         <field name="description">ITAXH_10-OUT</field>
-		<field name="amount">-10</field>
-		<field name="amount_type">percent</field>
-		<field name="type_tax_use">purchase</field>
-        <field name="account_id" ref="cuenta2201115000"/>
-        <field name="refund_account_id" ref="cuenta2201115000"/>
+        <field name="amount">-10</field>
+        <field name="amount_type">percent</field>
+        <field name="type_tax_use">purchase</field>
+        <field name="account_id" ref="cuenta216_04"/>
+        <field name="refund_account_id" ref="cuenta216_04"/>
         <field name="tag_ids" eval="[(6,0,[ref('tax_tag_07')])]"/>
-	</record>
+    </record>
 
-	<record id="tax7" model="account.tax.template">   
-        <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>   
+    <record id="tax7" model="account.tax.template">
+        <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
         <field name="name">RETENCION IVA ARRENDAMIENTO 10.67%</field>
         <field name="description">ITAX_1067-OUT</field>
-		<field name="amount">-10.67</field>
-		<field name="amount_type">percent</field>
-		<field name="type_tax_use">purchase</field>
-        <field name="account_id" ref="cuenta2201116000"/>
-        <field name="refund_account_id" ref="cuenta2201116000"/>
+        <field name="amount">-10.67</field>
+        <field name="amount_type">percent</field>
+        <field name="type_tax_use">purchase</field>
+        <field name="account_id" ref="cuenta216_10"/>
+        <field name="refund_account_id" ref="cuenta216_10"/>
         <field name="tag_ids" eval="[(6,0,[ref('tax_tag_08')])]"/>
-	</record>
+        <field name="use_cash_basis" eval="True"/>
+        <field name="cash_basis_account" ref="cuenta216_13"/>
+    </record>
 
-	<record id="tax8" model="account.tax.template">   
-        <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>   
+    <record id="tax8" model="account.tax.template">
+        <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
         <field name="name">RETENCION IVA HONORARIOS 10.67%</field>
         <field name="description">ITAX_167-OUT</field>
-		<field name="amount">-10.67</field>
-		<field name="amount_type">percent</field>
-		<field name="type_tax_use">purchase</field>
-        <field name="account_id" ref="cuenta2201118000"/>
-        <field name="refund_account_id" ref="cuenta2201118000"/>
+        <field name="amount">-10.67</field>
+        <field name="amount_type">percent</field>
+        <field name="type_tax_use">purchase</field>
+        <field name="account_id" ref="cuenta216_10"/>
+        <field name="refund_account_id" ref="cuenta216_10"/>
         <field name="tag_ids" eval="[(6,0,[ref('tax_tag_09')])]"/>
-	</record>
+        <field name="use_cash_basis" eval="True"/>
+        <field name="cash_basis_account" ref="cuenta216_13"/>
+    </record>
 
-	<record id="tax13" model="account.tax.template">   
-        <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>   
+    <record id="tax13" model="account.tax.template">
+        <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
         <field name="name">IVA(0%) COMPRAS</field>
         <field name="description">ITAX_010-OUT</field>
-		<field name="amount">0</field>
-		<field name="amount_type">percent</field>
-		<field name="type_tax_use">purchase</field>
-        <field name="account_id" ref="cuenta1151004000"/>
-        <field name="refund_account_id" ref="cuenta1151004000"/>
+        <field name="amount">0</field>
+        <field name="amount_type">percent</field>
+        <field name="type_tax_use">purchase</field>
+        <field name="account_id" ref="cuenta119_01"/>
+        <field name="refund_account_id" ref="cuenta119_01"/>
         <field name="tag_ids" eval="[(6,0,[ref('tax_tag_10')])]"/>
-	</record>
+        <field name="use_cash_basis" eval="True"/>
+        <field name="cash_basis_account" ref="cuenta118_01"/>
+    </record>
 
-	<record id="tax10" model="account.tax.template">   
-        <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>   
-        <field name="name">IVA(11%) COMPRAS</field>
-        <field name="description">ITAX_110-OUT</field>
-		<field name="amount">11</field>
-		<field name="amount_type">percent</field>
-		<field name="type_tax_use">purchase</field>
-        <field name="account_id" ref="cuenta1151004000"/>
-        <field name="refund_account_id" ref="cuenta1151004000"/>
-        <field name="tag_ids" eval="[(6,0,[ref('tax_tag_11')])]"/>
-	</record>
-
-	<record id="tax14" model="account.tax.template">   
-        <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>   
+    <record id="tax14" model="account.tax.template">
+        <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
         <field name="name">IVA(16%) COMPRAS</field>
         <field name="description">ITAX_160-OUT</field>
-		<field name="amount">16</field>
-		<field name="amount_type">percent</field>
-		<field name="type_tax_use">purchase</field>
-        <field name="account_id" ref="cuenta1151004000"/>
-        <field name="refund_account_id" ref="cuenta1151004000"/>
+        <field name="amount">16</field>
+        <field name="amount_type">percent</field>
+        <field name="type_tax_use">purchase</field>
+        <field name="account_id" ref="cuenta119_01"/>
+        <field name="refund_account_id" ref="cuenta119_01"/>
         <field name="tag_ids" eval="[(6,0,[ref('tax_tag_12')])]"/>
-	</record>
+        <field name="use_cash_basis" eval="True"/>
+        <field name="cash_basis_account" ref="cuenta118_01"/>
+    </record>
   </data>
 </odoo>

--- a/addons/l10n_mx/data/l10n_mx_account_journa_data.xml
+++ b/addons/l10n_mx/data/l10n_mx_account_journa_data.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" ?>
+<odoo>
+    <data noupdate="1">
+
+        <record id="journal_effectively_paid" model="account.journal">
+            <field name="company_id" ref="base.main_company"/>
+            <field name="name">Effectively Paid</field>
+            <field name="code">EP</field>
+            <field name="type">general</field>
+            <field name="show_on_dashboard" eval="True"/>
+        </record>
+
+    </data>
+</odoo>

--- a/addons/l10n_mx/data/l10n_mx_chart_data.xml
+++ b/addons/l10n_mx/data/l10n_mx_chart_data.xml
@@ -1,2145 +1,6604 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-	<data noupdate="1">
+    <data noupdate="1">
 <!-- Account Types -->
 
     <record model="account.account.type" id="account_type_other">
       <field name="name">other</field>
     </record>
 
-
 <!--
 Cuentas del plan
 -->
-	<record id="cuenta1129003000" model="account.account.template">
-		<field name="name">TRANSFERENCIAS BANCARIAS</field>
-		<field name="code">1129003000</field>
-		<field name="reconcile" eval="True"/>
-		<field name="user_type_id" ref="account.data_account_type_current_assets"/>
-	</record>
-	<record id="vauxoo_mx_chart_template" model="account.chart.template">
-		<field name="name">Plan de Cuentas para Mexico</field>
-		<field name="bank_account_code_prefix">1113</field>
-		<field name="cash_account_code_prefix">1111</field>
-		<field name="code_digits">6</field>
-		<field name="currency_id" ref="base.MXN"/>
-		<field name="transfer_account_id" ref="cuenta1129003000"/>
-	</record>
-
-	<record id="cuenta1129003000" model="account.account.template">
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-	</record>
-
-<record id="cuenta1115001000" model="account.account.template">
-		<field name="code">1115001000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">PAPELES COMERCIALES</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta1115002000" model="account.account.template">
-		<field name="code">1115002000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">INVERSIONES TEMPORALES</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta1115003000" model="account.account.template">
-		<field name="code">1115003000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">INVERSIONES EN BONOS M.N.</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta1115004000" model="account.account.template">
-		<field name="code">1115004000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">INVERSIONES EN BONOS M.E.</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta1121001000" model="account.account.template">
-		<field name="code">1121001000</field>
-		<field name="reconcile" eval="True"/>
-		<field name="user_type_id" ref="account.data_account_type_receivable"/>
-		<field name="name">EFECTOS POR COBRAR NACIONALES</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta1122001000" model="account.account.template">
-		<field name="code">1122001000</field>
-		<field name="reconcile" eval="True"/>
-		<field name="user_type_id" ref="account.data_account_type_receivable"/>
-		<field name="name">CUENTAS POR COBRAR CLIENTES</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta1122002000" model="account.account.template">
-		<field name="code">1122002000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">COBRO ANTICIPO CLIENTES</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta1122004000" model="account.account.template">
-		<field name="code">1122004000</field>
-		<field name="reconcile" eval="True"/>
-		<field name="user_type_id" ref="account.data_account_type_receivable"/>
-		<field name="name">CUENTAS POR COBRAR MAYORISTA</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta1122005000" model="account.account.template">
-		<field name="code">1122005000</field>
-		<field name="reconcile" eval="True"/>
-		<field name="user_type_id" ref="account.data_account_type_receivable"/>
-		<field name="name">CUENTAS POR COBRAR DETALLISTA</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta1124001000" model="account.account.template">
-		<field name="code">1124001000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">PROVISION INCOBRALES NACIONALES</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta1124002000" model="account.account.template">
-		<field name="code">1124002000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">PROVINCION INCOBRABLES EXTERIOR</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta1125001000" model="account.account.template">
-		<field name="code">1125001000</field>
-		<field name="reconcile" eval="True"/>
-		<field name="user_type_id" ref="account.data_account_type_receivable"/>
-		<field name="name">CUENTAS POR COBRAR EMPLEADOS</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta1125002000" model="account.account.template">
-		<field name="code">1125002000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">PRESTAMOS PERSONALES</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta1125003000" model="account.account.template">
-		<field name="code">1125003000</field>
-		<field name="reconcile" eval="True"/>
-		<field name="user_type_id" ref="account.data_account_type_receivable"/>
-		<field name="name">CUENTAS POR COBRAR SOCIOS</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta1125004000" model="account.account.template">
-		<field name="code">1125004000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">VIATICOS VENDEDORES</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta1125006000" model="account.account.template">
-		<field name="code">1125006000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">VACACIONES</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta1125007000" model="account.account.template">
-		<field name="code">1125007000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">UTILIDADES</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta1125008000" model="account.account.template">
-		<field name="code">1125008000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">SEGURO DE VEHICULOS</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta1125009000" model="account.account.template">
-		<field name="code">1125009000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">ANTICIPO DE NOMINA</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta1128001000" model="account.account.template">
-		<field name="code">1128001000</field>
-		<field name="reconcile" eval="True"/>
-		<field name="user_type_id" ref="account.data_account_type_receivable"/>
-		<field name="name">CUENTAS POR COBRAR SOCIOS</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta1129001000" model="account.account.template">
-		<field name="code">1129001000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">ADELANTO A PROVEEDORES</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta1129002000" model="account.account.template">
-		<field name="code">1129002000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">ENTES GUBERNAMENTALES</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta1129004000" model="account.account.template">
-		<field name="code">1129004000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">DEPOSITOS VARIOS</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta1129005000" model="account.account.template">
-		<field name="code">1129005000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">RECLAMO AL SEGURO</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta1129008000" model="account.account.template">
-		<field name="code">1129008000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">CHEQUES DEVUELTOS</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta1129009000" model="account.account.template">
-		<field name="code">1129009000</field>
-		<field name="reconcile" eval="True"/>
-		<field name="user_type_id" ref="account.data_account_type_receivable"/>
-		<field name="name">DEUDORES DIVERSOS</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta1129010000" model="account.account.template">
-		<field name="code">1129010000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account.data_account_type_current_assets"/>
-		<field name="name">RECLAMO AL BANCO</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta1131001000" model="account.account.template">
-		<field name="code">1131001000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">INVENTARIO FINAL</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta1131002000" model="account.account.template">
-		<field name="code">1131002000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">INVENTARIOS DE MERCANCIA NACIONAL</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta1131003000" model="account.account.template">
-		<field name="code">1131003000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">INVENTARIOS DE MERCANCIA EXTERIOR</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta1131009000" model="account.account.template">
-		<field name="code">1131009000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">INVENTARIO MERCANCIA ACTUALIZACION DEL VALOR</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta1134001000" model="account.account.template">
-		<field name="code">1134001000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">MERCANCIA EN TRANSITOS</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta1134002000" model="account.account.template">
-		<field name="code">1134002000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">MERCANCIA EN TRANSITO</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta1141001000" model="account.account.template">
-		<field name="code">1141001000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">PUBLICIDAD</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta1141002000" model="account.account.template">
-		<field name="code">1141002000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">SEGURO PREPAGADOS</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta1141004000" model="account.account.template">
-		<field name="code">1141004000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">ALQUILERES</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta1151001000" model="account.account.template">
-		<field name="code">1151001000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">ISR  DECLARACION ESTIMADAS</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta1151002000" model="account.account.template">
-		<field name="code">1151002000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">ISR  RETENIDO</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta1151003000" model="account.account.template">
-		<field name="code">1151003000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account.data_account_type_current_assets"/>
-		<field name="name">IVA EFECTIVAMENTE PAGADO</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta1151005000" model="account.account.template">
-		<field name="code">1151005000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">PATENTE  MUNICIPAL ESTIMADA</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta1151006000" model="account.account.template">
-		<field name="code">1151006000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">IVA . CREDITO FISCAL IMPORTACION</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta1151007000" model="account.account.template">
-		<field name="code">1151007000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">IMPUESTO MUNICIPAL PAGADO EN EXCESO</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta1151008000" model="account.account.template">
-		<field name="code">1151008000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account.data_account_type_current_assets"/>
-		<field name="name">IETU PAGADO</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta1151009000" model="account.account.template">
-		<field name="code">1151009000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account.data_account_type_current_assets"/>
-		<field name="name">ISR PAGADO</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta1151004000" model="account.account.template">
-		<field name="code">1151004000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account.data_account_type_current_assets"/>
-		<field name="name">IVA ACREDITABLE o PAGADO A PROVEEDORES</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta1211001000" model="account.account.template">
-		<field name="code">1211001000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">TERRENO COSTO ORIGINAL</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta1211005000" model="account.account.template">
-		<field name="code">1211005000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">INMUEBLES COSTO ORIGINAL</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta1211007000" model="account.account.template">
-		<field name="code">1211007000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">MAQUINARIAS Y EQUIPOS COSTO ORIGINAL</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta1211009000" model="account.account.template">
-		<field name="code">1211009000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">VEHICULOS COSTO ORIGINAL</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta1211011000" model="account.account.template">
-		<field name="code">1211011000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">MUEBLES Y ENSERES COSTO ORIGINAL</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta1211013000" model="account.account.template">
-		<field name="code">1211013000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">LICENCIA Y SOFTWARE COSTO ORIGINAL</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta1212001000" model="account.account.template">
-		<field name="code">1212001000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">TERRENOS COSTO ORIGINAL</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta1212006000" model="account.account.template">
-		<field name="code">1212006000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">INMUEBLES COSTO ORIGINAL</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta1212007000" model="account.account.template">
-		<field name="code">1212007000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">MAQUINARIAS Y EQUIPOS COSTO ORIGINAL</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta1212009000" model="account.account.template">
-		<field name="code">1212009000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">VEHICULOS COSTO ORIGINAL</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta1212011000" model="account.account.template">
-		<field name="code">1212011000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">MUEBLES Y ENSERES COSTO ORIGINAL</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta1212013000" model="account.account.template">
-		<field name="code">1212013000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">LICENCIA Y SOFTWARE COSTO ORIGINAL</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta1212015000" model="account.account.template">
-		<field name="code">1212015000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">MEJORAS A PROPIEDAD COSTO ORIGINAL</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta1221001000" model="account.account.template">
-		<field name="code">1221001000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">INVERSIONES PERMANENTES</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta1221003000" model="account.account.template">
-		<field name="code">1221003000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">BONOS TITULOS</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta1221004000" model="account.account.template">
-		<field name="code">1221004000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">INVERSIONES EN BONOS M.N.</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta1251001000" model="account.account.template">
-		<field name="code">1251001000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">IMPUESTOS DIFERIDOS ISR </field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta1271001000" model="account.account.template">
-		<field name="code">1271001000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">MARCA DE FABRICA</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta1271002000" model="account.account.template">
-		<field name="code">1271002000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">GASTOS DE CONSTITUCION</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta1271005000" model="account.account.template">
-		<field name="code">1271005000</field>
-		<field name="reconcile" eval="True"/>
-		<field name="user_type_id" ref="account.data_account_type_receivable"/>
-		<field name="name">OTRAS CUENTAS POR COBRAR</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta1291001000" model="account.account.template">
-		<field name="code">1291001000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">DEPOSITOS GARANTIA PROVEEDORES</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta1291002000" model="account.account.template">
-		<field name="code">1291002000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">DEPOSITOS GARANTIA BANCOS</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta1291004000" model="account.account.template">
-		<field name="code">1291004000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">DEPOSITOS GARANTIA ARRENDAMIENTO LOCAL</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta2111" model="account.account.template">
-		<field name="code">2111</field>
-		<field name="reconcile" eval="False"/>
-		<field name="name">PASIVOS FINANCIEROS A CORTO PLAZO</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-		<field name="user_type_id" ref="account.data_account_type_current_assets"/>
-</record>
-
-<record id="cuenta2122001000" model="account.account.template">
-		<field name="code">2122001000</field>
-		<field name="reconcile" eval="True"/>
-		<field name="user_type_id" ref="account.data_account_type_payable"/>
-		<field name="name">CUENTAS POR PAGAR PROVEEDORES</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta2122002000" model="account.account.template">
-		<field name="code">2122002000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account.data_account_type_current_liabilities"/>
-		<field name="name">TARJETA DE CREDITO X</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta2122003000" model="account.account.template">
-		<field name="code">2122003000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account.data_account_type_current_liabilities"/>
-		<field name="name">TARJETA DE CREDITO X</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta2122005000" model="account.account.template">
-		<field name="code">2122005000</field>
-		<field name="reconcile" eval="True"/>
-		<field name="user_type_id" ref="account.data_account_type_payable"/>
-		<field name="name">OTRAS CUENTAS POR PAGAR</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta2124001000" model="account.account.template">
-		<field name="code">2124001000</field>
-		<field name="reconcile" eval="True"/>
-		<field name="user_type_id" ref="account.data_account_type_payable"/>
-		<field name="name">CUENTAS POR PAGAR SOCIOS</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta2151001000" model="account.account.template">
-		<field name="code">2151001000</field>
-		<field name="reconcile" eval="True"/>
-		<field name="user_type_id" ref="account.data_account_type_payable"/>
-		<field name="name">DIVIDENDO POR PAGAR VIGENTES</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta2151002000" model="account.account.template">
-		<field name="code">2151002000</field>
-		<field name="reconcile" eval="True"/>
-		<field name="user_type_id" ref="account.data_account_type_receivable"/>
-		<field name="name">DIVDENDO POR COBRAR NO COBRADOS</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta2161005000" model="account.account.template">
-		<field name="code">2161005000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">FONDO FIDEICOMISO</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta2161006000" model="account.account.template">
-		<field name="code">2161006000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">FONDO DE AHORRO</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta2161007000" model="account.account.template">
-		<field name="code">2161007000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">APORTES EMPLEADOS</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta2171001000" model="account.account.template">
-		<field name="code">2171001000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">APORTE EMPRESA</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta2172001000" model="account.account.template">
-		<field name="code">2172001000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">RETENCIONES ISR  EMPLEADOS</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta2172002000" model="account.account.template">
-		<field name="code">2172002000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">RETENCIONES ISR  PROVEEDORES</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta2172003000" model="account.account.template">
-		<field name="code">2172003000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">IVA  DEBITO FISCAL</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta2173001000" model="account.account.template">
-		<field name="code">2173001000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">EMBARGO DE SUELDO</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta2173002000" model="account.account.template">
-		<field name="code">2173002000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">PRESTAMOS SOBRE FIDEICOMISO</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta2173003000" model="account.account.template">
-		<field name="code">2173003000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">SINDICATOS</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta2175001000" model="account.account.template">
-		<field name="code">2175001000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">VACACIONES</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta2175002000" model="account.account.template">
-		<field name="code">2175002000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">UTILIDADES</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta2175003000" model="account.account.template">
-		<field name="code">2175003000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">PRESTACIONES SOCIALES</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta2175004000" model="account.account.template">
-		<field name="code">2175004000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">INTERESES S/PRESTACIONES SOCIALES</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta2175005000" model="account.account.template">
-		<field name="code">2175005000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">BONIFICACION ACCIDENTAL UNICA</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta2175006000" model="account.account.template">
-		<field name="code">2175006000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">PRIMA POR EFECIENCIA</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta2175008000" model="account.account.template">
-		<field name="code">2175008000</field>
-		<field name="reconcile" eval="True"/>
-		<field name="user_type_id" ref="account.data_account_type_payable"/>
-		<field name="name">POLIZA DE SEGURO POR PAGAR</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta2175009000" model="account.account.template">
-		<field name="code">2175009000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">PUBLICIDAD Y PROPAGANDA</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta2175010000" model="account.account.template">
-		<field name="code">2175010000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">COMISIONES</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta2175011000" model="account.account.template">
-		<field name="code">2175011000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">ALQUILERES</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta2175012000" model="account.account.template">
-		<field name="code">2175012000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">TARJETA CORPORATIVA</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta2175013000" model="account.account.template">
-		<field name="code">2175013000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">CONDOMINIOS</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta2175014000" model="account.account.template">
-		<field name="code">2175014000</field>
-		<field name="reconcile" eval="True"/>
-		<field name="user_type_id" ref="account.data_account_type_payable"/>
-		<field name="name">IMPUESTOS MUNICIPALES POR PAGAR</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta2175015000" model="account.account.template">
-		<field name="code">2175015000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">CONVESION DE COMERCIALIZACION</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta2175017000" model="account.account.template">
-		<field name="code">2175017000</field>
-		<field name="reconcile" eval="True"/>
-		<field name="user_type_id" ref="account.data_account_type_payable"/>
-		<field name="name">NOMINA POR PAGAR</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta2175018000" model="account.account.template">
-		<field name="code">2175018000</field>
-		<field name="reconcile" eval="True"/>
-		<field name="user_type_id" ref="account.data_account_type_payable"/>
-		<field name="name">IMPUESTOS POR PAGAR</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta2175019000" model="account.account.template">
-		<field name="code">2175019000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">PROGRAMA DE ALIMENTACION</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta2175020000" model="account.account.template">
-		<field name="code">2175020000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">ADELANTO DE CLIENTES</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta2175021000" model="account.account.template">
-		<field name="code">2175021000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">PATENTE INDUSTRIA Y COMERCIO</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta2181001000" model="account.account.template">
-		<field name="code">2181001000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">RESERVAS OPERATIVAS</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta2181002000" model="account.account.template">
-		<field name="code">2181002000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">RESERVAS FINANCIERAS</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta2181003000" model="account.account.template">
-		<field name="code">2181003000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">RESERVAS FISCALES</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta2191001000" model="account.account.template">
-		<field name="code">2191001000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">ISR  ACUMULADOS GASTOS</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta2191002000" model="account.account.template">
-		<field name="code">2191002000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">DECLARACION ESTIMADAS</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta2191003000" model="account.account.template">
-		<field name="code">2191003000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">RAR AJUSTE INICIAL POR INFLACION</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta2201111000" model="account.account.template">
-		<field name="code">2201111000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">PASIVOS A  CORTO PLAZO</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta2201112000" model="account.account.template">
-		<field name="code">2201112000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account.data_account_type_current_assets"/>
-		<field name="name">4% IVA RETENIDO FLETES</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta2201113000" model="account.account.template">
-		<field name="code">2201113000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account.data_account_type_current_liabilities"/>
-		<field name="name">ISR RETENIDO SALARIOS</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta2201114000" model="account.account.template">
-		<field name="code">2201114000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account.data_account_type_current_liabilities"/>
-		<field name="name">ISR RETENIDO ASIMILABLES</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta2201115000" model="account.account.template">
-		<field name="code">2201115000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account.data_account_type_current_assets"/>
-		<field name="name">10% ISR RETENIDO HONORARIOS</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta2201116000" model="account.account.template">
-		<field name="code">2201116000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account.data_account_type_current_assets"/>
-		<field name="name">10% ISR RETENIDO ARRENDAMIENTO</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta2201117000" model="account.account.template">
-		<field name="code">2201117000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account.data_account_type_current_assets"/>
-		<field name="name">10.67%  IVA RETENIDO ARRENDAMIENTO</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta2201118000" model="account.account.template">
-		<field name="code">2201118000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account.data_account_type_current_assets"/>
-		<field name="name">10.67%  IVA RETENIDO HONORARIOS</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta2201119000" model="account.account.template">
-		<field name="code">2201119000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account.data_account_type_current_liabilities"/>
-		<field name="name">1% DE RET CEDULAR ARRENDAMIETOS (GUANAJUATO)</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta2202113000" model="account.account.template">
-		<field name="code">2202113000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account.data_account_type_current_liabilities"/>
-		<field name="name">IVA POR TRASLADAR o COBRADO</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta2511001000" model="account.account.template">
-		<field name="code">2511001000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">PASIVOS FINANCIEROS A LARGO PLAZO</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta2521001000" model="account.account.template">
-		<field name="code">2521001000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">INDEMNIZACIONES SENCILLAS</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta2521002000" model="account.account.template">
-		<field name="code">2521002000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">INDEMNIZACIONES DOBLES</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta2581001000" model="account.account.template">
-		<field name="code">2581001000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">PASIVOS INTERCOMPAÑIAS</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta2591001000" model="account.account.template">
-		<field name="code">2591001000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">OTROS PASIVOS A LARGO PLAZO</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta3111001000" model="account.account.template">
-		<field name="code">3111001000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">CAPITAL SOCIAL</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta3111002000" model="account.account.template">
-		<field name="code">3111002000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">ACTUALIZACION DEL VALOR</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta3131001000" model="account.account.template">
-		<field name="code">3131001000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">ACCIONES EN TESORERIA</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta3131002000" model="account.account.template">
-		<field name="code">3131002000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">ACTUALIZACION DE VALOR</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta3211001000" model="account.account.template">
-		<field name="code">3211001000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">UTILIDADES NO DISTRIBUIDAS</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta3211002000" model="account.account.template">
-		<field name="code">3211002000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">UTILIDADES DEL EJERCICIO</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta3212003000" model="account.account.template">
-		<field name="code">3212003000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">REAJUSTE POR INFLACION</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta3212004000" model="account.account.template">
-		<field name="code">3212004000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">ACTUALIZACION DEL PATRIMONIO</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta3212005000" model="account.account.template">
-		<field name="code">3212005000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">EXCLUSIONES FISCALES</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta3311001000" model="account.account.template">
-		<field name="code">3311001000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">VALOR ORIGINAL RESERVA LEGAL</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta3311002000" model="account.account.template">
-		<field name="code">3311002000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">RESERVA P/FUTURO AUMENTO DE CAPITAL</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta3391001000" model="account.account.template">
-		<field name="code">3391001000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">VALOR ORIGINAL</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta3391002000" model="account.account.template">
-		<field name="code">3391002000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">ACTUALIZACION DEL VALOR</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta4111001000" model="account.account.template">
-		<field name="code">4111001000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">CARTAS DE CREDITOS</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta4111002000" model="account.account.template">
-		<field name="code">4111002000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">MERCANCIAS EN CONSIGNACION</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta4111003000" model="account.account.template">
-		<field name="code">4111003000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">MERCANCIAS COMPRADAS EN TRANSITO</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta4511002000" model="account.account.template">
-		<field name="code">4511002000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">MERCANCIA EN CONSIGNACION P. COMPRA</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta4511003000" model="account.account.template">
-		<field name="code">4511003000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">MERCANCIA VENDIDAS EN TRANSITO</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta5111001000" model="account.account.template">
-		<field name="code">5111001000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account.data_account_type_revenue"/>
-		<field name="name">VENTAS NACIONALES</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta5111002000" model="account.account.template">
-		<field name="code">5111002000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">VENTAS NACIONALES AL DETAL</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta5111003000" model="account.account.template">
-		<field name="code">5111003000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account.data_account_type_other_income"/>
-		<field name="name">VENTAS EXPORTACION</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta5111004000" model="account.account.template">
-		<field name="code">5111004000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">VENTAS INMUEBLES</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta5112001000" model="account.account.template">
-		<field name="code">5112001000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">INGRESOS POR SERVICIOS</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta5114001000" model="account.account.template">
-		<field name="code">5114001000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">DESCUENTOS EN VENTAS</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta5114002000" model="account.account.template">
-		<field name="code">5114002000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">DEVOLUCIONES EN VENTAS</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta6111001000" model="account.account.template">
-		<field name="code">6111001000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account.data_account_type_expenses"/>
-		<field name="name">COSTO DE VENTAS</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta7111001000" model="account.account.template">
-		<field name="code">7111001000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">DISTRIBUCION Y REPARTO LOCALES</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta7111002000" model="account.account.template">
-		<field name="code">7111002000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">PROMOCIONES</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta7111003000" model="account.account.template">
-		<field name="code">7111003000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">ACTIVIDADES REGIONALES</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta7111004000" model="account.account.template">
-		<field name="code">7111004000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">EVENTOS ESPECIALES</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta7111005000" model="account.account.template">
-		<field name="code">7111005000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">MATERIALES PROMOCIONALES</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta7111006000" model="account.account.template">
-		<field name="code">7111006000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">PUBLICIDAD</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta7111007000" model="account.account.template">
-		<field name="code">7111007000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">MEDIOS</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta7111008000" model="account.account.template">
-		<field name="code">7111008000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">PRODUCCION MATERIAL P.O.P.</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta7111009000" model="account.account.template">
-		<field name="code">7111009000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">CUENTAS INCOBRABLES NACIONALES</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta7111010000" model="account.account.template">
-		<field name="code">7111010000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">TRANSPORTE Y FLETES</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta7111011000" model="account.account.template">
-		<field name="code">7111011000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">PATENTE INDUSTRIA Y COMERCIO</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta7131001000" model="account.account.template">
-		<field name="code">7131001000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">SUELDOS EMPLEADOS</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta7131002000" model="account.account.template">
-		<field name="code">7131002000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">SUELDOS DIRECTIVOS</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta7131003000" model="account.account.template">
-		<field name="code">7131003000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">HORAS EXTRAS</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta7131004000" model="account.account.template">
-		<field name="code">7131004000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">HORAS EXTRAORDINARIAS</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta7131005000" model="account.account.template">
-		<field name="code">7131005000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">COMISION AL PERSONAL</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta7131006000" model="account.account.template">
-		<field name="code">7131006000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">TRANSPORTE Y ALIMENTACION</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta7131007000" model="account.account.template">
-		<field name="code">7131007000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">PROGRAMA DE ALIMENTACION EMPLEADOS</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta7131008000" model="account.account.template">
-		<field name="code">7131008000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">BENEFICIOS UNIFORMES</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta7131009000" model="account.account.template">
-		<field name="code">7131009000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">BENEFICIOS COMEDOR</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta7131010000" model="account.account.template">
-		<field name="code">7131010000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">BENEFICIOS SERVICIOS MEDICOS</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta7131011000" model="account.account.template">
-		<field name="code">7131011000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">BENEFICIOS AYUDAS ESCOLARES</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta7131012000" model="account.account.template">
-		<field name="code">7131012000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">BENEFICIOS ADIESTRAMIENTOS-CURSOS</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta7131013000" model="account.account.template">
-		<field name="code">7131013000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">BENEFICIOS BECAS</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta7131016000" model="account.account.template">
-		<field name="code">7131016000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">PRESTACIONES SOCIALES</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta7131017000" model="account.account.template">
-		<field name="code">7131017000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">INTERESES S/PRESTACIONES SOCIALES</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta7131018000" model="account.account.template">
-		<field name="code">7131018000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">UTILIDADES</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta7131019000" model="account.account.template">
-		<field name="code">7131019000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">VACACIONES</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta7131020000" model="account.account.template">
-		<field name="code">7131020000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">BONO VACACIONAL</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta7131021000" model="account.account.template">
-		<field name="code">7131021000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">CONTRIBUCIONES</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta7131025000" model="account.account.template">
-		<field name="code">7131025000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">BONIFICACION UNICA ESPECIAL</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta7131030000" model="account.account.template">
-		<field name="code">7131030000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">VIATICOS Y GASTOS DE REPRESENTACION</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta7131031000" model="account.account.template">
-		<field name="code">7131031000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">HONORARIOS POR PARTIPACION JUNTA DIRECTIVA</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta7131033000" model="account.account.template">
-		<field name="code">7131033000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">PRIMA POR RENDIMIENTO</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta7131035000" model="account.account.template">
-		<field name="code">7131035000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">GASTOS PERSONAL CONTRATADO</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta7131036000" model="account.account.template">
-		<field name="code">7131036000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">GASTOS PERSONAL TRANSFERIDOSR</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta7151001000" model="account.account.template">
-		<field name="code">7151001000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">SUMINISTROS DE EQUIPOS DE OFICINA</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta7151002000" model="account.account.template">
-		<field name="code">7151002000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">REPARACIONES</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta7151003000" model="account.account.template">
-		<field name="code">7151003000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">MANTENIMIENTOS</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta7151004000" model="account.account.template">
-		<field name="code">7151004000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">MANTENIMIENTO DE VEHICULOS</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta7151005000" model="account.account.template">
-		<field name="code">7151005000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">ARTICULOS DE OFICINA</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta7151006000" model="account.account.template">
-		<field name="code">7151006000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">UTILES DE LIMPIEZA</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta7151007000" model="account.account.template">
-		<field name="code">7151007000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">HONORARIOS PROFESIONALES</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta7151009000" model="account.account.template">
-		<field name="code">7151009000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">SERVICIOS PUBLICOS</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta7151010000" model="account.account.template">
-		<field name="code">7151010000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">ENERGIA ELECTRICA</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta7151012000" model="account.account.template">
-		<field name="code">7151012000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">TELEFONOS Y TELECOMUNICACIONES</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta7151013000" model="account.account.template">
-		<field name="code">7151013000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">AGUA POTABLE Y REFRIGERIO</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta7151014000" model="account.account.template">
-		<field name="code">7151014000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">ASEO URBANO</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta7151015000" model="account.account.template">
-		<field name="code">7151015000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">PALERIA Y FOTOCOPIADO</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta7151016000" model="account.account.template">
-		<field name="code">7151016000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">ASEO Y LIMPIEZA</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta7151017000" model="account.account.template">
-		<field name="code">7151017000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">PASAJES LOCALES Y EXT.DEDUCIBLES</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta7151018000" model="account.account.template">
-		<field name="code">7151018000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">PASAJE EXTERIOR NO DEDUCIBLE</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta7151019000" model="account.account.template">
-		<field name="code">7151019000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">VIATICOS DEDUCIBLES</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta7151020000" model="account.account.template">
-		<field name="code">7151020000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">VIATICOS NO DEDUCIBLES</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta7151021000" model="account.account.template">
-		<field name="code">7151021000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">GASTOS DE REPRESENTACION</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta7151022000" model="account.account.template">
-		<field name="code">7151022000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">HOSPEDAJE</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta7151023000" model="account.account.template">
-		<field name="code">7151023000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">EQUIPOS Y EVENTOS DEPORTIVOS</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta7151024000" model="account.account.template">
-		<field name="code">7151024000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">CONVENSION  DE COMERCIALIZACION</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta7151025000" model="account.account.template">
-		<field name="code">7151025000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">OTROS GASTOS</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta7151026000" model="account.account.template">
-		<field name="code">7151026000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">ARRENDAMIENTO</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta7151027000" model="account.account.template">
-		<field name="code">7151027000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">AVERIAS-PRODUCTOS</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta7151028000" model="account.account.template">
-		<field name="code">7151028000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">AJUSTE DE INVENTARIOS DONADOS</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta7151029000" model="account.account.template">
-		<field name="code">7151029000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">AJUSTE DE INVENTARIOS OBSOLETOS</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta7151030000" model="account.account.template">
-		<field name="code">7151030000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">TRAMITES DE SOLVENCIAS</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta7151031000" model="account.account.template">
-		<field name="code">7151031000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">CONDOMINIOS</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta7151032000" model="account.account.template">
-		<field name="code">7151032000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">FLETES Y TRANSPORTES</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta7151033000" model="account.account.template">
-		<field name="code">7151033000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">ESTACIONAMINETO</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta7151035000" model="account.account.template">
-		<field name="code">7151035000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">TRAMITES LEGALES</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta7151036000" model="account.account.template">
-		<field name="code">7151036000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">GASTOS DE SISTEMAS</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta7151037000" model="account.account.template">
-		<field name="code">7151037000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">DERECHO DE FRENTE</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta7151039000" model="account.account.template">
-		<field name="code">7151039000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">COMIDAS, VIAJES Y TRASLADOS</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta7151040000" model="account.account.template">
-		<field name="code">7151040000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">COMBUSTIBLES</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta7151041000" model="account.account.template">
-		<field name="code">7151041000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">GASTOS DE ISR </field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta7151042000" model="account.account.template">
-		<field name="code">7151042000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">REPAROS</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta7151043000" model="account.account.template">
-		<field name="code">7151043000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">SEGUROS</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta7151044000" model="account.account.template">
-		<field name="code">7151044000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">PARTIDAS NO DEDUCIBLES</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta7151045000" model="account.account.template">
-		<field name="code">7151045000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">SERVICIOS CONTRATADOS A TERCEROS</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta7151046000" model="account.account.template">
-		<field name="code">7151046000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account.data_account_type_current_assets"/>
-		<field name="name">BONIFICACION UNICA ESPECIAL</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta7151047000" model="account.account.template">
-		<field name="code">7151047000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account.data_account_type_current_assets"/>
-		<field name="name">SERVICIOS DE PUBLICIDAD</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta7151048000" model="account.account.template">
-		<field name="code">7151048000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">REMANENTES DISTRIBUIBLES</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta7151049000" model="account.account.template">
-		<field name="code">7151049000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">ASIMILABLES A SALARIOS</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta7161002000" model="account.account.template">
-		<field name="code">7161002000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">INMUEBLES</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta7161003000" model="account.account.template">
-		<field name="code">7161003000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">MAQUINARIAS Y EQUIPOS</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta7161004000" model="account.account.template">
-		<field name="code">7161004000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">VEHICULOS</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta7161005000" model="account.account.template">
-		<field name="code">7161005000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">MUEBLES Y ENSERES</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta7161006000" model="account.account.template">
-		<field name="code">7161006000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">LICENCIA Y SOFTWARE</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta7161007000" model="account.account.template">
-		<field name="code">7161007000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">MEJORAS A PROPIEDAD</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta7162001000" model="account.account.template">
-		<field name="code">7162001000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">SEGUROS</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta9111001000" model="account.account.template">
-		<field name="code">9111001000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">INTERESES BANCOS NACIONALES</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta9111002000" model="account.account.template">
-		<field name="code">9111002000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">COMISIONES Y GASTOS BANCARIOS</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta9111003000" model="account.account.template">
-		<field name="code">9111003000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">COMISIONES TICKET DE ALIMENTACION</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta9111004000" model="account.account.template">
-		<field name="code">9111004000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">INTERESES POR FINANCIAMIENTOS</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta9111099000" model="account.account.template">
-		<field name="code">9111099000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">OTROS EGRESOS</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta9113002000" model="account.account.template">
-		<field name="code">9113002000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">INTERESES S/PRESTACIONES SOCIALES</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta9113003000" model="account.account.template">
-		<field name="code">9113003000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">PERDIDAS EN VENTAS ACTIVOS FIJOS</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta9113004000" model="account.account.template">
-		<field name="code">9113004000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">PERDIDAS EN INVERSIONES DE BONOS P.</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta9113005000" model="account.account.template">
-		<field name="code">9113005000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">PERDIDAS EN VENTAS DE INVERSIONES</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta9113006000" model="account.account.template">
-		<field name="code">9113006000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">PERDIDAS EN DIFERENCIAL CAMBIARIO</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta9113007000" model="account.account.template">
-		<field name="code">9113007000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">AJUSTE DE AÑOS ANTERIORES</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta9113010000" model="account.account.template">
-		<field name="code">9113010000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">PERDIDA POR ROBO DE INVENTARIO</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta9113012000" model="account.account.template">
-		<field name="code">9113012000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">FLUCTUACION CAMBIARIA NO REALIZADAS</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta9114001000" model="account.account.template">
-		<field name="code">9114001000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">IMPUESTOS A LAS TRANSACIONES FINANCIERAS</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta9211001000" model="account.account.template">
-		<field name="code">9211001000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account.data_account_type_other_income"/>
-		<field name="name">INTERESES DE BANCOS NACIONALES</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta9211002000" model="account.account.template">
-		<field name="code">9211002000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">INTERESES DE BANCOS EXTRANJEROS</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta9211003000" model="account.account.template">
-		<field name="code">9211003000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">OTROS INGRESOS FINANCIEROS</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta9212001000" model="account.account.template">
-		<field name="code">9212001000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">GANANCIAS EN VENTAS DE ACTIVOS FIJOS</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta9212002000" model="account.account.template">
-		<field name="code">9212002000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">GANANCIAS EN VENTAS DE INVERSIONES</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta9212003000" model="account.account.template">
-		<field name="code">9212003000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account.data_account_type_other_income"/>
-		<field name="name">GANANCIAS EN DIFERENCIAL CAMBIARIO</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta9212004000" model="account.account.template">
-		<field name="code">9212004000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">INTERESES VARIOS</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
-<record id="cuenta9212005000" model="account.account.template">
-		<field name="code">9212005000</field>
-		<field name="reconcile" eval="False"/>
-		<field name="user_type_id" ref="account_type_other"/>
-		<field name="name">OTROS INGRESOS</field>
-		<field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
-</record>
-
+    <record id="cuenta1129003000" model="account.account.template">
+        <field name="name">TRANSFERENCIAS BANCARIAS</field>
+        <field name="code">1129003000</field>
+        <field name="reconcile" eval="True"/>
+        <field name="user_type_id" ref="account.data_account_type_current_assets"/>
+    </record>
+    <record id="vauxoo_mx_chart_template" model="account.chart.template">
+        <field name="name">Plan de Cuentas para Mexico</field>
+        <field name="bank_account_code_prefix">1113</field>
+        <field name="cash_account_code_prefix">1111</field>
+        <field name="code_digits">3</field>
+        <field name="currency_id" ref="base.MXN"/>
+        <field name="transfer_account_id" ref="cuenta1129003000"/>
+    </record>
+
+    <record id="cuenta1129003000" model="account.account.template">
+        <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+    </record>
 
 <!--
-	 Cuenta Template 
+    Cuenta Template
 -->
-     
-	<record id="vauxoo_mx_chart_template" model="account.chart.template">
-        <field name="property_account_receivable_id" ref="cuenta1122001000"/>
-        <field name="property_account_payable_id" ref="cuenta2122001000"/>
-        <field name="property_account_expense_categ_id" ref="cuenta6111001000"/>
-        <field name="property_account_income_categ_id" ref="cuenta5111001000"/>
-        <field name="income_currency_exchange_account_id" ref="cuenta9212003000"/>
-        <field name="expense_currency_exchange_account_id" ref="cuenta9113006000"/>
-	</record>
-   
-  
-</data>
+        <record id='cuenta101_01' model='account.account.template'>
+            <field name='name'>Caja y efectivo</field>
+            <field name='code'>101.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account.data_account_type_liquidity"/>
+            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_101'), ref('account_tag_101_01')])]"/>
+        </record>
+        <record id='cuenta102_01' model='account.account.template'>
+            <field name='name'>Bancos nacionales</field>
+            <field name='code'>102.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account.data_account_type_liquidity"/>
+            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_102'), ref('account_tag_102_01')])]"/>
+        </record>
+        <record id='cuenta102_02' model='account.account.template'>
+            <field name='name'>Bancos extranjeros</field>
+            <field name='code'>102.02</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account.data_account_type_liquidity"/>
+            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_102'), ref('account_tag_102_02')])]"/>
+        </record>
+        <record id='cuenta103_01' model='account.account.template'>
+            <field name='name'>Inversiones temporales</field>
+            <field name='code'>103.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_103'), ref('account_tag_103_01')])]"/>
+        </record>
+        <record id='cuenta103_02' model='account.account.template'>
+            <field name='name'>Inversiones en fideicomisos</field>
+            <field name='code'>103.02</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_103'), ref('account_tag_103_02')])]"/>
+        </record>
+        <record id='cuenta103_03' model='account.account.template'>
+            <field name='name'>Otras inversiones</field>
+            <field name='code'>103.03</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_103'), ref('account_tag_103_03')])]"/>
+        </record>
+        <record id='cuenta104_01' model='account.account.template'>
+            <field name='name'>Otros instrumentos financieros</field>
+            <field name='code'>104.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_104'), ref('account_tag_104_01')])]"/>
+        </record>
+        <record id='cuenta105_01' model='account.account.template'>
+            <field name='name'>Clientes nacionales</field>
+            <field name='code'>105.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account.data_account_type_receivable"/>
+            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_105'), ref('account_tag_105_01')])]"/>
+        </record>
+        <record id='cuenta105_02' model='account.account.template'>
+            <field name='name'>Clientes extranjeros</field>
+            <field name='code'>105.02</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account.data_account_type_receivable"/>
+            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_105'), ref('account_tag_105_02')])]"/>
+        </record>
+        <record id='cuenta105_03' model='account.account.template'>
+            <field name='name'>Clientes nacionales parte relacionada</field>
+            <field name='code'>105.03</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account.data_account_type_receivable"/>
+            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_105'), ref('account_tag_105_03')])]"/>
+        </record>
+        <record id='cuenta105_04' model='account.account.template'>
+            <field name='name'>Clientes extranjeros parte relacionada</field>
+            <field name='code'>105.04</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account.data_account_type_receivable"/>
+            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_105'), ref('account_tag_105_04')])]"/>
+        </record>
+        <record id='cuenta106_01' model='account.account.template'>
+            <field name='name'>Cuentas y documentos por cobrar a corto plazo nacional</field>
+            <field name='code'>106.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account.data_account_type_receivable"/>
+            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_106'), ref('account_tag_106_01')])]"/>
+        </record>
+        <record id='cuenta106_02' model='account.account.template'>
+            <field name='name'>Cuentas y documentos por cobrar a corto plazo extranjero</field>
+            <field name='code'>106.02</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account.data_account_type_receivable"/>
+            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_106'), ref('account_tag_106_02')])]"/>
+        </record>
+        <record id='cuenta106_03' model='account.account.template'>
+            <field name='name'>Cuentas y documentos por cobrar a corto plazo nacional parte relacionada</field>
+            <field name='code'>106.03</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account.data_account_type_receivable"/>
+            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_106'), ref('account_tag_106_03')])]"/>
+        </record>
+        <record id='cuenta106_04' model='account.account.template'>
+            <field name='name'>Cuentas y documentos por cobrar a corto plazo extranjero parte relacionada</field>
+            <field name='code'>106.04</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account.data_account_type_receivable"/>
+            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_106'), ref('account_tag_106_04')])]"/>
+        </record>
+        <record id='cuenta106_05' model='account.account.template'>
+            <field name='name'>Intereses por cobrar a corto plazo nacional</field>
+            <field name='code'>106.05</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account.data_account_type_receivable"/>
+            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_106'), ref('account_tag_106_05')])]"/>
+        </record>
+        <record id='cuenta106_06' model='account.account.template'>
+            <field name='name'>Intereses por cobrar a corto plazo extranjero</field>
+            <field name='code'>106.06</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account.data_account_type_receivable"/>
+            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_106'), ref('account_tag_106_06')])]"/>
+        </record>
+        <record id='cuenta106_07' model='account.account.template'>
+            <field name='name'>Intereses por cobrar a corto plazo nacional parte relacionada</field>
+            <field name='code'>106.07</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account.data_account_type_receivable"/>
+            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_106'), ref('account_tag_106_07')])]"/>
+        </record>
+        <record id='cuenta106_08' model='account.account.template'>
+            <field name='name'>Intereses por cobrar a corto plazo extranjero parte relacionada</field>
+            <field name='code'>106.08</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account.data_account_type_receivable"/>
+            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_106'), ref('account_tag_106_08')])]"/>
+        </record>
+        <record id='cuenta106_09' model='account.account.template'>
+            <field name='name'>Otras cuentas y documentos por cobrar a corto plazo</field>
+            <field name='code'>106.09</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account.data_account_type_receivable"/>
+            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_106'), ref('account_tag_106_09')])]"/>
+        </record>
+        <record id='cuenta106_10' model='account.account.template'>
+            <field name='name'>Otras cuentas y documentos por cobrar a corto plazo parte relacionada</field>
+            <field name='code'>106.10</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account.data_account_type_receivable"/>
+            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_106'), ref('account_tag_106_10')])]"/>
+        </record>
+        <record id='cuenta107_01' model='account.account.template'>
+            <field name='name'>Funcionarios y empleados</field>
+            <field name='code'>107.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account.data_account_type_receivable"/>
+            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_107'), ref('account_tag_107_01')])]"/>
+        </record>
+        <record id='cuenta107_02' model='account.account.template'>
+            <field name='name'>Socios y accionistas</field>
+            <field name='code'>107.02</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account.data_account_type_receivable"/>
+            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_107'), ref('account_tag_107_02')])]"/>
+        </record>
+        <record id='cuenta107_03' model='account.account.template'>
+            <field name='name'>Partes relacionadas nacionales</field>
+            <field name='code'>107.03</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account.data_account_type_receivable"/>
+            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_107'), ref('account_tag_107_03')])]"/>
+        </record>
+        <record id='cuenta107_04' model='account.account.template'>
+            <field name='name'>Partes relacionadas extranjeros</field>
+            <field name='code'>107.04</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account.data_account_type_receivable"/>
+            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_107'), ref('account_tag_107_04')])]"/>
+        </record>
+        <record id='cuenta107_05' model='account.account.template'>
+            <field name='name'>Otros deudores diversos</field>
+            <field name='code'>107.05</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account.data_account_type_receivable"/>
+            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_107'), ref('account_tag_107_05')])]"/>
+        </record>
+        <record id='cuenta108_01' model='account.account.template'>
+            <field name='name'>Estimación de cuentas incobrables nacional</field>
+            <field name='code'>108.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account.data_account_type_receivable"/>
+            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_108'), ref('account_tag_108_01')])]"/>
+        </record>
+        <record id='cuenta108_02' model='account.account.template'>
+            <field name='name'>Estimación de cuentas incobrables extranjero</field>
+            <field name='code'>108.02</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account.data_account_type_receivable"/>
+            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_108'), ref('account_tag_108_02')])]"/>
+        </record>
+        <record id='cuenta108_03' model='account.account.template'>
+            <field name='name'>Estimación de cuentas incobrables nacional parte relacionada</field>
+            <field name='code'>108.03</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account.data_account_type_receivable"/>
+            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_108'), ref('account_tag_108_03')])]"/>
+        </record>
+        <record id='cuenta108_04' model='account.account.template'>
+            <field name='name'>Estimación de cuentas incobrables extranjero parte relacionada</field>
+            <field name='code'>108.04</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account.data_account_type_receivable"/>
+            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_108'), ref('account_tag_108_04')])]"/>
+        </record>
+        <record id='cuenta109_01' model='account.account.template'>
+            <field name='name'>Seguros y fianzas pagados por anticipado nacional</field>
+            <field name='code'>109.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account.data_account_type_receivable"/>
+            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_109'), ref('account_tag_109_01')])]"/>
+        </record>
+        <record id='cuenta109_02' model='account.account.template'>
+            <field name='name'>Seguros y fianzas pagados por anticipado extranjero</field>
+            <field name='code'>109.02</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account.data_account_type_receivable"/>
+            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_109'), ref('account_tag_109_02')])]"/>
+        </record>
+        <record id='cuenta109_03' model='account.account.template'>
+            <field name='name'>Seguros y fianzas pagados por anticipado nacional parte relacionada</field>
+            <field name='code'>109.03</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account.data_account_type_receivable"/>
+            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_109'), ref('account_tag_109_03')])]"/>
+        </record>
+        <record id='cuenta109_04' model='account.account.template'>
+            <field name='name'>Seguros y fianzas pagados por anticipado extranjero parte relacionada</field>
+            <field name='code'>109.04</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account.data_account_type_receivable"/>
+            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_109'), ref('account_tag_109_04')])]"/>
+        </record>
+        <record id='cuenta109_05' model='account.account.template'>
+            <field name='name'>Rentas pagados por anticipado nacional</field>
+            <field name='code'>109.05</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account.data_account_type_receivable"/>
+            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_109'), ref('account_tag_109_05')])]"/>
+        </record>
+        <record id='cuenta109_06' model='account.account.template'>
+            <field name='name'>Rentas pagados por anticipado extranjero</field>
+            <field name='code'>109.06</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account.data_account_type_receivable"/>
+            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_109'), ref('account_tag_109_06')])]"/>
+        </record>
+        <record id='cuenta109_07' model='account.account.template'>
+            <field name='name'>Rentas pagados por anticipado nacional parte relacionada</field>
+            <field name='code'>109.07</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account.data_account_type_receivable"/>
+            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_109'), ref('account_tag_109_07')])]"/>
+        </record>
+        <record id='cuenta109_08' model='account.account.template'>
+            <field name='name'>Rentas pagados por anticipado extranjero parte relacionada</field>
+            <field name='code'>109.08</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account.data_account_type_receivable"/>
+            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_109'), ref('account_tag_109_08')])]"/>
+        </record>
+        <record id='cuenta109_09' model='account.account.template'>
+            <field name='name'>Intereses pagados por anticipado nacional</field>
+            <field name='code'>109.09</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account.data_account_type_receivable"/>
+            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_109'), ref('account_tag_109_09')])]"/>
+        </record>
+        <record id='cuenta109_10' model='account.account.template'>
+            <field name='name'>Intereses pagados por anticipado extranjero</field>
+            <field name='code'>109.10</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account.data_account_type_receivable"/>
+            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_109'), ref('account_tag_109_10')])]"/>
+        </record>
+        <record id='cuenta109_11' model='account.account.template'>
+            <field name='name'>Intereses pagados por anticipado nacional parte relacionada</field>
+            <field name='code'>109.11</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account.data_account_type_receivable"/>
+            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_109'), ref('account_tag_109_11')])]"/>
+        </record>
+        <record id='cuenta109_12' model='account.account.template'>
+            <field name='name'>Intereses pagados por anticipado extranjero parte relacionada</field>
+            <field name='code'>109.12</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account.data_account_type_receivable"/>
+            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_109'), ref('account_tag_109_12')])]"/>
+        </record>
+        <record id='cuenta109_13' model='account.account.template'>
+            <field name='name'>Factoraje financiero pagados por anticipado nacional</field>
+            <field name='code'>109.13</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account.data_account_type_receivable"/>
+            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_109'), ref('account_tag_109_13')])]"/>
+        </record>
+        <record id='cuenta109_14' model='account.account.template'>
+            <field name='name'>Factoraje financiero pagados por anticipado extranjero</field>
+            <field name='code'>109.14</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account.data_account_type_receivable"/>
+            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_109'), ref('account_tag_109_14')])]"/>
+        </record>
+        <record id='cuenta109_15' model='account.account.template'>
+            <field name='name'>Factoraje financiero pagados por anticipado nacional parte relacionada</field>
+            <field name='code'>109.15</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account.data_account_type_receivable"/>
+            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_109'), ref('account_tag_109_15')])]"/>
+        </record>
+        <record id='cuenta109_16' model='account.account.template'>
+            <field name='name'>Factoraje financiero pagados por anticipado extranjero parte relacionada</field>
+            <field name='code'>109.16</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account.data_account_type_receivable"/>
+            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_109'), ref('account_tag_109_16')])]"/>
+        </record>
+        <record id='cuenta109_17' model='account.account.template'>
+            <field name='name'>Arrendamiento financiero pagados por anticipado nacional</field>
+            <field name='code'>109.17</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account.data_account_type_receivable"/>
+            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_109'), ref('account_tag_109_17')])]"/>
+        </record>
+        <record id='cuenta109_18' model='account.account.template'>
+            <field name='name'>Arrendamiento financiero pagados por anticipado extranjero</field>
+            <field name='code'>109.18</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account.data_account_type_receivable"/>
+            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_109'), ref('account_tag_109_18')])]"/>
+        </record>
+        <record id='cuenta109_19' model='account.account.template'>
+            <field name='name'>Arrendamiento financiero pagados por anticipado nacional parte relacionada</field>
+            <field name='code'>109.19</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account.data_account_type_receivable"/>
+            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_109'), ref('account_tag_109_19')])]"/>
+        </record>
+        <record id='cuenta109_20' model='account.account.template'>
+            <field name='name'>Arrendamiento financiero pagados por anticipado extranjero parte relacionada</field>
+            <field name='code'>109.20</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account.data_account_type_receivable"/>
+            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_109'), ref('account_tag_109_20')])]"/>
+        </record>
+        <record id='cuenta109_21' model='account.account.template'>
+            <field name='name'>Pérdida por deterioro de pagos anticipados</field>
+            <field name='code'>109.21</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account.data_account_type_receivable"/>
+            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_109'), ref('account_tag_109_21')])]"/>
+        </record>
+        <record id='cuenta109_22' model='account.account.template'>
+            <field name='name'>Derechos fiduciarios</field>
+            <field name='code'>109.22</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account.data_account_type_receivable"/>
+            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_109'), ref('account_tag_109_22')])]"/>
+        </record>
+        <record id='cuenta109_23' model='account.account.template'>
+            <field name='name'>Otros pagos anticipados</field>
+            <field name='code'>109.23</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account.data_account_type_receivable"/>
+            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_109'), ref('account_tag_109_23')])]"/>
+        </record>
+        <record id='cuenta110_01' model='account.account.template'>
+            <field name='name'>Subsidio al empleo por aplicar</field>
+            <field name='code'>110.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_110'), ref('account_tag_110_01')])]"/>
+        </record>
+        <record id='cuenta111_01' model='account.account.template'>
+            <field name='name'>Crédito al diesel por acreditar</field>
+            <field name='code'>111.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_111'), ref('account_tag_111_01')])]"/>
+        </record>
+        <record id='cuenta112_01' model='account.account.template'>
+            <field name='name'>Otros estímulos</field>
+            <field name='code'>112.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_112'), ref('account_tag_112_01')])]"/>
+        </record>
+        <record id='cuenta113_01' model='account.account.template'>
+            <field name='name'>IVA a favor</field>
+            <field name='code'>113.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_113'), ref('account_tag_113_01')])]"/>
+        </record>
+        <record id='cuenta113_02' model='account.account.template'>
+            <field name='name'>ISR a favor</field>
+            <field name='code'>113.02</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_113'), ref('account_tag_113_02')])]"/>
+        </record>
+        <record id='cuenta113_03' model='account.account.template'>
+            <field name='name'>IETU a favor</field>
+            <field name='code'>113.03</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_113'), ref('account_tag_113_03')])]"/>
+        </record>
+        <record id='cuenta113_04' model='account.account.template'>
+            <field name='name'>IDE a favor</field>
+            <field name='code'>113.04</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_113'), ref('account_tag_113_04')])]"/>
+        </record>
+        <record id='cuenta113_05' model='account.account.template'>
+            <field name='name'>IA a favor</field>
+            <field name='code'>113.05</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_113'), ref('account_tag_113_05')])]"/>
+        </record>
+        <record id='cuenta113_06' model='account.account.template'>
+            <field name='name'>Subsidio al empleo</field>
+            <field name='code'>113.06</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_113'), ref('account_tag_113_06')])]"/>
+        </record>
+        <record id='cuenta113_07' model='account.account.template'>
+            <field name='name'>Pago de lo indebido</field>
+            <field name='code'>113.07</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_113'), ref('account_tag_113_07')])]"/>
+        </record>
+        <record id='cuenta113_08' model='account.account.template'>
+            <field name='name'>Otros impuestos a favor</field>
+            <field name='code'>113.08</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_113'), ref('account_tag_113_08')])]"/>
+        </record>
+        <record id='cuenta114_01' model='account.account.template'>
+            <field name='name'>Pagos provisionales de ISR</field>
+            <field name='code'>114.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_114'), ref('account_tag_114_01')])]"/>
+        </record>
+        <record id='cuenta115_01' model='account.account.template'>
+            <field name='name'>Inventario</field>
+            <field name='code'>115.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_115'), ref('account_tag_115_01')])]"/>
+        </record>
+        <record id='cuenta115_02' model='account.account.template'>
+            <field name='name'>Materia prima y materiales</field>
+            <field name='code'>115.02</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_115'), ref('account_tag_115_02')])]"/>
+        </record>
+        <record id='cuenta115_03' model='account.account.template'>
+            <field name='name'>Producción en proceso</field>
+            <field name='code'>115.03</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_115'), ref('account_tag_115_03')])]"/>
+        </record>
+        <record id='cuenta115_04' model='account.account.template'>
+            <field name='name'>Productos terminados</field>
+            <field name='code'>115.04</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_115'), ref('account_tag_115_04')])]"/>
+        </record>
+        <record id='cuenta115_05' model='account.account.template'>
+            <field name='name'>Mercancías en tránsito</field>
+            <field name='code'>115.05</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_115'), ref('account_tag_115_05')])]"/>
+        </record>
+        <record id='cuenta115_06' model='account.account.template'>
+            <field name='name'>Mercancías en poder de terceros</field>
+            <field name='code'>115.06</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_115'), ref('account_tag_115_06')])]"/>
+        </record>
+        <record id='cuenta115_07' model='account.account.template'>
+            <field name='name'>Otros</field>
+            <field name='code'>115.07</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_115'), ref('account_tag_115_07')])]"/>
+        </record>
+        <record id='cuenta116_01' model='account.account.template'>
+            <field name='name'>Estimación de inventarios obsoletos y de lento movimiento</field>
+            <field name='code'>116.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_116'), ref('account_tag_116_01')])]"/>
+        </record>
+        <record id='cuenta117_01' model='account.account.template'>
+            <field name='name'>Obras en proceso de inmuebles</field>
+            <field name='code'>117.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_117'), ref('account_tag_117_01')])]"/>
+        </record>
+        <record id='cuenta118_01' model='account.account.template'>
+            <field name='name'>IVA acreditable pagado</field>
+            <field name='code'>118.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_118'), ref('account_tag_118_01')])]"/>
+        </record>
+        <record id='cuenta118_02' model='account.account.template'>
+            <field name='name'>IVA acreditable de importación pagado</field>
+            <field name='code'>118.02</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_118'), ref('account_tag_118_02')])]"/>
+        </record>
+        <record id='cuenta118_03' model='account.account.template'>
+            <field name='name'>IEPS acreditable pagado</field>
+            <field name='code'>118.03</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_118'), ref('account_tag_118_03')])]"/>
+        </record>
+        <record id='cuenta118_04' model='account.account.template'>
+            <field name='name'>IEPS pagado en importación</field>
+            <field name='code'>118.04</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_118'), ref('account_tag_118_04')])]"/>
+        </record>
+        <record id='cuenta119_01' model='account.account.template'>
+            <field name='name'>IVA pendiente de pago</field>
+            <field name='code'>119.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_119'), ref('account_tag_119_01')])]"/>
+        </record>
+        <record id='cuenta119_02' model='account.account.template'>
+            <field name='name'>IVA de importación pendiente de pago</field>
+            <field name='code'>119.02</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_119'), ref('account_tag_119_02')])]"/>
+        </record>
+        <record id='cuenta119_03' model='account.account.template'>
+            <field name='name'>IEPS pendiente de pago</field>
+            <field name='code'>119.03</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_119'), ref('account_tag_119_03')])]"/>
+        </record>
+        <record id='cuenta119_04' model='account.account.template'>
+            <field name='name'>IEPS pendiente de pago en importación</field>
+            <field name='code'>119.04</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_119'), ref('account_tag_119_04')])]"/>
+        </record>
+        <record id='cuenta120_01' model='account.account.template'>
+            <field name='name'>Anticipo a proveedores nacional</field>
+            <field name='code'>120.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_120'), ref('account_tag_120_01')])]"/>
+        </record>
+        <record id='cuenta120_02' model='account.account.template'>
+            <field name='name'>Anticipo a proveedores extranjero</field>
+            <field name='code'>120.02</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_120'), ref('account_tag_120_02')])]"/>
+        </record>
+        <record id='cuenta120_03' model='account.account.template'>
+            <field name='name'>Anticipo a proveedores nacional parte relacionada</field>
+            <field name='code'>120.03</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_120'), ref('account_tag_120_03')])]"/>
+        </record>
+        <record id='cuenta120_04' model='account.account.template'>
+            <field name='name'>Anticipo a proveedores extranjero parte relacionada</field>
+            <field name='code'>120.04</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_120'), ref('account_tag_120_04')])]"/>
+        </record>
+        <record id='cuenta121_01' model='account.account.template'>
+            <field name='name'>Otros activos a corto plazo</field>
+            <field name='code'>121.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_121'), ref('account_tag_121_01')])]"/>
+        </record>
+        <record id='cuenta151_01' model='account.account.template'>
+            <field name='name'>Terrenos</field>
+            <field name='code'>151.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_151'), ref('account_tag_151_01')])]"/>
+        </record>
+        <record id='cuenta152_01' model='account.account.template'>
+            <field name='name'>Edificios</field>
+            <field name='code'>152.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_152'), ref('account_tag_152_01')])]"/>
+        </record>
+        <record id='cuenta153_01' model='account.account.template'>
+            <field name='name'>Maquinaria y equipo</field>
+            <field name='code'>153.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_153'), ref('account_tag_153_01')])]"/>
+        </record>
+        <record id='cuenta154_01' model='account.account.template'>
+            <field name='name'>Automóviles, autobuses, camiones de carga, tractocamiones, montacargas y remolques</field>
+            <field name='code'>154.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_154'), ref('account_tag_154_01')])]"/>
+        </record>
+        <record id='cuenta155_01' model='account.account.template'>
+            <field name='name'>Mobiliario y equipo de oficina</field>
+            <field name='code'>155.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_155'), ref('account_tag_155_01')])]"/>
+        </record>
+        <record id='cuenta156_01' model='account.account.template'>
+            <field name='name'>Equipo de cómputo</field>
+            <field name='code'>156.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_156'), ref('account_tag_156_01')])]"/>
+        </record>
+        <record id='cuenta157_01' model='account.account.template'>
+            <field name='name'>Equipo de comunicación</field>
+            <field name='code'>157.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_157'), ref('account_tag_157_01')])]"/>
+        </record>
+        <record id='cuenta158_01' model='account.account.template'>
+            <field name='name'>Activos biológicos, vegetales y semovientes</field>
+            <field name='code'>158.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_158'), ref('account_tag_158_01')])]"/>
+        </record>
+        <record id='cuenta159_01' model='account.account.template'>
+            <field name='name'>Obras en proceso de activos fijos</field>
+            <field name='code'>159.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_159'), ref('account_tag_159_01')])]"/>
+        </record>
+        <record id='cuenta160_01' model='account.account.template'>
+            <field name='name'>Otros activos fijos</field>
+            <field name='code'>160.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_160'), ref('account_tag_160_01')])]"/>
+        </record>
+        <record id='cuenta161_01' model='account.account.template'>
+            <field name='name'>Ferrocarriles</field>
+            <field name='code'>161.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_161'), ref('account_tag_161_01')])]"/>
+        </record>
+        <record id='cuenta162_01' model='account.account.template'>
+            <field name='name'>Embarcaciones</field>
+            <field name='code'>162.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_162'), ref('account_tag_162_01')])]"/>
+        </record>
+        <record id='cuenta163_01' model='account.account.template'>
+            <field name='name'>Aviones</field>
+            <field name='code'>163.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_163'), ref('account_tag_163_01')])]"/>
+        </record>
+        <record id='cuenta164_01' model='account.account.template'>
+            <field name='name'>Troqueles, moldes, matrices y herramental</field>
+            <field name='code'>164.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_164'), ref('account_tag_164_01')])]"/>
+        </record>
+        <record id='cuenta165_01' model='account.account.template'>
+            <field name='name'>Equipo de comunicaciones telefónicas</field>
+            <field name='code'>165.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_165'), ref('account_tag_165_01')])]"/>
+        </record>
+        <record id='cuenta166_01' model='account.account.template'>
+            <field name='name'>Equipo de comunicación satelital</field>
+            <field name='code'>166.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_166'), ref('account_tag_166_01')])]"/>
+        </record>
+        <record id='cuenta167_01' model='account.account.template'>
+            <field name='name'>Equipo de adaptaciones para personas con capacidades diferentes</field>
+            <field name='code'>167.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_167'), ref('account_tag_167_01')])]"/>
+        </record>
+        <record id='cuenta168_01' model='account.account.template'>
+            <field name='name'>Maquinaria y equipo de generación de energía de fuentes renovables o de sistemas de cogeneración de electricidad eficiente</field>
+            <field name='code'>168.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_168'), ref('account_tag_168_01')])]"/>
+        </record>
+        <record id='cuenta169_01' model='account.account.template'>
+            <field name='name'>Otra maquinaria y equipo</field>
+            <field name='code'>169.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_169'), ref('account_tag_169_01')])]"/>
+        </record>
+        <record id='cuenta170_01' model='account.account.template'>
+            <field name='name'>Adaptaciones y mejoras</field>
+            <field name='code'>170.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_170'), ref('account_tag_170_01')])]"/>
+        </record>
+        <record id='cuenta171_01' model='account.account.template'>
+            <field name='name'>Depreciación acumulada de edificios</field>
+            <field name='code'>171.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_171'), ref('account_tag_171_01')])]"/>
+        </record>
+        <record id='cuenta171_02' model='account.account.template'>
+            <field name='name'>Depreciación acumulada de maquinaria y equipo</field>
+            <field name='code'>171.02</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_171'), ref('account_tag_171_02')])]"/>
+        </record>
+        <record id='cuenta171_03' model='account.account.template'>
+            <field name='name'>Depreciación acumulada de automóviles, autobuses, camiones de carga, tractocamiones, montacargas y remolques</field>
+            <field name='code'>171.03</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_171'), ref('account_tag_171_03')])]"/>
+        </record>
+        <record id='cuenta171_04' model='account.account.template'>
+            <field name='name'>Depreciación acumulada de mobiliario y equipo de oficina</field>
+            <field name='code'>171.04</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_171'), ref('account_tag_171_04')])]"/>
+        </record>
+        <record id='cuenta171_05' model='account.account.template'>
+            <field name='name'>Depreciación acumulada de equipo de cómputo</field>
+            <field name='code'>171.05</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_171'), ref('account_tag_171_05')])]"/>
+        </record>
+        <record id='cuenta171_06' model='account.account.template'>
+            <field name='name'>Depreciación acumulada de equipo de comunicación</field>
+            <field name='code'>171.06</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_171'), ref('account_tag_171_06')])]"/>
+        </record>
+        <record id='cuenta171_07' model='account.account.template'>
+            <field name='name'>Depreciación acumulada de activos biológicos, vegetales y semovientes</field>
+            <field name='code'>171.07</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_171'), ref('account_tag_171_07')])]"/>
+        </record>
+        <record id='cuenta171_08' model='account.account.template'>
+            <field name='name'>Depreciación acumulada de otros activos fijos</field>
+            <field name='code'>171.08</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_171'), ref('account_tag_171_08')])]"/>
+        </record>
+        <record id='cuenta171_09' model='account.account.template'>
+            <field name='name'>Depreciación acumulada de ferrocarriles</field>
+            <field name='code'>171.09</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_171'), ref('account_tag_171_09')])]"/>
+        </record>
+        <record id='cuenta171_10' model='account.account.template'>
+            <field name='name'>Depreciación acumulada de embarcaciones</field>
+            <field name='code'>171.10</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_171'), ref('account_tag_171_10')])]"/>
+        </record>
+        <record id='cuenta171_11' model='account.account.template'>
+            <field name='name'>Depreciación acumulada de aviones</field>
+            <field name='code'>171.11</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_171'), ref('account_tag_171_11')])]"/>
+        </record>
+        <record id='cuenta171_12' model='account.account.template'>
+            <field name='name'>Depreciación acumulada de troqueles, moldes, matrices y herramental</field>
+            <field name='code'>171.12</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_171'), ref('account_tag_171_12')])]"/>
+        </record>
+        <record id='cuenta171_13' model='account.account.template'>
+            <field name='name'>Depreciación acumulada de equipo de comunicaciones telefónicas</field>
+            <field name='code'>171.13</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_171'), ref('account_tag_171_13')])]"/>
+        </record>
+        <record id='cuenta171_14' model='account.account.template'>
+            <field name='name'>Depreciación acumulada de equipo de comunicación satelital</field>
+            <field name='code'>171.14</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_171'), ref('account_tag_171_14')])]"/>
+        </record>
+        <record id='cuenta171_15' model='account.account.template'>
+            <field name='name'>Depreciación acumulada de equipo de adaptaciones para personas con capacidades diferentes</field>
+            <field name='code'>171.15</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_171'), ref('account_tag_171_15')])]"/>
+        </record>
+        <record id='cuenta171_16' model='account.account.template'>
+            <field name='name'>Depreciación acumulada de maquinaria y equipo de generación de energía de fuentes renovables o de sistemas de cogeneración de electricidad eficiente</field>
+            <field name='code'>171.16</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_171'), ref('account_tag_171_16')])]"/>
+        </record>
+        <record id='cuenta171_17' model='account.account.template'>
+            <field name='name'>Depreciación acumulada de adaptaciones y mejoras</field>
+            <field name='code'>171.17</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_171'), ref('account_tag_171_17')])]"/>
+        </record>
+        <record id='cuenta171_18' model='account.account.template'>
+            <field name='name'>Depreciación acumulada de otra maquinaria y equipo</field>
+            <field name='code'>171.18</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_171'), ref('account_tag_171_18')])]"/>
+        </record>
+        <record id='cuenta172_01' model='account.account.template'>
+            <field name='name'>Pérdida por deterioro acumulado de edificios</field>
+            <field name='code'>172.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_172'), ref('account_tag_172_01')])]"/>
+        </record>
+        <record id='cuenta172_02' model='account.account.template'>
+            <field name='name'>Pérdida por deterioro acumulado de maquinaria y equipo</field>
+            <field name='code'>172.02</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_172'), ref('account_tag_172_02')])]"/>
+        </record>
+        <record id='cuenta172_03' model='account.account.template'>
+            <field name='name'>Pérdida por deterioro acumulado de automóviles, autobuses, camiones de carga, tractocamiones, montacargas y remolques</field>
+            <field name='code'>172.03</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_172'), ref('account_tag_172_03')])]"/>
+        </record>
+        <record id='cuenta172_04' model='account.account.template'>
+            <field name='name'>Pérdida por deterioro acumulado de mobiliario y equipo de oficina</field>
+            <field name='code'>172.04</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_172'), ref('account_tag_172_04')])]"/>
+        </record>
+        <record id='cuenta172_05' model='account.account.template'>
+            <field name='name'>Pérdida por deterioro acumulado de equipo de cómputo</field>
+            <field name='code'>172.05</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_172'), ref('account_tag_172_05')])]"/>
+        </record>
+        <record id='cuenta172_06' model='account.account.template'>
+            <field name='name'>Pérdida por deterioro acumulado de equipo de comunicación</field>
+            <field name='code'>172.06</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_172')], ref('account_tag_172_06'))]"/>
+        </record>
+        <record id='cuenta172_07' model='account.account.template'>
+            <field name='name'>Pérdida por deterioro acumulado de activos biológicos, vegetales y semovientes</field>
+            <field name='code'>172.07</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_172'), ref('account_tag_172_07')])]"/>
+        </record>
+        <record id='cuenta172_08' model='account.account.template'>
+            <field name='name'>Pérdida por deterioro acumulado de otros activos fijos</field>
+            <field name='code'>172.08</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_172'), ref('account_tag_172_08')])]"/>
+        </record>
+        <record id='cuenta172_09' model='account.account.template'>
+            <field name='name'>Pérdida por deterioro acumulado de ferrocarriles</field>
+            <field name='code'>172.09</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_172'), ref('account_tag_172_09')])]"/>
+        </record>
+        <record id='cuenta172_10' model='account.account.template'>
+            <field name='name'>Pérdida por deterioro acumulado de embarcaciones</field>
+            <field name='code'>172.10</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_172'), ref('account_tag_172_10')])]"/>
+        </record>
+        <record id='cuenta172_11' model='account.account.template'>
+            <field name='name'>Pérdida por deterioro acumulado de aviones</field>
+            <field name='code'>172.11</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_172'), ref('account_tag_172_11')])]"/>
+        </record>
+        <record id='cuenta172_12' model='account.account.template'>
+            <field name='name'>Pérdida por deterioro acumulado de troqueles, moldes, matrices y herramental</field>
+            <field name='code'>172.12</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_172'), ref('account_tag_172_12')])]"/>
+        </record>
+        <record id='cuenta172_13' model='account.account.template'>
+            <field name='name'>Pérdida por deterioro acumulado de equipo de comunicaciones telefónicas</field>
+            <field name='code'>172.13</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_172'), ref('account_tag_172_13')])]"/>
+        </record>
+        <record id='cuenta172_14' model='account.account.template'>
+            <field name='name'>Pérdida por deterioro acumulado de equipo de comunicación satelital</field>
+            <field name='code'>172.14</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_172'), ref('account_tag_172_14')])]"/>
+        </record>
+        <record id='cuenta172_15' model='account.account.template'>
+            <field name='name'>Pérdida por deterioro acumulado de equipo de adaptaciones para personas con capacidades diferentes</field>
+            <field name='code'>172.15</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_172'), ref('account_tag_172_15')])]"/>
+        </record>
+        <record id='cuenta172_16' model='account.account.template'>
+            <field name='name'>Pérdida por deterioro acumulado de maquinaria y equipo de generación de energía de fuentes renovables o de sistemas de cogeneración de electricidad eficiente</field>
+            <field name='code'>172.16</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_172'), ref('account_tag_172_16')])]"/>
+        </record>
+        <record id='cuenta172_17' model='account.account.template'>
+            <field name='name'>Pérdida por deterioro acumulado de adaptaciones y mejoras</field>
+            <field name='code'>172.17</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_172'), ref('account_tag_172_17')])]"/>
+        </record>
+        <record id='cuenta172_18' model='account.account.template'>
+            <field name='name'>Pérdida por deterioro acumulado de otra maquinaria y equipo</field>
+            <field name='code'>172.18</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_172'), ref('account_tag_172_18')])]"/>
+        </record>
+        <record id='cuenta173_01' model='account.account.template'>
+            <field name='name'>Gastos diferidos</field>
+            <field name='code'>173.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_173'), ref('account_tag_173_01')])]"/>
+        </record>
+        <record id='cuenta174_01' model='account.account.template'>
+            <field name='name'>Gastos pre operativos</field>
+            <field name='code'>174.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_174'), ref('account_tag_174_01')])]"/>
+        </record>
+        <record id='cuenta175_01' model='account.account.template'>
+            <field name='name'>Regalías, asistencia técnica y otros gastos diferidos</field>
+            <field name='code'>175.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_175'), ref('account_tag_175_01')])]"/>
+        </record>
+        <record id='cuenta176_01' model='account.account.template'>
+            <field name='name'>Activos intangibles</field>
+            <field name='code'>176.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_176'), ref('account_tag_176_01')])]"/>
+        </record>
+        <record id='cuenta177_01' model='account.account.template'>
+            <field name='name'>Gastos de organización</field>
+            <field name='code'>177.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_177'), ref('account_tag_177_01')])]"/>
+        </record>
+        <record id='cuenta178_01' model='account.account.template'>
+            <field name='name'>Investigación y desarrollo de mercado</field>
+            <field name='code'>178.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_178'), ref('account_tag_178_01')])]"/>
+        </record>
+        <record id='cuenta179_01' model='account.account.template'>
+            <field name='name'>Marcas y patentes</field>
+            <field name='code'>179.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_179'), ref('account_tag_179_01')])]"/>
+        </record>
+        <record id='cuenta180_01' model='account.account.template'>
+            <field name='name'>Crédito mercantil</field>
+            <field name='code'>180.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_180'), ref('account_tag_180_01')])]"/>
+        </record>
+        <record id='cuenta181_01' model='account.account.template'>
+            <field name='name'>Gastos de instalación</field>
+            <field name='code'>181.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_181'), ref('account_tag_181_01')])]"/>
+        </record>
+        <record id='cuenta182_01' model='account.account.template'>
+            <field name='name'>Otros activos diferidos</field>
+            <field name='code'>182.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_182'), ref('account_tag_182_01')])]"/>
+        </record>
+        <record id='cuenta183_01' model='account.account.template'>
+            <field name='name'>Amortización acumulada de gastos diferidos</field>
+            <field name='code'>183.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_183'), ref('account_tag_183_01')])]"/>
+        </record>
+        <record id='cuenta183_02' model='account.account.template'>
+            <field name='name'>Amortización acumulada de gastos pre operativos</field>
+            <field name='code'>183.02</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_183'), ref('account_tag_183_02')])]"/>
+        </record>
+        <record id='cuenta183_03' model='account.account.template'>
+            <field name='name'>Amortización acumulada de regalías, asistencia técnica y otros gastos diferidos</field>
+            <field name='code'>183.03</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_183'), ref('account_tag_183_03')])]"/>
+        </record>
+        <record id='cuenta183_04' model='account.account.template'>
+            <field name='name'>Amortización acumulada de activos intangibles</field>
+            <field name='code'>183.04</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_183'), ref('account_tag_183_04')])]"/>
+        </record>
+        <record id='cuenta183_05' model='account.account.template'>
+            <field name='name'>Amortización acumulada de gastos de organización</field>
+            <field name='code'>183.05</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_183'), ref('account_tag_183_05')])]"/>
+        </record>
+        <record id='cuenta183_06' model='account.account.template'>
+            <field name='name'>Amortización acumulada de investigación y desarrollo de mercado</field>
+            <field name='code'>183.06</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_183'), ref('account_tag_183_06')])]"/>
+        </record>
+        <record id='cuenta183_07' model='account.account.template'>
+            <field name='name'>Amortización acumulada de marcas y patentes</field>
+            <field name='code'>183.07</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_183'), ref('account_tag_183_07')])]"/>
+        </record>
+        <record id='cuenta183_08' model='account.account.template'>
+            <field name='name'>Amortización acumulada de crédito mercantil</field>
+            <field name='code'>183.08</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_183'), ref('account_tag_183_08')])]"/>
+        </record>
+        <record id='cuenta183_09' model='account.account.template'>
+            <field name='name'>Amortización acumulada de gastos de instalación</field>
+            <field name='code'>183.09</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_183'), ref('account_tag_183_09')])]"/>
+        </record>
+        <record id='cuenta183_10' model='account.account.template'>
+            <field name='name'>Amortización acumulada de otros activos diferidos</field>
+            <field name='code'>183.10</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_183'), ref('account_tag_183_10')])]"/>
+        </record>
+        <record id='cuenta184_01' model='account.account.template'>
+            <field name='name'>Depósitos de fianzas</field>
+            <field name='code'>184.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_184'), ref('account_tag_184_01')])]"/>
+        </record>
+        <record id='cuenta184_02' model='account.account.template'>
+            <field name='name'>Depósitos de arrendamiento de bienes inmuebles</field>
+            <field name='code'>184.02</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_184'), ref('account_tag_184_02')])]"/>
+        </record>
+        <record id='cuenta184_03' model='account.account.template'>
+            <field name='name'>Otros depósitos en garantía</field>
+            <field name='code'>184.03</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_184'), ref('account_tag_184_03')])]"/>
+        </record>
+        <record id='cuenta185_01' model='account.account.template'>
+            <field name='name'>Impuestos diferidos ISR</field>
+            <field name='code'>185.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_185'), ref('account_tag_185_01')])]"/>
+        </record>
+        <record id='cuenta186_01' model='account.account.template'>
+            <field name='name'>Cuentas y documentos por cobrar a largo plazo nacional</field>
+            <field name='code'>186.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_186'), ref('account_tag_186_01')])]"/>
+        </record>
+        <record id='cuenta186_02' model='account.account.template'>
+            <field name='name'>Cuentas y documentos por cobrar a largo plazo extranjero</field>
+            <field name='code'>186.02</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_186'), ref('account_tag_186_02')])]"/>
+        </record>
+        <record id='cuenta186_03' model='account.account.template'>
+            <field name='name'>Cuentas y documentos por cobrar a largo plazo nacional parte relacionada</field>
+            <field name='code'>186.03</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_186'), ref('account_tag_186_03')])]"/>
+        </record>
+        <record id='cuenta186_04' model='account.account.template'>
+            <field name='name'>Cuentas y documentos por cobrar a largo plazo extranjero parte relacionada</field>
+            <field name='code'>186.04</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_186'), ref('account_tag_186_04')])]"/>
+        </record>
+        <record id='cuenta186_05' model='account.account.template'>
+            <field name='name'>Intereses por cobrar a largo plazo nacional</field>
+            <field name='code'>186.05</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_186'), ref('account_tag_186_05')])]"/>
+        </record>
+        <record id='cuenta186_06' model='account.account.template'>
+            <field name='name'>Intereses por cobrar a largo plazo extranjero</field>
+            <field name='code'>186.06</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_186'), ref('account_tag_186_06')])]"/>
+        </record>
+        <record id='cuenta186_07' model='account.account.template'>
+            <field name='name'>Intereses por cobrar a largo plazo nacional parte relacionada</field>
+            <field name='code'>186.07</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_186'), ref('account_tag_186_07')])]"/>
+        </record>
+        <record id='cuenta186_08' model='account.account.template'>
+            <field name='name'>Intereses por cobrar a largo plazo extranjero parte relacionada</field>
+            <field name='code'>186.08</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_186'), ref('account_tag_186_08')])]"/>
+        </record>
+        <record id='cuenta186_09' model='account.account.template'>
+            <field name='name'>Otras cuentas y documentos por cobrar a largo plazo</field>
+            <field name='code'>186.09</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_186'), ref('account_tag_186_09')])]"/>
+        </record>
+        <record id='cuenta186_10' model='account.account.template'>
+            <field name='name'>Otras cuentas y documentos por cobrar a largo plazo parte relacionada</field>
+            <field name='code'>186.10</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_186'), ref('account_tag_186_10')])]"/>
+        </record>
+        <record id='cuenta187_01' model='account.account.template'>
+            <field name='name'>Participación de los trabajadores en las utilidades diferidas</field>
+            <field name='code'>187.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_187'), ref('account_tag_187_01')])]"/>
+        </record>
+        <record id='cuenta188_01' model='account.account.template'>
+            <field name='name'>Inversiones a largo plazo en subsidiarias</field>
+            <field name='code'>188.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_188'), ref('account_tag_188_01')])]"/>
+        </record>
+        <record id='cuenta188_02' model='account.account.template'>
+            <field name='name'>Inversiones a largo plazo en asociadas</field>
+            <field name='code'>188.02</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_188'), ref('account_tag_188_02')])]"/>
+        </record>
+        <record id='cuenta188_03' model='account.account.template'>
+            <field name='name'>Otras inversiones permanentes en acciones</field>
+            <field name='code'>188.03</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_188'), ref('account_tag_188_03')])]"/>
+        </record>
+        <record id='cuenta189_01' model='account.account.template'>
+            <field name='name'>Estimación por deterioro de inversiones permanentes en acciones</field>
+            <field name='code'>189.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_189'), ref('account_tag_189_01')])]"/>
+        </record>
+        <record id='cuenta190_01' model='account.account.template'>
+            <field name='name'>Otros instrumentos financieros</field>
+            <field name='code'>190.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_190'), ref('account_tag_190_01')])]"/>
+        </record>
+        <record id='cuenta191_01' model='account.account.template'>
+            <field name='name'>Otros activos a largo plazo</field>
+            <field name='code'>191.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_190'), ref('account_tag_191_01')])]"/>
+        </record>
+        <record id='cuenta201_01' model='account.account.template'>
+            <field name='name'>Proveedores nacionales</field>
+            <field name='code'>201.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account.data_account_type_payable"/>
+            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_201'), ref('account_tag_201_01')])]"/>
+        </record>
+        <record id='cuenta201_02' model='account.account.template'>
+            <field name='name'>Proveedores extranjeros</field>
+            <field name='code'>201.02</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account.data_account_type_payable"/>
+            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_201'), ref('account_tag_201_02')])]"/>
+        </record>
+        <record id='cuenta201_03' model='account.account.template'>
+            <field name='name'>Proveedores nacionales parte relacionada</field>
+            <field name='code'>201.03</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account.data_account_type_payable"/>
+            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_201'), ref('account_tag_201_03')])]"/>
+        </record>
+        <record id='cuenta201_04' model='account.account.template'>
+            <field name='name'>Proveedores extranjeros parte relacionada</field>
+            <field name='code'>201.04</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account.data_account_type_payable"/>
+            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_201'), ref('account_tag_201_04')])]"/>
+        </record>
+        <record id='cuenta202_01' model='account.account.template'>
+            <field name='name'>Documentos por pagar bancario y financiero nacional</field>
+            <field name='code'>202.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account.data_account_type_payable"/>
+            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_202'), ref('account_tag_202_01')])]"/>
+        </record>
+        <record id='cuenta202_02' model='account.account.template'>
+            <field name='name'>Documentos por pagar bancario y financiero extranjero</field>
+            <field name='code'>202.02</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account.data_account_type_payable"/>
+            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_202'), ref('account_tag_202_02')])]"/>
+        </record>
+        <record id='cuenta202_03' model='account.account.template'>
+            <field name='name'>Documentos y cuentas por pagar a corto plazo nacional</field>
+            <field name='code'>202.03</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account.data_account_type_payable"/>
+            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_202'), ref('account_tag_202_03')])]"/>
+        </record>
+        <record id='cuenta202_04' model='account.account.template'>
+            <field name='name'>Documentos y cuentas por pagar a corto plazo extranjero</field>
+            <field name='code'>202.04</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account.data_account_type_payable"/>
+            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_202'), ref('account_tag_202_04')])]"/>
+        </record>
+        <record id='cuenta202_05' model='account.account.template'>
+            <field name='name'>Documentos y cuentas por pagar a corto plazo nacional parte relacionada</field>
+            <field name='code'>202.05</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account.data_account_type_payable"/>
+            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_202'), ref('account_tag_202_05')])]"/>
+        </record>
+        <record id='cuenta202_06' model='account.account.template'>
+            <field name='name'>Documentos y cuentas por pagar a corto plazo extranjero parte relacionada</field>
+            <field name='code'>202.06</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account.data_account_type_payable"/>
+            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_202'), ref('account_tag_202_06')])]"/>
+        </record>
+        <record id='cuenta202_07' model='account.account.template'>
+            <field name='name'>Intereses por pagar a corto plazo nacional</field>
+            <field name='code'>202.07</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account.data_account_type_payable"/>
+            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_202'), ref('account_tag_202_07')])]"/>
+        </record>
+        <record id='cuenta202_08' model='account.account.template'>
+            <field name='name'>Intereses por pagar a corto plazo extranjero</field>
+            <field name='code'>202.08</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account.data_account_type_payable"/>
+            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_202'), ref('account_tag_202_08')])]"/>
+        </record>
+        <record id='cuenta202_09' model='account.account.template'>
+            <field name='name'>Intereses por pagar a corto plazo nacional parte relacionada</field>
+            <field name='code'>202.09</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account.data_account_type_payable"/>
+            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_202'), ref('account_tag_202_09')])]"/>
+        </record>
+        <record id='cuenta202_10' model='account.account.template'>
+            <field name='name'>Intereses por pagar a corto plazo extranjero parte relacionada</field>
+            <field name='code'>202.10</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account.data_account_type_payable"/>
+            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_202'), ref('account_tag_202_10')])]"/>
+        </record>
+        <record id='cuenta202_11' model='account.account.template'>
+            <field name='name'>Dividendo por pagar nacional</field>
+            <field name='code'>202.11</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account.data_account_type_payable"/>
+            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_202'), ref('account_tag_202_11')])]"/>
+        </record>
+        <record id='cuenta202_12' model='account.account.template'>
+            <field name='name'>Dividendo por pagar extranjero</field>
+            <field name='code'>202.12</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account.data_account_type_payable"/>
+            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_202'), ref('account_tag_202_12')])]"/>
+        </record>
+        <record id='cuenta203_01' model='account.account.template'>
+            <field name='name'>Rentas cobradas por anticipado a corto plazo nacional</field>
+            <field name='code'>203.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account.data_account_type_payable"/>
+            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_203'), ref('account_tag_203_01')])]"/>
+        </record>
+        <record id='cuenta203_02' model='account.account.template'>
+            <field name='name'>Rentas cobradas por anticipado a corto plazo extranjero</field>
+            <field name='code'>203.02</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account.data_account_type_payable"/>
+            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_203'), ref('account_tag_203_02')])]"/>
+        </record>
+        <record id='cuenta203_03' model='account.account.template'>
+            <field name='name'>Rentas cobradas por anticipado a corto plazo nacional parte relacionada</field>
+            <field name='code'>203.03</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account.data_account_type_payable"/>
+            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_203'), ref('account_tag_203_03')])]"/>
+        </record>
+        <record id='cuenta203_04' model='account.account.template'>
+            <field name='name'>Rentas cobradas por anticipado a corto plazo extranjero parte relacionada</field>
+            <field name='code'>203.04</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account.data_account_type_payable"/>
+            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_203'), ref('account_tag_203_04')])]"/>
+        </record>
+        <record id='cuenta203_05' model='account.account.template'>
+            <field name='name'>Intereses cobrados por anticipado a corto plazo nacional</field>
+            <field name='code'>203.05</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account.data_account_type_payable"/>
+            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_203'), ref('account_tag_203_05')])]"/>
+        </record>
+        <record id='cuenta203_06' model='account.account.template'>
+            <field name='name'>Intereses cobrados por anticipado a corto plazo extranjero</field>
+            <field name='code'>203.06</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account.data_account_type_payable"/>
+            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_203'), ref('account_tag_203_06')])]"/>
+        </record>
+        <record id='cuenta203_07' model='account.account.template'>
+            <field name='name'>Intereses cobrados por anticipado a corto plazo nacional parte relacionada</field>
+            <field name='code'>203.07</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account.data_account_type_payable"/>
+            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_203'), ref('account_tag_203_07')])]"/>
+        </record>
+        <record id='cuenta203_08' model='account.account.template'>
+            <field name='name'>Intereses cobrados por anticipado a corto plazo extranjero parte relacionada</field>
+            <field name='code'>203.08</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account.data_account_type_payable"/>
+            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_203'), ref('account_tag_203_08')])]"/>
+        </record>
+        <record id='cuenta203_09' model='account.account.template'>
+            <field name='name'>Factoraje financiero cobrados por anticipado a corto plazo nacional</field>
+            <field name='code'>203.09</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account.data_account_type_payable"/>
+            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_203'), ref('account_tag_203_09')])]"/>
+        </record>
+        <record id='cuenta203_10' model='account.account.template'>
+            <field name='name'>Factoraje financiero cobrados por anticipado a corto plazo extranjero</field>
+            <field name='code'>203.10</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account.data_account_type_payable"/>
+            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_203'), ref('account_tag_203_10')])]"/>
+        </record>
+        <record id='cuenta203_11' model='account.account.template'>
+            <field name='name'>Factoraje financiero cobrados por anticipado a corto plazo nacional parte relacionada</field>
+            <field name='code'>203.11</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account.data_account_type_payable"/>
+            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_203'), ref('account_tag_203_11')])]"/>
+        </record>
+        <record id='cuenta203_12' model='account.account.template'>
+            <field name='name'>Factoraje financiero cobrados por anticipado a corto plazo extranjero parte relacionada</field>
+            <field name='code'>203.12</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account.data_account_type_payable"/>
+            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_203'), ref('account_tag_203_12')])]"/>
+        </record>
+        <record id='cuenta203_13' model='account.account.template'>
+            <field name='name'>Arrendamiento financiero cobrados por anticipado a corto plazo nacional</field>
+            <field name='code'>203.13</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account.data_account_type_payable"/>
+            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_203'), ref('account_tag_203_13')])]"/>
+        </record>
+        <record id='cuenta203_14' model='account.account.template'>
+            <field name='name'>Arrendamiento financiero cobrados por anticipado a corto plazo extranjero</field>
+            <field name='code'>203.14</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account.data_account_type_payable"/>
+            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_203'), ref('account_tag_203_14')])]"/>
+        </record>
+        <record id='cuenta203_15' model='account.account.template'>
+            <field name='name'>Arrendamiento financiero cobrados por anticipado a corto plazo nacional parte relacionada</field>
+            <field name='code'>203.15</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account.data_account_type_payable"/>
+            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_203'), ref('account_tag_203_15')])]"/>
+        </record>
+        <record id='cuenta203_16' model='account.account.template'>
+            <field name='name'>Arrendamiento financiero cobrados por anticipado a corto plazo extranjero parte relacionada</field>
+            <field name='code'>203.16</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account.data_account_type_payable"/>
+            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_203'), ref('account_tag_203_16')])]"/>
+        </record>
+        <record id='cuenta203_17' model='account.account.template'>
+            <field name='name'>Derechos fiduciarios</field>
+            <field name='code'>203.17</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account.data_account_type_payable"/>
+            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_203'), ref('account_tag_203_17')])]"/>
+        </record>
+        <record id='cuenta203_18' model='account.account.template'>
+            <field name='name'>Otros cobros anticipados</field>
+            <field name='code'>203.18</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account.data_account_type_payable"/>
+            <field name="reconcile" eval="True"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_203'), ref('account_tag_203_18')])]"/>
+        </record>
+        <record id='cuenta204_01' model='account.account.template'>
+            <field name='name'>Instrumentos financieros a corto plazo</field>
+            <field name='code'>204.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_204'), ref('account_tag_204_01')])]"/>
+        </record>
+        <record id='cuenta205_01' model='account.account.template'>
+            <field name='name'>Socios, accionistas o representante legal</field>
+            <field name='code'>205.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_205'), ref('account_tag_205_01')])]"/>
+        </record>
+        <record id='cuenta205_02' model='account.account.template'>
+            <field name='name'>Acreedores diversos a corto plazo nacional</field>
+            <field name='code'>205.02</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_205'), ref('account_tag_205_02')])]"/>
+        </record>
+        <record id='cuenta205_03' model='account.account.template'>
+            <field name='name'>Acreedores diversos a corto plazo extranjero</field>
+            <field name='code'>205.03</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_205'), ref('account_tag_205_03')])]"/>
+        </record>
+        <record id='cuenta205_04' model='account.account.template'>
+            <field name='name'>Acreedores diversos a corto plazo nacional parte relacionada</field>
+            <field name='code'>205.04</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_205'), ref('account_tag_205_04')])]"/>
+        </record>
+        <record id='cuenta205_05' model='account.account.template'>
+            <field name='name'>Acreedores diversos a corto plazo extranjero parte relacionada</field>
+            <field name='code'>205.05</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_205'), ref('account_tag_205_05')])]"/>
+        </record>
+        <record id='cuenta205_06' model='account.account.template'>
+            <field name='name'>Otros acreedores diversos a corto plazo</field>
+            <field name='code'>205.06</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_205'), ref('account_tag_205_06')])]"/>
+        </record>
+        <record id='cuenta206_01' model='account.account.template'>
+            <field name='name'>Anticipo de cliente nacional</field>
+            <field name='code'>206.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_206'), ref('account_tag_206_01')])]"/>
+        </record>
+        <record id='cuenta206_02' model='account.account.template'>
+            <field name='name'>Anticipo de cliente extranjero</field>
+            <field name='code'>206.02</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_206'), ref('account_tag_206_02')])]"/>
+        </record>
+        <record id='cuenta206_03' model='account.account.template'>
+            <field name='name'>Anticipo de cliente nacional parte relacionada</field>
+            <field name='code'>206.03</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_206'), ref('account_tag_206_03')])]"/>
+        </record>
+        <record id='cuenta206_04' model='account.account.template'>
+            <field name='name'>Anticipo de cliente extranjero parte relacionada</field>
+            <field name='code'>206.04</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_206'), ref('account_tag_206_04')])]"/>
+        </record>
+        <record id='cuenta206_05' model='account.account.template'>
+            <field name='name'>Otros anticipos de clientes</field>
+            <field name='code'>206.05</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_206'), ref('account_tag_206_05')])]"/>
+        </record>
+        <record id='cuenta207_01' model='account.account.template'>
+            <field name='name'>IVA trasladado</field>
+            <field name='code'>207.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_207'), ref('account_tag_207_01')])]"/>
+        </record>
+        <record id='cuenta207_02' model='account.account.template'>
+            <field name='name'>IEPS trasladado</field>
+            <field name='code'>207.02</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_207'), ref('account_tag_207_02')])]"/>
+        </record>
+        <record id='cuenta208_01' model='account.account.template'>
+            <field name='name'>IVA trasladado cobrado</field>
+            <field name='code'>208.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_208'), ref('account_tag_208_01')])]"/>
+        </record>
+        <record id='cuenta208_02' model='account.account.template'>
+            <field name='name'>IEPS trasladado cobrado</field>
+            <field name='code'>208.02</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_208'), ref('account_tag_208_02')])]"/>
+        </record>
+        <record id='cuenta209_01' model='account.account.template'>
+            <field name='name'>IVA trasladado no cobrado</field>
+            <field name='code'>209.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_209'), ref('account_tag_209_01')])]"/>
+        </record>
+        <record id='cuenta209_02' model='account.account.template'>
+            <field name='name'>IEPS trasladado no cobrado</field>
+            <field name='code'>209.02</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_209'), ref('account_tag_209_02')])]"/>
+        </record>
+        <record id='cuenta210_01' model='account.account.template'>
+            <field name='name'>Provisión de sueldos y salarios por pagar</field>
+            <field name='code'>210.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_210'), ref('account_tag_210_01')])]"/>
+        </record>
+        <record id='cuenta210_02' model='account.account.template'>
+            <field name='name'>Provisión de vacaciones por pagar</field>
+            <field name='code'>210.02</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_210'), ref('account_tag_210_02')])]"/>
+        </record>
+        <record id='cuenta210_03' model='account.account.template'>
+            <field name='name'>Provisión de aguinaldo por pagar</field>
+            <field name='code'>210.03</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_210'), ref('account_tag_210_03')])]"/>
+        </record>
+        <record id='cuenta210_04' model='account.account.template'>
+            <field name='name'>Provisión de fondo de ahorro por pagar</field>
+            <field name='code'>210.04</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_210'), ref('account_tag_210_04')])]"/>
+        </record>
+        <record id='cuenta210_05' model='account.account.template'>
+            <field name='name'>Provisión de asimilados a salarios por pagar</field>
+            <field name='code'>210.05</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_210'), ref('account_tag_210_05')])]"/>
+        </record>
+        <record id='cuenta210_06' model='account.account.template'>
+            <field name='name'>Provisión de anticipos o remanentes por distribuir</field>
+            <field name='code'>210.06</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_210'), ref('account_tag_210_06')])]"/>
+        </record>
+        <record id='cuenta210_07' model='account.account.template'>
+            <field name='name'>Provisión de otros sueldos y salarios por pagar</field>
+            <field name='code'>210.07</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_210'), ref('account_tag_210_07')])]"/>
+        </record>
+        <record id='cuenta211_01' model='account.account.template'>
+            <field name='name'>Provisión de IMSS patronal por pagar</field>
+            <field name='code'>211.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_211'), ref('account_tag_211_01')])]"/>
+        </record>
+        <record id='cuenta211_02' model='account.account.template'>
+            <field name='name'>Provisión de SAR por pagar</field>
+            <field name='code'>211.02</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_211'), ref('account_tag_211_02')])]"/>
+        </record>
+        <record id='cuenta211_03' model='account.account.template'>
+            <field name='name'>Provisión de infonavit por pagar</field>
+            <field name='code'>211.03</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_211'), ref('account_tag_211_03')])]"/>
+        </record>
+        <record id='cuenta212_01' model='account.account.template'>
+            <field name='name'>Provisión de impuesto estatal sobre nómina por pagar</field>
+            <field name='code'>212.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_212'), ref('account_tag_212_01')])]"/>
+        </record>
+        <record id='cuenta213_01' model='account.account.template'>
+            <field name='name'>IVA por pagar</field>
+            <field name='code'>213.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_213'), ref('account_tag_213_01')])]"/>
+        </record>
+        <record id='cuenta213_02' model='account.account.template'>
+            <field name='name'>IEPS por pagar</field>
+            <field name='code'>213.02</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_213'), ref('account_tag_213_02')])]"/>
+        </record>
+        <record id='cuenta213_03' model='account.account.template'>
+            <field name='name'>ISR por pagar</field>
+            <field name='code'>213.03</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_213'), ref('account_tag_213_03')])]"/>
+        </record>
+        <record id='cuenta213_04' model='account.account.template'>
+            <field name='name'>Impuesto estatal sobre nómina por pagar</field>
+            <field name='code'>213.04</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_213'), ref('account_tag_213_04')])]"/>
+        </record>
+        <record id='cuenta213_05' model='account.account.template'>
+            <field name='name'>Impuesto estatal y municipal por pagar</field>
+            <field name='code'>213.05</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_213'), ref('account_tag_213_05')])]"/>
+        </record>
+        <record id='cuenta213_06' model='account.account.template'>
+            <field name='name'>Derechos por pagar</field>
+            <field name='code'>213.06</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_213'), ref('account_tag_213_06')])]"/>
+        </record>
+        <record id='cuenta213_07' model='account.account.template'>
+            <field name='name'>Otros impuestos por pagar</field>
+            <field name='code'>213.07</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_213'), ref('account_tag_213_07')])]"/>
+        </record>
+        <record id='cuenta214_01' model='account.account.template'>
+            <field name='name'>Dividendos por pagar</field>
+            <field name='code'>214.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_214'), ref('account_tag_214_01')])]"/>
+        </record>
+        <record id='cuenta215_01' model='account.account.template'>
+            <field name='name'>PTU por pagar</field>
+            <field name='code'>215.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_215'), ref('account_tag_215_01')])]"/>
+        </record>
+        <record id='cuenta215_02' model='account.account.template'>
+            <field name='name'>PTU por pagar de ejercicios anteriores</field>
+            <field name='code'>215.02</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_215'), ref('account_tag_215_02')])]"/>
+        </record>
+        <record id='cuenta215_03' model='account.account.template'>
+            <field name='name'>Provisión de PTU por pagar</field>
+            <field name='code'>215.03</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_215'), ref('account_tag_215_03')])]"/>
+        </record>
+        <record id='cuenta216_01' model='account.account.template'>
+            <field name='name'>Impuestos retenidos de ISR por sueldos y salarios</field>
+            <field name='code'>216.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_216'), ref('account_tag_216_01')])]"/>
+        </record>
+        <record id='cuenta216_02' model='account.account.template'>
+            <field name='name'>Impuestos retenidos de ISR por asimilados a salarios</field>
+            <field name='code'>216.02</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_216'), ref('account_tag_216_02')])]"/>
+        </record>
+        <record id='cuenta216_03' model='account.account.template'>
+            <field name='name'>Impuestos retenidos de ISR por arrendamiento</field>
+            <field name='code'>216.03</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_216'), ref('account_tag_216_03')])]"/>
+        </record>
+        <record id='cuenta216_04' model='account.account.template'>
+            <field name='name'>Impuestos retenidos de ISR por servicios profesionales</field>
+            <field name='code'>216.04</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_216'), ref('account_tag_216_04')])]"/>
+        </record>
+        <record id='cuenta216_05' model='account.account.template'>
+            <field name='name'>Impuestos retenidos de ISR por dividendos</field>
+            <field name='code'>216.05</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_216'), ref('account_tag_216_05')])]"/>
+        </record>
+        <record id='cuenta216_06' model='account.account.template'>
+            <field name='name'>Impuestos retenidos de ISR por intereses</field>
+            <field name='code'>216.06</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_216'), ref('account_tag_216_06')])]"/>
+        </record>
+        <record id='cuenta216_07' model='account.account.template'>
+            <field name='name'>Impuestos retenidos de ISR por pagos al extranjero</field>
+            <field name='code'>216.07</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_216'), ref('account_tag_216_07')])]"/>
+        </record>
+        <record id='cuenta216_08' model='account.account.template'>
+            <field name='name'>Impuestos retenidos de ISR por venta de acciones</field>
+            <field name='code'>216.08</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_216'), ref('account_tag_216_08')])]"/>
+        </record>
+        <record id='cuenta216_09' model='account.account.template'>
+            <field name='name'>Impuestos retenidos de ISR por venta de partes sociales</field>
+            <field name='code'>216.09</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_216'), ref('account_tag_216_09')])]"/>
+        </record>
+        <record id='cuenta216_10' model='account.account.template'>
+            <field name='name'>Impuestos retenidos de IVA</field>
+            <field name='code'>216.10</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_216'), ref('account_tag_216_10')])]"/>
+        </record>
+        <record id='cuenta216_11' model='account.account.template'>
+            <field name='name'>Retenciones de IMSS a los trabajadores</field>
+            <field name='code'>216.11</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_216'), ref('account_tag_216_11')])]"/>
+        </record>
+        <record id='cuenta216_12' model='account.account.template'>
+            <field name='name'>Otras impuestos retenidos</field>
+            <field name='code'>216.12</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_216'), ref('account_tag_216_12')])]"/>
+        </record>
+        <record id='cuenta216_13' model='account.account.template'>
+            <field name='name'>Impuestos retenidos de iva efectivamente pagados</field>
+            <field name='code'>216.13</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_216'), ref('account_tag_216_10')])]"/>
+        </record>
+        <record id='cuenta217_01' model='account.account.template'>
+            <field name='name'>Pagos realizados por cuenta de terceros</field>
+            <field name='code'>217.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_217'), ref('account_tag_217_01')])]"/>
+        </record>
+        <record id='cuenta218_01' model='account.account.template'>
+            <field name='name'>Otros pasivos a corto plazo</field>
+            <field name='code'>218.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_218'), ref('account_tag_218_01')])]"/>
+        </record>
+        <record id='cuenta251_01' model='account.account.template'>
+            <field name='name'>Socios, accionistas o representante legal</field>
+            <field name='code'>251.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_251'), ref('account_tag_251_01')])]"/>
+        </record>
+        <record id='cuenta251_02' model='account.account.template'>
+            <field name='name'>Acreedores diversos a largo plazo nacional</field>
+            <field name='code'>251.02</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_251'), ref('account_tag_251_02')])]"/>
+        </record>
+        <record id='cuenta251_03' model='account.account.template'>
+            <field name='name'>Acreedores diversos a largo plazo extranjero</field>
+            <field name='code'>251.03</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_251'), ref('account_tag_251_03')])]"/>
+        </record>
+        <record id='cuenta251_04' model='account.account.template'>
+            <field name='name'>Acreedores diversos a largo plazo nacional parte relacionada</field>
+            <field name='code'>251.04</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_251'), ref('account_tag_251_04')])]"/>
+        </record>
+        <record id='cuenta251_05' model='account.account.template'>
+            <field name='name'>Acreedores diversos a largo plazo extranjero parte relacionada</field>
+            <field name='code'>251.05</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_251'), ref('account_tag_251_05')])]"/>
+        </record>
+        <record id='cuenta251_06' model='account.account.template'>
+            <field name='name'>Otros acreedores diversos a largo plazo</field>
+            <field name='code'>251.06</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_251'), ref('account_tag_251_06')])]"/>
+        </record>
+        <record id='cuenta252_01' model='account.account.template'>
+            <field name='name'>Documentos bancarios y financieros por pagar a largo plazo nacional</field>
+            <field name='code'>252.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_252'), ref('account_tag_252_01')])]"/>
+        </record>
+        <record id='cuenta252_02' model='account.account.template'>
+            <field name='name'>Documentos bancarios y financieros por pagar a largo plazo extranjero</field>
+            <field name='code'>252.02</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_252'), ref('account_tag_252_02')])]"/>
+        </record>
+        <record id='cuenta252_03' model='account.account.template'>
+            <field name='name'>Documentos y cuentas por pagar a largo plazo nacional</field>
+            <field name='code'>252.03</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_252'), ref('account_tag_252_03')])]"/>
+        </record>
+        <record id='cuenta252_04' model='account.account.template'>
+            <field name='name'>Documentos y cuentas por pagar a largo plazo extranjero</field>
+            <field name='code'>252.04</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_252'), ref('account_tag_252_04')])]"/>
+        </record>
+        <record id='cuenta252_05' model='account.account.template'>
+            <field name='name'>Documentos y cuentas por pagar a largo plazo nacional parte relacionada</field>
+            <field name='code'>252.05</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_252'), ref('account_tag_252_05')])]"/>
+        </record>
+        <record id='cuenta252_06' model='account.account.template'>
+            <field name='name'>Documentos y cuentas por pagar a largo plazo extranjero parte relacionada</field>
+            <field name='code'>252.06</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_252'), ref('account_tag_252_06')])]"/>
+        </record>
+        <record id='cuenta252_07' model='account.account.template'>
+            <field name='name'>Hipotecas por pagar a largo plazo nacional</field>
+            <field name='code'>252.07</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_252'), ref('account_tag_252_07')])]"/>
+        </record>
+        <record id='cuenta252_08' model='account.account.template'>
+            <field name='name'>Hipotecas por pagar a largo plazo extranjero</field>
+            <field name='code'>252.08</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_252'), ref('account_tag_252_08')])]"/>
+        </record>
+        <record id='cuenta252_09' model='account.account.template'>
+            <field name='name'>Hipotecas por pagar a largo plazo nacional parte relacionada</field>
+            <field name='code'>252.09</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_252'), ref('account_tag_252_09')])]"/>
+        </record>
+        <record id='cuenta252_10' model='account.account.template'>
+            <field name='name'>Hipotecas por pagar a largo plazo extranjero parte relacionada</field>
+            <field name='code'>252.10</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_252'), ref('account_tag_252_10')])]"/>
+        </record>
+        <record id='cuenta252_11' model='account.account.template'>
+            <field name='name'>Intereses por pagar a largo plazo nacional</field>
+            <field name='code'>252.11</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_252'), ref('account_tag_252_11')])]"/>
+        </record>
+        <record id='cuenta252_12' model='account.account.template'>
+            <field name='name'>Intereses por pagar a largo plazo extranjero</field>
+            <field name='code'>252.12</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_252'), ref('account_tag_252_12')])]"/>
+        </record>
+        <record id='cuenta252_13' model='account.account.template'>
+            <field name='name'>Intereses por pagar a largo plazo nacional parte relacionada</field>
+            <field name='code'>252.13</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_252'), ref('account_tag_252_13')])]"/>
+        </record>
+        <record id='cuenta252_14' model='account.account.template'>
+            <field name='name'>Intereses por pagar a largo plazo extranjero parte relacionada</field>
+            <field name='code'>252.14</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_252'), ref('account_tag_252_14')])]"/>
+        </record>
+        <record id='cuenta252_15' model='account.account.template'>
+            <field name='name'>Dividendos por pagar nacionales</field>
+            <field name='code'>252.15</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_252'), ref('account_tag_252_15')])]"/>
+        </record>
+        <record id='cuenta252_16' model='account.account.template'>
+            <field name='name'>Dividendos por pagar extranjeros</field>
+            <field name='code'>252.16</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_252'), ref('account_tag_252_16')])]"/>
+        </record>
+        <record id='cuenta252_17' model='account.account.template'>
+            <field name='name'>Otras cuentas y documentos por pagar a largo plazo</field>
+            <field name='code'>252.17</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_252'), ref('account_tag_252_17')])]"/>
+        </record>
+        <record id='cuenta253_01' model='account.account.template'>
+            <field name='name'>Rentas cobradas por anticipado a largo plazo nacional</field>
+            <field name='code'>253.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_253'), ref('account_tag_253_01')])]"/>
+        </record>
+        <record id='cuenta253_02' model='account.account.template'>
+            <field name='name'>Rentas cobradas por anticipado a largo plazo extranjero</field>
+            <field name='code'>253.02</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_253'), ref('account_tag_253_02')])]"/>
+        </record>
+        <record id='cuenta253_03' model='account.account.template'>
+            <field name='name'>Rentas cobradas por anticipado a largo plazo nacional parte relacionada</field>
+            <field name='code'>253.03</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_253'), ref('account_tag_253_03')])]"/>
+        </record>
+        <record id='cuenta253_04' model='account.account.template'>
+            <field name='name'>Rentas cobradas por anticipado a largo plazo extranjero parte relacionada</field>
+            <field name='code'>253.04</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_253'), ref('account_tag_253_04')])]"/>
+        </record>
+        <record id='cuenta253_05' model='account.account.template'>
+            <field name='name'>Intereses cobrados por anticipado a largo plazo nacional</field>
+            <field name='code'>253.05</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_253'), ref('account_tag_253_05')])]"/>
+        </record>
+        <record id='cuenta253_06' model='account.account.template'>
+            <field name='name'>Intereses cobrados por anticipado a largo plazo extranjero</field>
+            <field name='code'>253.06</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_253'), ref('account_tag_253_06')])]"/>
+        </record>
+        <record id='cuenta253_07' model='account.account.template'>
+            <field name='name'>Intereses cobrados por anticipado a largo plazo nacional parte relacionada</field>
+            <field name='code'>253.07</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_253'), ref('account_tag_253_07')])]"/>
+        </record>
+        <record id='cuenta253_08' model='account.account.template'>
+            <field name='name'>Intereses cobrados por anticipado a largo plazo extranjero parte relacionada</field>
+            <field name='code'>253.08</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_253'), ref('account_tag_253_08')])]"/>
+        </record>
+        <record id='cuenta253_09' model='account.account.template'>
+            <field name='name'>Factoraje financiero cobrados por anticipado a largo plazo nacional</field>
+            <field name='code'>253.09</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_253'), ref('account_tag_253_09')])]"/>
+        </record>
+        <record id='cuenta253_10' model='account.account.template'>
+            <field name='name'>Factoraje financiero cobrados por anticipado a largo plazo extranjero</field>
+            <field name='code'>253.10</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_253'), ref('account_tag_253_10')])]"/>
+        </record>
+        <record id='cuenta253_11' model='account.account.template'>
+            <field name='name'>Factoraje financiero cobrados por anticipado a largo plazo nacional parte relacionada</field>
+            <field name='code'>253.11</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_253'), ref('account_tag_253_11')])]"/>
+        </record>
+        <record id='cuenta253_12' model='account.account.template'>
+            <field name='name'>Factoraje financiero cobrados por anticipado a largo plazo extranjero parte relacionada</field>
+            <field name='code'>253.12</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_253'), ref('account_tag_253_12')])]"/>
+        </record>
+        <record id='cuenta253_13' model='account.account.template'>
+            <field name='name'>Arrendamiento financiero cobrados por anticipado a largo plazo nacional</field>
+            <field name='code'>253.13</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_253'), ref('account_tag_253_13')])]"/>
+        </record>
+        <record id='cuenta253_14' model='account.account.template'>
+            <field name='name'>Arrendamiento financiero cobrados por anticipado a largo plazo extranjero</field>
+            <field name='code'>253.14</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_253'), ref('account_tag_253_14')])]"/>
+        </record>
+        <record id='cuenta253_15' model='account.account.template'>
+            <field name='name'>Arrendamiento financiero cobrados por anticipado a largo plazo nacional parte relacionada</field>
+            <field name='code'>253.15</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_253'), ref('account_tag_253_15')])]"/>
+        </record>
+        <record id='cuenta253_16' model='account.account.template'>
+            <field name='name'>Arrendamiento financiero cobrados por anticipado a largo plazo extranjero parte relacionada</field>
+            <field name='code'>253.16</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_253'), ref('account_tag_253_16')])]"/>
+        </record>
+        <record id='cuenta253_17' model='account.account.template'>
+            <field name='name'>Derechos fiduciarios</field>
+            <field name='code'>253.17</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_253'), ref('account_tag_253_17')])]"/>
+        </record>
+        <record id='cuenta253_18' model='account.account.template'>
+            <field name='name'>Otros cobros anticipados</field>
+            <field name='code'>253.18</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_253'), ref('account_tag_253_18')])]"/>
+        </record>
+        <record id='cuenta254_01' model='account.account.template'>
+            <field name='name'>Instrumentos financieros a largo plazo</field>
+            <field name='code'>254.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_254'), ref('account_tag_254_01')])]"/>
+        </record>
+        <record id='cuenta255_01' model='account.account.template'>
+            <field name='name'>Pasivos por beneficios a los empleados a largo plazo</field>
+            <field name='code'>255.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_255'), ref('account_tag_255_01')])]"/>
+        </record>
+        <record id='cuenta256_01' model='account.account.template'>
+            <field name='name'>Otros pasivos a largo plazo</field>
+            <field name='code'>256.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_256'), ref('account_tag_256_01')])]"/>
+        </record>
+        <record id='cuenta257_01' model='account.account.template'>
+            <field name='name'>Participación de los trabajadores en las utilidades diferida</field>
+            <field name='code'>257.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_257'), ref('account_tag_257_01')])]"/>
+        </record>
+        <record id='cuenta258_01' model='account.account.template'>
+            <field name='name'>Obligaciones contraídas de fideicomisos</field>
+            <field name='code'>258.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_258'), ref('account_tag_258_01')])]"/>
+        </record>
+        <record id='cuenta259_01' model='account.account.template'>
+            <field name='name'>ISR diferido</field>
+            <field name='code'>259.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_259'), ref('account_tag_259_01')])]"/>
+        </record>
+        <record id='cuenta259_02' model='account.account.template'>
+            <field name='name'>ISR por dividendo diferido</field>
+            <field name='code'>259.02</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_259'), ref('account_tag_259_02')])]"/>
+        </record>
+        <record id='cuenta259_03' model='account.account.template'>
+            <field name='name'>Otros impuestos diferidos</field>
+            <field name='code'>259.03</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_259'), ref('account_tag_259_03')])]"/>
+        </record>
+        <record id='cuenta260_01' model='account.account.template'>
+            <field name='name'>Pasivos diferidos</field>
+            <field name='code'>260.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_260'), ref('account_tag_260_01')])]"/>
+        </record>
+        <record id='cuenta301_01' model='account.account.template'>
+            <field name='name'>Capital fijo</field>
+            <field name='code'>301.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_301'), ref('account_tag_301_01')])]"/>
+        </record>
+        <record id='cuenta301_02' model='account.account.template'>
+            <field name='name'>Capital variable</field>
+            <field name='code'>301.02</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_301'), ref('account_tag_301_02')])]"/>
+        </record>
+        <record id='cuenta301_03' model='account.account.template'>
+            <field name='name'>Aportaciones para futuros aumentos de capital</field>
+            <field name='code'>301.03</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_301'), ref('account_tag_301_03')])]"/>
+        </record>
+        <record id='cuenta301_04' model='account.account.template'>
+            <field name='name'>Prima en suscripción de acciones</field>
+            <field name='code'>301.04</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_301'), ref('account_tag_301_04')])]"/>
+        </record>
+        <record id='cuenta301_05' model='account.account.template'>
+            <field name='name'>Prima en suscripción de partes sociales</field>
+            <field name='code'>301.05</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_301'), ref('account_tag_301_05')])]"/>
+        </record>
+        <record id='cuenta302_01' model='account.account.template'>
+            <field name='name'>Patrimonio</field>
+            <field name='code'>302.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_302'), ref('account_tag_302_01')])]"/>
+        </record>
+        <record id='cuenta302_02' model='account.account.template'>
+            <field name='name'>Aportación patrimonial</field>
+            <field name='code'>302.02</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_302'), ref('account_tag_302_02')])]"/>
+        </record>
+        <record id='cuenta302_03' model='account.account.template'>
+            <field name='name'>Déficit o remanente del ejercicio</field>
+            <field name='code'>302.03</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_302'), ref('account_tag_302_03')])]"/>
+        </record>
+        <record id='cuenta303_01' model='account.account.template'>
+            <field name='name'>Reserva legal</field>
+            <field name='code'>303.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_303'), ref('account_tag_303_01')])]"/>
+        </record>
+        <record id='cuenta304_01' model='account.account.template'>
+            <field name='name'>Utilidad de ejercicios anteriores</field>
+            <field name='code'>304.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_304'), ref('account_tag_304_01')])]"/>
+        </record>
+        <record id='cuenta304_02' model='account.account.template'>
+            <field name='name'>Pérdida de ejercicios anteriores</field>
+            <field name='code'>304.02</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_304'), ref('account_tag_304_02')])]"/>
+        </record>
+        <record id='cuenta304_03' model='account.account.template'>
+            <field name='name'>Resultado integral de ejercicios anteriores</field>
+            <field name='code'>304.03</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_304'), ref('account_tag_304_03')])]"/>
+        </record>
+        <record id='cuenta304_04' model='account.account.template'>
+            <field name='name'>Déficit o remanente de ejercicio anteriores</field>
+            <field name='code'>304.04</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_304'), ref('account_tag_304_04')])]"/>
+        </record>
+        <record id='cuenta305_01' model='account.account.template'>
+            <field name='name'>Utilidad del ejercicio</field>
+            <field name='code'>305.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_305'), ref('account_tag_305_01')])]"/>
+        </record>
+        <record id='cuenta305_02' model='account.account.template'>
+            <field name='name'>Pérdida del ejercicio</field>
+            <field name='code'>305.02</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_305'), ref('account_tag_305_02')])]"/>
+        </record>
+        <record id='cuenta305_03' model='account.account.template'>
+            <field name='name'>Resultado integral</field>
+            <field name='code'>305.03</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_305'), ref('account_tag_305_03')])]"/>
+        </record>
+        <record id='cuenta306_01' model='account.account.template'>
+            <field name='name'>Otras cuentas de capital</field>
+            <field name='code'>306.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_306'), ref('account_tag_306_01')])]"/>
+        </record>
+        <record id='cuenta401_01' model='account.account.template'>
+            <field name='name'>Ventas y/o servicios gravados a la tasa general</field>
+            <field name='code'>401.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_401'), ref('account_tag_401_01')])]"/>
+        </record>
+        <record id='cuenta401_02' model='account.account.template'>
+            <field name='name'>Ventas y/o servicios gravados a la tasa general de contado</field>
+            <field name='code'>401.02</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_401'), ref('account_tag_401_02')])]"/>
+        </record>
+        <record id='cuenta401_03' model='account.account.template'>
+            <field name='name'>Ventas y/o servicios gravados a la tasa general a crédito</field>
+            <field name='code'>401.03</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_401'), ref('account_tag_401_03')])]"/>
+        </record>
+        <record id='cuenta401_04' model='account.account.template'>
+            <field name='name'>Ventas y/o servicios gravados al 0%</field>
+            <field name='code'>401.04</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_401'), ref('account_tag_401_04')])]"/>
+        </record>
+        <record id='cuenta401_05' model='account.account.template'>
+            <field name='name'>Ventas y/o servicios gravados al 0% de contado</field>
+            <field name='code'>401.05</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_401'), ref('account_tag_401_05')])]"/>
+        </record>
+        <record id='cuenta401_06' model='account.account.template'>
+            <field name='name'>Ventas y/o servicios gravados al 0% a crédito</field>
+            <field name='code'>401.06</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_401'), ref('account_tag_401_06')])]"/>
+        </record>
+        <record id='cuenta401_07' model='account.account.template'>
+            <field name='name'>Ventas y/o servicios exentos</field>
+            <field name='code'>401.07</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_401'), ref('account_tag_401_07')])]"/>
+        </record>
+        <record id='cuenta401_08' model='account.account.template'>
+            <field name='name'>Ventas y/o servicios exentos de contado</field>
+            <field name='code'>401.08</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_401'), ref('account_tag_401_08')])]"/>
+        </record>
+        <record id='cuenta401_09' model='account.account.template'>
+            <field name='name'>Ventas y/o servicios exentos a crédito</field>
+            <field name='code'>401.09</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_401'), ref('account_tag_401_09')])]"/>
+        </record>
+        <record id='cuenta401_10' model='account.account.template'>
+            <field name='name'>Ventas y/o servicios gravados a la tasa general nacionales partes relacionadas</field>
+            <field name='code'>401.10</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_401'), ref('account_tag_401_10')])]"/>
+        </record>
+        <record id='cuenta401_11' model='account.account.template'>
+            <field name='name'>Ventas y/o servicios gravados a la tasa general extranjeros partes relacionadas</field>
+            <field name='code'>401.11</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_401'), ref('account_tag_401_11')])]"/>
+        </record>
+        <record id='cuenta401_12' model='account.account.template'>
+            <field name='name'>Ventas y/o servicios gravados al 0% nacionales partes relacionadas</field>
+            <field name='code'>401.12</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_401'), ref('account_tag_401_12')])]"/>
+        </record>
+        <record id='cuenta401_13' model='account.account.template'>
+            <field name='name'>Ventas y/o servicios gravados al 0% extranjeros partes relacionadas</field>
+            <field name='code'>401.13</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_401'), ref('account_tag_401_13')])]"/>
+        </record>
+        <record id='cuenta401_14' model='account.account.template'>
+            <field name='name'>Ventas y/o servicios exentos nacionales partes relacionadas</field>
+            <field name='code'>401.14</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_401'), ref('account_tag_401_14')])]"/>
+        </record>
+        <record id='cuenta401_15' model='account.account.template'>
+            <field name='name'>Ventas y/o servicios exentos extranjeros partes relacionadas</field>
+            <field name='code'>401.15</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_401'), ref('account_tag_401_15')])]"/>
+        </record>
+        <record id='cuenta401_16' model='account.account.template'>
+            <field name='name'>Ingresos por servicios administrativos</field>
+            <field name='code'>401.16</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_401'), ref('account_tag_401_16')])]"/>
+        </record>
+        <record id='cuenta401_17' model='account.account.template'>
+            <field name='name'>Ingresos por servicios administrativos nacionales partes relacionadas</field>
+            <field name='code'>401.17</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_401'), ref('account_tag_401_17')])]"/>
+        </record>
+        <record id='cuenta401_18' model='account.account.template'>
+            <field name='name'>Ingresos por servicios administrativos extranjeros partes relacionadas</field>
+            <field name='code'>401.18</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_401'), ref('account_tag_401_18')])]"/>
+        </record>
+        <record id='cuenta401_19' model='account.account.template'>
+            <field name='name'>Ingresos por servicios profesionales</field>
+            <field name='code'>401.19</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_401'), ref('account_tag_401_19')])]"/>
+        </record>
+        <record id='cuenta401_20' model='account.account.template'>
+            <field name='name'>Ingresos por servicios profesionales nacionales partes relacionadas</field>
+            <field name='code'>401.20</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_401'), ref('account_tag_401_20')])]"/>
+        </record>
+        <record id='cuenta401_21' model='account.account.template'>
+            <field name='name'>Ingresos por servicios profesionales extranjeros partes relacionadas</field>
+            <field name='code'>401.21</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_401'), ref('account_tag_401_21')])]"/>
+        </record>
+        <record id='cuenta401_22' model='account.account.template'>
+            <field name='name'>Ingresos por arrendamiento</field>
+            <field name='code'>401.22</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_401'), ref('account_tag_401_22')])]"/>
+        </record>
+        <record id='cuenta401_23' model='account.account.template'>
+            <field name='name'>Ingresos por arrendamiento nacionales partes relacionadas</field>
+            <field name='code'>401.23</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_401'), ref('account_tag_401_23')])]"/>
+        </record>
+        <record id='cuenta401_24' model='account.account.template'>
+            <field name='name'>Ingresos por arrendamiento extranjeros partes relacionadas</field>
+            <field name='code'>401.24</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_401'), ref('account_tag_401_24')])]"/>
+        </record>
+        <record id='cuenta401_25' model='account.account.template'>
+            <field name='name'>Ingresos por exportación</field>
+            <field name='code'>401.25</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_401'), ref('account_tag_401_25')])]"/>
+        </record>
+        <record id='cuenta401_26' model='account.account.template'>
+            <field name='name'>Ingresos por comisiones</field>
+            <field name='code'>401.26</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_401'), ref('account_tag_401_26')])]"/>
+        </record>
+        <record id='cuenta401_27' model='account.account.template'>
+            <field name='name'>Ingresos por maquila</field>
+            <field name='code'>401.27</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_401'), ref('account_tag_401_27')])]"/>
+        </record>
+        <record id='cuenta401_28' model='account.account.template'>
+            <field name='name'>Ingresos por coordinados</field>
+            <field name='code'>401.28</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_401'), ref('account_tag_401_28')])]"/>
+        </record>
+        <record id='cuenta401_29' model='account.account.template'>
+            <field name='name'>Ingresos por regalías</field>
+            <field name='code'>401.29</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_401'), ref('account_tag_401_29')])]"/>
+        </record>
+        <record id='cuenta401_30' model='account.account.template'>
+            <field name='name'>Ingresos por asistencia técnica</field>
+            <field name='code'>401.30</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_401'), ref('account_tag_401_30')])]"/>
+        </record>
+        <record id='cuenta401_31' model='account.account.template'>
+            <field name='name'>Ingresos por donativos</field>
+            <field name='code'>401.31</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_401'), ref('account_tag_401_31')])]"/>
+        </record>
+        <record id='cuenta401_32' model='account.account.template'>
+            <field name='name'>Ingresos por intereses (actividad propia)</field>
+            <field name='code'>401.32</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_401'), ref('account_tag_401_32')])]"/>
+        </record>
+        <record id='cuenta401_33' model='account.account.template'>
+            <field name='name'>Ingresos de copropiedad</field>
+            <field name='code'>401.33</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_401'), ref('account_tag_401_33')])]"/>
+        </record>
+        <record id='cuenta401_34' model='account.account.template'>
+            <field name='name'>Ingresos por fideicomisos</field>
+            <field name='code'>401.34</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_401'), ref('account_tag_401_34')])]"/>
+        </record>
+        <record id='cuenta401_35' model='account.account.template'>
+            <field name='name'>Ingresos por factoraje financiero</field>
+            <field name='code'>401.35</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_401'), ref('account_tag_401_35')])]"/>
+        </record>
+        <record id='cuenta401_36' model='account.account.template'>
+            <field name='name'>Ingresos por arrendamiento financiero</field>
+            <field name='code'>401.36</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_401'), ref('account_tag_401_36')])]"/>
+        </record>
+        <record id='cuenta401_37' model='account.account.template'>
+            <field name='name'>Ingresos de extranjeros con establecimiento en el país</field>
+            <field name='code'>401.37</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_401'), ref('account_tag_401_37')])]"/>
+        </record>
+        <record id='cuenta401_38' model='account.account.template'>
+            <field name='name'>Otros ingresos propios</field>
+            <field name='code'>401.38</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_401'), ref('account_tag_401_38')])]"/>
+        </record>
+        <record id='cuenta402_01' model='account.account.template'>
+            <field name='name'>Devoluciones, descuentos o bonificaciones sobre ventas y/o servicios a la tasa general</field>
+            <field name='code'>402.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_402'), ref('account_tag_402_01')])]"/>
+        </record>
+        <record id='cuenta402_02' model='account.account.template'>
+            <field name='name'>Devoluciones, descuentos o bonificaciones sobre ventas y/o servicios al 0%</field>
+            <field name='code'>402.02</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_402'), ref('account_tag_402_02')])]"/>
+        </record>
+        <record id='cuenta402_03' model='account.account.template'>
+            <field name='name'>Devoluciones, descuentos o bonificaciones sobre ventas y/o servicios exentos</field>
+            <field name='code'>402.03</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_402'), ref('account_tag_402_03')])]"/>
+        </record>
+        <record id='cuenta402_04' model='account.account.template'>
+            <field name='name'>Devoluciones, descuentos o bonificaciones de otros ingresos</field>
+            <field name='code'>402.04</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_402'), ref('account_tag_402_04')])]"/>
+        </record>
+        <record id='cuenta403_01' model='account.account.template'>
+            <field name='name'>Otros Ingresos</field>
+            <field name='code'>403.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_403'), ref('account_tag_403_01')])]"/>
+        </record>
+        <record id='cuenta403_02' model='account.account.template'>
+            <field name='name'>Otros ingresos nacionales parte relacionada</field>
+            <field name='code'>403.02</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_403'), ref('account_tag_403_02')])]"/>
+        </record>
+        <record id='cuenta403_03' model='account.account.template'>
+            <field name='name'>Otros ingresos extranjeros parte relacionada</field>
+            <field name='code'>403.03</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_403'), ref('account_tag_403_03')])]"/>
+        </record>
+        <record id='cuenta403_04' model='account.account.template'>
+            <field name='name'>Ingresos por operaciones discontinuas</field>
+            <field name='code'>403.04</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_403'), ref('account_tag_403_04')])]"/>
+        </record>
+        <record id='cuenta403_05' model='account.account.template'>
+            <field name='name'>Ingresos por condonación de adeudo</field>
+            <field name='code'>403.05</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_403'), ref('account_tag_403_05')])]"/>
+        </record>
+        <record id='cuenta501_01' model='account.account.template'>
+            <field name='name'>Costo de venta</field>
+            <field name='code'>501.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_501'), ref('account_tag_501_01')])]"/>
+        </record>
+        <record id='cuenta501_02' model='account.account.template'>
+            <field name='name'>Costo de servicios (Mano de obra)</field>
+            <field name='code'>501.02</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_501'), ref('account_tag_501_02')])]"/>
+        </record>
+        <record id='cuenta501_03' model='account.account.template'>
+            <field name='name'>Materia prima directa utilizada para la producción</field>
+            <field name='code'>501.03</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_501'), ref('account_tag_501_03')])]"/>
+        </record>
+        <record id='cuenta501_04' model='account.account.template'>
+            <field name='name'>Materia prima consumida en el proceso productivo</field>
+            <field name='code'>501.04</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_501'), ref('account_tag_501_04')])]"/>
+        </record>
+        <record id='cuenta501_05' model='account.account.template'>
+            <field name='name'>Mano de obra directa consumida</field>
+            <field name='code'>501.05</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_501'), ref('account_tag_501_05')])]"/>
+        </record>
+        <record id='cuenta501_06' model='account.account.template'>
+            <field name='name'>Mano de obra directa</field>
+            <field name='code'>501.06</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_501'), ref('account_tag_501_06')])]"/>
+        </record>
+        <record id='cuenta501_07' model='account.account.template'>
+            <field name='name'>Cargos indirectos de producción</field>
+            <field name='code'>501.07</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_501'), ref('account_tag_501_07')])]"/>
+        </record>
+        <record id='cuenta501_08' model='account.account.template'>
+            <field name='name'>Otros conceptos de costo</field>
+            <field name='code'>501.08</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_501'), ref('account_tag_501_08')])]"/>
+        </record>
+        <record id='cuenta502_01' model='account.account.template'>
+            <field name='name'>Compras nacionales</field>
+            <field name='code'>502.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_502'), ref('account_tag_502_01')])]"/>
+        </record>
+        <record id='cuenta502_02' model='account.account.template'>
+            <field name='name'>Compras nacionales parte relacionada</field>
+            <field name='code'>502.02</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_502'), ref('account_tag_502_02')])]"/>
+        </record>
+        <record id='cuenta502_03' model='account.account.template'>
+            <field name='name'>Compras de Importación</field>
+            <field name='code'>502.03</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_502'), ref('account_tag_502_03')])]"/>
+        </record>
+        <record id='cuenta502_04' model='account.account.template'>
+            <field name='name'>Compras de Importación partes relacionadas</field>
+            <field name='code'>502.04</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_502'), ref('account_tag_502_04')])]"/>
+        </record>
+        <record id='cuenta503_01' model='account.account.template'>
+            <field name='name'>Devoluciones, descuentos o bonificaciones sobre compras</field>
+            <field name='code'>503.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_503'), ref('account_tag_503_01')])]"/>
+        </record>
+        <record id='cuenta504_01' model='account.account.template'>
+            <field name='name'>Gastos indirectos de fabricación</field>
+            <field name='code'>504.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_504'), ref('account_tag_504_01')])]"/>
+        </record>
+        <record id='cuenta504_02' model='account.account.template'>
+            <field name='name'>Gastos indirectos de fabricación de partes relacionadas nacionales</field>
+            <field name='code'>504.02</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_504'), ref('account_tag_504_02')])]"/>
+        </record>
+        <record id='cuenta504_03' model='account.account.template'>
+            <field name='name'>Gastos indirectos de fabricación de partes relacionadas extranjeras</field>
+            <field name='code'>504.03</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_504'), ref('account_tag_504_03')])]"/>
+        </record>
+        <record id='cuenta504_04' model='account.account.template'>
+            <field name='name'>Otras cuentas de costos incurridos</field>
+            <field name='code'>504.04</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_504'), ref('account_tag_504_04')])]"/>
+        </record>
+        <record id='cuenta504_05' model='account.account.template'>
+            <field name='name'>Otras cuentas de costos incurridos con partes relacionadas nacionales</field>
+            <field name='code'>504.05</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_504'), ref('account_tag_504_05')])]"/>
+        </record>
+        <record id='cuenta504_06' model='account.account.template'>
+            <field name='name'>Otras cuentas de costos incurridos con partes relacionadas extranjeras</field>
+            <field name='code'>504.06</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_504'), ref('account_tag_504_06')])]"/>
+        </record>
+        <record id='cuenta504_07' model='account.account.template'>
+            <field name='name'>Depreciación de edificios</field>
+            <field name='code'>504.07</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_504'), ref('account_tag_504_07')])]"/>
+        </record>
+        <record id='cuenta504_08' model='account.account.template'>
+            <field name='name'>Depreciación de maquinaria y equipo</field>
+            <field name='code'>504.08</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_504'), ref('account_tag_504_08')])]"/>
+        </record>
+        <record id='cuenta504_09' model='account.account.template'>
+            <field name='name'>Depreciación de automóviles, autobuses, camiones de carga, tractocamiones, montacargas y remolques</field>
+            <field name='code'>504.09</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_504'), ref('account_tag_504_09')])]"/>
+        </record>
+        <record id='cuenta504_10' model='account.account.template'>
+            <field name='name'>Depreciación de mobiliario y equipo de oficina</field>
+            <field name='code'>504.10</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_504'), ref('account_tag_504_10')])]"/>
+        </record>
+        <record id='cuenta504_11' model='account.account.template'>
+            <field name='name'>Depreciación de equipo de cómputo</field>
+            <field name='code'>504.11</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_504'), ref('account_tag_504_11')])]"/>
+        </record>
+        <record id='cuenta504_12' model='account.account.template'>
+            <field name='name'>Depreciación de equipo de comunicación</field>
+            <field name='code'>504.12</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_504'), ref('account_tag_504_12')])]"/>
+        </record>
+        <record id='cuenta504_13' model='account.account.template'>
+            <field name='name'>Depreciación de activos biológicos, vegetales y semovientes</field>
+            <field name='code'>504.13</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_504'), ref('account_tag_504_13')])]"/>
+        </record>
+        <record id='cuenta504_14' model='account.account.template'>
+            <field name='name'>Depreciación de otros activos fijos</field>
+            <field name='code'>504.14</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_504'), ref('account_tag_504_14')])]"/>
+        </record>
+        <record id='cuenta504_15' model='account.account.template'>
+            <field name='name'>Depreciación de ferrocarriles</field>
+            <field name='code'>504.15</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_504'), ref('account_tag_504_15')])]"/>
+        </record>
+        <record id='cuenta504_16' model='account.account.template'>
+            <field name='name'>Depreciación de embarcaciones</field>
+            <field name='code'>504.16</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_504'), ref('account_tag_504_16')])]"/>
+        </record>
+        <record id='cuenta504_17' model='account.account.template'>
+            <field name='name'>Depreciación de aviones</field>
+            <field name='code'>504.17</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_504'), ref('account_tag_504_17')])]"/>
+        </record>
+        <record id='cuenta504_18' model='account.account.template'>
+            <field name='name'>Depreciación de troqueles, moldes, matrices y herramental</field>
+            <field name='code'>504.18</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_504'), ref('account_tag_504_18')])]"/>
+        </record>
+        <record id='cuenta504_19' model='account.account.template'>
+            <field name='name'>Depreciación de equipo de comunicaciones telefónicas</field>
+            <field name='code'>504.19</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_504'), ref('account_tag_504_19')])]"/>
+        </record>
+        <record id='cuenta504_20' model='account.account.template'>
+            <field name='name'>Depreciación de equipo de comunicación satelital</field>
+            <field name='code'>504.20</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_504'), ref('account_tag_504_20')])]"/>
+        </record>
+        <record id='cuenta504_21' model='account.account.template'>
+            <field name='name'>Depreciación de equipo de adaptaciones para personas con capacidades diferentes</field>
+            <field name='code'>504.21</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_504'), ref('account_tag_504_21')])]"/>
+        </record>
+        <record id='cuenta504_22' model='account.account.template'>
+            <field name='name'>Depreciación de maquinaria y equipo de generación de energía de fuentes renovables o de sistemas de cogeneración de electricidad eficiente</field>
+            <field name='code'>504.22</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_504'), ref('account_tag_504_22')])]"/>
+        </record>
+        <record id='cuenta504_23' model='account.account.template'>
+            <field name='name'>Depreciación de adaptaciones y mejoras</field>
+            <field name='code'>504.23</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_504'), ref('account_tag_504_23')])]"/>
+        </record>
+        <record id='cuenta504_24' model='account.account.template'>
+            <field name='name'>Depreciación de otra maquinaria y equipo</field>
+            <field name='code'>504.24</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_504'), ref('account_tag_504_24')])]"/>
+        </record>
+        <record id='cuenta504_25' model='account.account.template'>
+            <field name='name'>Otras cuentas de costos</field>
+            <field name='code'>504.25</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_504'), ref('account_tag_504_25')])]"/>
+        </record>
+        <record id='cuenta505_01' model='account.account.template'>
+            <field name='name'>Costo por venta de activo fijo</field>
+            <field name='code'>505.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_505'), ref('account_tag_505_01')])]"/>
+        </record>
+        <record id='cuenta505_02' model='account.account.template'>
+            <field name='name'>Costo por baja de activo fijo</field>
+            <field name='code'>505.02</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_505'), ref('account_tag_505_02')])]"/>
+        </record>
+        <record id='cuenta601_01' model='account.account.template'>
+            <field name='name'>Sueldos y salarios</field>
+            <field name='code'>601.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601'), ref('account_tag_601_01')])]"/>
+        </record>
+        <record id='cuenta601_02' model='account.account.template'>
+            <field name='name'>Compensaciones</field>
+            <field name='code'>601.02</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601'), ref('account_tag_601_02')])]"/>
+        </record>
+        <record id='cuenta601_03' model='account.account.template'>
+            <field name='name'>Tiempos extras</field>
+            <field name='code'>601.03</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601'), ref('account_tag_601_03')])]"/>
+        </record>
+        <record id='cuenta601_04' model='account.account.template'>
+            <field name='name'>Premios de asistencia</field>
+            <field name='code'>601.04</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601'), ref('account_tag_601_04')])]"/>
+        </record>
+        <record id='cuenta601_05' model='account.account.template'>
+            <field name='name'>Premios de puntualidad</field>
+            <field name='code'>601.05</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601'), ref('account_tag_601_05')])]"/>
+        </record>
+        <record id='cuenta601_06' model='account.account.template'>
+            <field name='name'>Vacaciones</field>
+            <field name='code'>601.06</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601'), ref('account_tag_601_06')])]"/>
+        </record>
+        <record id='cuenta601_07' model='account.account.template'>
+            <field name='name'>Prima vacacional</field>
+            <field name='code'>601.07</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601'), ref('account_tag_601_07')])]"/>
+        </record>
+        <record id='cuenta601_08' model='account.account.template'>
+            <field name='name'>Prima dominical</field>
+            <field name='code'>601.08</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601'), ref('account_tag_601_08')])]"/>
+        </record>
+        <record id='cuenta601_09' model='account.account.template'>
+            <field name='name'>Días festivos</field>
+            <field name='code'>601.09</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601'), ref('account_tag_601_09')])]"/>
+        </record>
+        <record id='cuenta601_10' model='account.account.template'>
+            <field name='name'>Gratificaciones</field>
+            <field name='code'>601.10</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601'), ref('account_tag_601_10')])]"/>
+        </record>
+        <record id='cuenta601_11' model='account.account.template'>
+            <field name='name'>Primas de antigüedad</field>
+            <field name='code'>601.11</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601'), ref('account_tag_601_11')])]"/>
+        </record>
+        <record id='cuenta601_12' model='account.account.template'>
+            <field name='name'>Aguinaldo</field>
+            <field name='code'>601.12</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601'), ref('account_tag_601_12')])]"/>
+        </record>
+        <record id='cuenta601_13' model='account.account.template'>
+            <field name='name'>Indemnizaciones</field>
+            <field name='code'>601.13</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601'), ref('account_tag_601_13')])]"/>
+        </record>
+        <record id='cuenta601_14' model='account.account.template'>
+            <field name='name'>Destajo</field>
+            <field name='code'>601.14</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601'), ref('account_tag_601_14')])]"/>
+        </record>
+        <record id='cuenta601_15' model='account.account.template'>
+            <field name='name'>Despensa</field>
+            <field name='code'>601.15</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601'), ref('account_tag_601_15')])]"/>
+        </record>
+        <record id='cuenta601_16' model='account.account.template'>
+            <field name='name'>Transporte</field>
+            <field name='code'>601.16</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601'), ref('account_tag_601_16')])]"/>
+        </record>
+        <record id='cuenta601_17' model='account.account.template'>
+            <field name='name'>Servicio médico</field>
+            <field name='code'>601.17</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601'), ref('account_tag_601_17')])]"/>
+        </record>
+        <record id='cuenta601_18' model='account.account.template'>
+            <field name='name'>Ayuda en gastos funerarios</field>
+            <field name='code'>601.18</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601'), ref('account_tag_601_18')])]"/>
+        </record>
+        <record id='cuenta601_19' model='account.account.template'>
+            <field name='name'>Fondo de ahorro</field>
+            <field name='code'>601.19</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601'), ref('account_tag_601_19')])]"/>
+        </record>
+        <record id='cuenta601_20' model='account.account.template'>
+            <field name='name'>Cuotas sindicales</field>
+            <field name='code'>601.20</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601'), ref('account_tag_601_20')])]"/>
+        </record>
+        <record id='cuenta601_21' model='account.account.template'>
+            <field name='name'>PTU</field>
+            <field name='code'>601.21</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601'), ref('account_tag_601_21')])]"/>
+        </record>
+        <record id='cuenta601_22' model='account.account.template'>
+            <field name='name'>Estímulo al personal</field>
+            <field name='code'>601.22</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601'), ref('account_tag_601_22')])]"/>
+        </record>
+        <record id='cuenta601_23' model='account.account.template'>
+            <field name='name'>Previsión social</field>
+            <field name='code'>601.23</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601'), ref('account_tag_601_23')])]"/>
+        </record>
+        <record id='cuenta601_24' model='account.account.template'>
+            <field name='name'>Aportaciones para el plan de jubilación</field>
+            <field name='code'>601.24</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601'), ref('account_tag_601_24')])]"/>
+        </record>
+        <record id='cuenta601_25' model='account.account.template'>
+            <field name='name'>Otras prestaciones al personal</field>
+            <field name='code'>601.25</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601'), ref('account_tag_601_25')])]"/>
+        </record>
+        <record id='cuenta601_26' model='account.account.template'>
+            <field name='name'>Cuotas al IMSS</field>
+            <field name='code'>601.26</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601'), ref('account_tag_601_26')])]"/>
+        </record>
+        <record id='cuenta601_27' model='account.account.template'>
+            <field name='name'>Aportaciones al infonavit</field>
+            <field name='code'>601.27</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601'), ref('account_tag_601_27')])]"/>
+        </record>
+        <record id='cuenta601_28' model='account.account.template'>
+            <field name='name'>Aportaciones al SAR</field>
+            <field name='code'>601.28</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601'), ref('account_tag_601_28')])]"/>
+        </record>
+        <record id='cuenta601_29' model='account.account.template'>
+            <field name='name'>Impuesto estatal sobre nóminas</field>
+            <field name='code'>601.29</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601'), ref('account_tag_601_29')])]"/>
+        </record>
+        <record id='cuenta601_30' model='account.account.template'>
+            <field name='name'>Otras aportaciones</field>
+            <field name='code'>601.30</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601'), ref('account_tag_601_30')])]"/>
+        </record>
+        <record id='cuenta601_31' model='account.account.template'>
+            <field name='name'>Asimilados a salarios</field>
+            <field name='code'>601.31</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601'), ref('account_tag_601_31')])]"/>
+        </record>
+        <record id='cuenta601_32' model='account.account.template'>
+            <field name='name'>Servicios administrativos</field>
+            <field name='code'>601.32</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601'), ref('account_tag_601_32')])]"/>
+        </record>
+        <record id='cuenta601_33' model='account.account.template'>
+            <field name='name'>Servicios administrativos partes relacionadas</field>
+            <field name='code'>601.33</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601'), ref('account_tag_601_33')])]"/>
+        </record>
+        <record id='cuenta601_34' model='account.account.template'>
+            <field name='name'>Honorarios a personas físicas residentes nacionales</field>
+            <field name='code'>601.34</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601'), ref('account_tag_601_34')])]"/>
+        </record>
+        <record id='cuenta601_35' model='account.account.template'>
+            <field name='name'>Honorarios a personas físicas residentes nacionales partes relacionadas</field>
+            <field name='code'>601.35</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601'), ref('account_tag_601_35')])]"/>
+        </record>
+        <record id='cuenta601_36' model='account.account.template'>
+            <field name='name'>Honorarios a personas físicas residentes del extranjero</field>
+            <field name='code'>601.36</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601'), ref('account_tag_601_36')])]"/>
+        </record>
+        <record id='cuenta601_37' model='account.account.template'>
+            <field name='name'>Honorarios a personas físicas residentes del extranjero partes relacionadas</field>
+            <field name='code'>601.37</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601'), ref('account_tag_601_37')])]"/>
+        </record>
+        <record id='cuenta601_38' model='account.account.template'>
+            <field name='name'>Honorarios a personas morales residentes nacionales</field>
+            <field name='code'>601.38</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601'), ref('account_tag_601_38')])]"/>
+        </record>
+        <record id='cuenta601_39' model='account.account.template'>
+            <field name='name'>Honorarios a personas morales residentes nacionales partes relacionadas</field>
+            <field name='code'>601.39</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601'), ref('account_tag_601_39')])]"/>
+        </record>
+        <record id='cuenta601_40' model='account.account.template'>
+            <field name='name'>Honorarios a personas morales residentes del extranjero</field>
+            <field name='code'>601.40</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601'), ref('account_tag_601_40')])]"/>
+        </record>
+        <record id='cuenta601_41' model='account.account.template'>
+            <field name='name'>Honorarios a personas morales residentes del extranjero partes relacionadas</field>
+            <field name='code'>601.41</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601'), ref('account_tag_601_41')])]"/>
+        </record>
+        <record id='cuenta601_42' model='account.account.template'>
+            <field name='name'>Honorarios aduanales personas físicas</field>
+            <field name='code'>601.42</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601'), ref('account_tag_601_42')])]"/>
+        </record>
+        <record id='cuenta601_43' model='account.account.template'>
+            <field name='name'>Honorarios aduanales personas morales</field>
+            <field name='code'>601.43</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601'), ref('account_tag_601_43')])]"/>
+        </record>
+        <record id='cuenta601_44' model='account.account.template'>
+            <field name='name'>Honorarios al consejo de administración</field>
+            <field name='code'>601.44</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601'), ref('account_tag_601_44')])]"/>
+        </record>
+        <record id='cuenta601_45' model='account.account.template'>
+            <field name='name'>Arrendamiento a personas físicas residentes nacionales</field>
+            <field name='code'>601.45</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601'), ref('account_tag_601_45')])]"/>
+        </record>
+        <record id='cuenta601_46' model='account.account.template'>
+            <field name='name'>Arrendamiento a personas morales residentes nacionales</field>
+            <field name='code'>601.46</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601'), ref('account_tag_601_46')])]"/>
+        </record>
+        <record id='cuenta601_47' model='account.account.template'>
+            <field name='name'>Arrendamiento a residentes del extranjero</field>
+            <field name='code'>601.47</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601'), ref('account_tag_601_47')])]"/>
+        </record>
+        <record id='cuenta601_48' model='account.account.template'>
+            <field name='name'>Combustibles y lubricantes</field>
+            <field name='code'>601.48</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601'), ref('account_tag_601_48')])]"/>
+        </record>
+        <record id='cuenta601_49' model='account.account.template'>
+            <field name='name'>Viáticos y gastos de viaje</field>
+            <field name='code'>601.49</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601'), ref('account_tag_601_49')])]"/>
+        </record>
+        <record id='cuenta601_50' model='account.account.template'>
+            <field name='name'>Teléfono, internet</field>
+            <field name='code'>601.50</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601'), ref('account_tag_601_50')])]"/>
+        </record>
+        <record id='cuenta601_51' model='account.account.template'>
+            <field name='name'>Agua</field>
+            <field name='code'>601.51</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601'), ref('account_tag_601_51')])]"/>
+        </record>
+        <record id='cuenta601_52' model='account.account.template'>
+            <field name='name'>Energía eléctrica</field>
+            <field name='code'>601.52</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601'), ref('account_tag_601_52')])]"/>
+        </record>
+        <record id='cuenta601_53' model='account.account.template'>
+            <field name='name'>Vigilancia y seguridad</field>
+            <field name='code'>601.53</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601'), ref('account_tag_601_53')])]"/>
+        </record>
+        <record id='cuenta601_54' model='account.account.template'>
+            <field name='name'>Limpieza</field>
+            <field name='code'>601.54</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601'), ref('account_tag_601_54')])]"/>
+        </record>
+        <record id='cuenta601_55' model='account.account.template'>
+            <field name='name'>Papelería y artículos de oficina</field>
+            <field name='code'>601.55</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601'), ref('account_tag_601_55')])]"/>
+        </record>
+        <record id='cuenta601_56' model='account.account.template'>
+            <field name='name'>Mantenimiento y conservación</field>
+            <field name='code'>601.56</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601'), ref('account_tag_601_56')])]"/>
+        </record>
+        <record id='cuenta601_57' model='account.account.template'>
+            <field name='name'>Seguros y fianzas</field>
+            <field name='code'>601.57</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601'), ref('account_tag_601_57')])]"/>
+        </record>
+        <record id='cuenta601_58' model='account.account.template'>
+            <field name='name'>Otros impuestos y derechos</field>
+            <field name='code'>601.58</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601'), ref('account_tag_601_58')])]"/>
+        </record>
+        <record id='cuenta601_59' model='account.account.template'>
+            <field name='name'>Recargos fiscales</field>
+            <field name='code'>601.59</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601'), ref('account_tag_601_59')])]"/>
+        </record>
+        <record id='cuenta601_60' model='account.account.template'>
+            <field name='name'>Cuotas y suscripciones</field>
+            <field name='code'>601.60</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601'), ref('account_tag_601_60')])]"/>
+        </record>
+        <record id='cuenta601_61' model='account.account.template'>
+            <field name='name'>Propaganda y publicidad</field>
+            <field name='code'>601.61</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601'), ref('account_tag_601_61')])]"/>
+        </record>
+        <record id='cuenta601_62' model='account.account.template'>
+            <field name='name'>Capacitación al personal</field>
+            <field name='code'>601.62</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601'), ref('account_tag_601_62')])]"/>
+        </record>
+        <record id='cuenta601_63' model='account.account.template'>
+            <field name='name'>Donativos y ayudas</field>
+            <field name='code'>601.63</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601'), ref('account_tag_601_63')])]"/>
+        </record>
+        <record id='cuenta601_64' model='account.account.template'>
+            <field name='name'>Asistencia técnica</field>
+            <field name='code'>601.64</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601'), ref('account_tag_601_64')])]"/>
+        </record>
+        <record id='cuenta601_65' model='account.account.template'>
+            <field name='name'>Regalías sujetas a otros porcentajes</field>
+            <field name='code'>601.65</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601'), ref('account_tag_601_65')])]"/>
+        </record>
+        <record id='cuenta601_66' model='account.account.template'>
+            <field name='name'>Regalías sujetas al 5%</field>
+            <field name='code'>601.66</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601'), ref('account_tag_601_66')])]"/>
+        </record>
+        <record id='cuenta601_67' model='account.account.template'>
+            <field name='name'>Regalías sujetas al 10%</field>
+            <field name='code'>601.67</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601'), ref('account_tag_601_67')])]"/>
+        </record>
+        <record id='cuenta601_68' model='account.account.template'>
+            <field name='name'>Regalías sujetas al 15%</field>
+            <field name='code'>601.68</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601'), ref('account_tag_601_68')])]"/>
+        </record>
+        <record id='cuenta601_69' model='account.account.template'>
+            <field name='name'>Regalías sujetas al 25%</field>
+            <field name='code'>601.69</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601'), ref('account_tag_601_69')])]"/>
+        </record>
+        <record id='cuenta601_70' model='account.account.template'>
+            <field name='name'>Regalías sujetas al 30%</field>
+            <field name='code'>601.70</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601'), ref('account_tag_601_70')])]"/>
+        </record>
+        <record id='cuenta601_71' model='account.account.template'>
+            <field name='name'>Regalías sin retención</field>
+            <field name='code'>601.71</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601'), ref('account_tag_601_71')])]"/>
+        </record>
+        <record id='cuenta601_72' model='account.account.template'>
+            <field name='name'>Fletes y acarreos</field>
+            <field name='code'>601.72</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601'), ref('account_tag_601_72')])]"/>
+        </record>
+        <record id='cuenta601_73' model='account.account.template'>
+            <field name='name'>Gastos de importación</field>
+            <field name='code'>601.73</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601'), ref('account_tag_601_73')])]"/>
+        </record>
+        <record id='cuenta601_74' model='account.account.template'>
+            <field name='name'>Comisiones sobre ventas</field>
+            <field name='code'>601.74</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601'), ref('account_tag_601_74')])]"/>
+        </record>
+        <record id='cuenta601_75' model='account.account.template'>
+            <field name='name'>Comisiones por tarjetas de crédito</field>
+            <field name='code'>601.75</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601'), ref('account_tag_601_75')])]"/>
+        </record>
+        <record id='cuenta601_76' model='account.account.template'>
+            <field name='name'>Patentes y marcas</field>
+            <field name='code'>601.76</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601'), ref('account_tag_601_76')])]"/>
+        </record>
+        <record id='cuenta601_77' model='account.account.template'>
+            <field name='name'>Uniformes</field>
+            <field name='code'>601.77</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601'), ref('account_tag_601_77')])]"/>
+        </record>
+        <record id='cuenta601_78' model='account.account.template'>
+            <field name='name'>Prediales</field>
+            <field name='code'>601.78</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601'), ref('account_tag_601_78')])]"/>
+        </record>
+        <record id='cuenta601_79' model='account.account.template'>
+            <field name='name'>Gastos generales de urbanización</field>
+            <field name='code'>601.79</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601'), ref('account_tag_601_79')])]"/>
+        </record>
+        <record id='cuenta601_80' model='account.account.template'>
+            <field name='name'>Gastos generales de construcción</field>
+            <field name='code'>601.80</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601'), ref('account_tag_601_80')])]"/>
+        </record>
+        <record id='cuenta601_81' model='account.account.template'>
+            <field name='name'>Fletes del extranjero</field>
+            <field name='code'>601.81</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601'), ref('account_tag_601_81')])]"/>
+        </record>
+        <record id='cuenta601_82' model='account.account.template'>
+            <field name='name'>Recolección de bienes del sector agropecuario y/o ganadero</field>
+            <field name='code'>601.82</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601'), ref('account_tag_601_82')])]"/>
+        </record>
+        <record id='cuenta601_83' model='account.account.template'>
+            <field name='name'>Gastos no deducibles (sin requisitos fiscales)</field>
+            <field name='code'>601.83</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601'), ref('account_tag_601_83')])]"/>
+        </record>
+        <record id='cuenta601_84' model='account.account.template'>
+            <field name='name'>Otros gastos generales</field>
+            <field name='code'>601.84</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_601'), ref('account_tag_601_84')])]"/>
+        </record>
+        <record id='cuenta602_01' model='account.account.template'>
+            <field name='name'>Sueldos y salarios</field>
+            <field name='code'>602.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602'), ref('account_tag_602_01')])]"/>
+        </record>
+        <record id='cuenta602_02' model='account.account.template'>
+            <field name='name'>Compensaciones</field>
+            <field name='code'>602.02</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602'), ref('account_tag_602_02')])]"/>
+        </record>
+        <record id='cuenta602_03' model='account.account.template'>
+            <field name='name'>Tiempos extras</field>
+            <field name='code'>602.03</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602'), ref('account_tag_602_03')])]"/>
+        </record>
+        <record id='cuenta602_04' model='account.account.template'>
+            <field name='name'>Premios de asistencia</field>
+            <field name='code'>602.04</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602'), ref('account_tag_602_04')])]"/>
+        </record>
+        <record id='cuenta602_05' model='account.account.template'>
+            <field name='name'>Premios de puntualidad</field>
+            <field name='code'>602.05</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602'), ref('account_tag_602_05')])]"/>
+        </record>
+        <record id='cuenta602_06' model='account.account.template'>
+            <field name='name'>Vacaciones</field>
+            <field name='code'>602.06</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602'), ref('account_tag_602_06')])]"/>
+        </record>
+        <record id='cuenta602_07' model='account.account.template'>
+            <field name='name'>Prima vacacional</field>
+            <field name='code'>602.07</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602'), ref('account_tag_602_07')])]"/>
+        </record>
+        <record id='cuenta602_08' model='account.account.template'>
+            <field name='name'>Prima dominical</field>
+            <field name='code'>602.08</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602'), ref('account_tag_602_08')])]"/>
+        </record>
+        <record id='cuenta602_09' model='account.account.template'>
+            <field name='name'>Días festivos</field>
+            <field name='code'>602.09</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602'), ref('account_tag_602_09')])]"/>
+        </record>
+        <record id='cuenta602_10' model='account.account.template'>
+            <field name='name'>Gratificaciones</field>
+            <field name='code'>602.10</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602'), ref('account_tag_602_10')])]"/>
+        </record>
+        <record id='cuenta602_11' model='account.account.template'>
+            <field name='name'>Primas de antigüedad</field>
+            <field name='code'>602.11</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602'), ref('account_tag_602_11')])]"/>
+        </record>
+        <record id='cuenta602_12' model='account.account.template'>
+            <field name='name'>Aguinaldo</field>
+            <field name='code'>602.12</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602'), ref('account_tag_602_12')])]"/>
+        </record>
+        <record id='cuenta602_13' model='account.account.template'>
+            <field name='name'>Indemnizaciones</field>
+            <field name='code'>602.13</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602'), ref('account_tag_602_13')])]"/>
+        </record>
+        <record id='cuenta602_14' model='account.account.template'>
+            <field name='name'>Destajo</field>
+            <field name='code'>602.14</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602'), ref('account_tag_602_14')])]"/>
+        </record>
+        <record id='cuenta602_15' model='account.account.template'>
+            <field name='name'>Despensa</field>
+            <field name='code'>602.15</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602'), ref('account_tag_602_15')])]"/>
+        </record>
+        <record id='cuenta602_16' model='account.account.template'>
+            <field name='name'>Transporte</field>
+            <field name='code'>602.16</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602'), ref('account_tag_602_16')])]"/>
+        </record>
+        <record id='cuenta602_17' model='account.account.template'>
+            <field name='name'>Servicio médico</field>
+            <field name='code'>602.17</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602'), ref('account_tag_602_17')])]"/>
+        </record>
+        <record id='cuenta602_18' model='account.account.template'>
+            <field name='name'>Ayuda en gastos funerarios</field>
+            <field name='code'>602.18</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602'), ref('account_tag_602_18')])]"/>
+        </record>
+        <record id='cuenta602_19' model='account.account.template'>
+            <field name='name'>Fondo de ahorro</field>
+            <field name='code'>602.19</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602'), ref('account_tag_602_19')])]"/>
+        </record>
+        <record id='cuenta602_20' model='account.account.template'>
+            <field name='name'>Cuotas sindicales</field>
+            <field name='code'>602.20</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602'), ref('account_tag_602_20')])]"/>
+        </record>
+        <record id='cuenta602_21' model='account.account.template'>
+            <field name='name'>PTU</field>
+            <field name='code'>602.21</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602'), ref('account_tag_602_21')])]"/>
+        </record>
+        <record id='cuenta602_22' model='account.account.template'>
+            <field name='name'>Estímulo al personal</field>
+            <field name='code'>602.22</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602'), ref('account_tag_602_22')])]"/>
+        </record>
+        <record id='cuenta602_23' model='account.account.template'>
+            <field name='name'>Previsión social</field>
+            <field name='code'>602.23</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602'), ref('account_tag_602_23')])]"/>
+        </record>
+        <record id='cuenta602_24' model='account.account.template'>
+            <field name='name'>Aportaciones para el plan de jubilación</field>
+            <field name='code'>602.24</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602'), ref('account_tag_602_24')])]"/>
+        </record>
+        <record id='cuenta602_25' model='account.account.template'>
+            <field name='name'>Otras prestaciones al personal</field>
+            <field name='code'>602.25</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602'), ref('account_tag_602_25')])]"/>
+        </record>
+        <record id='cuenta602_26' model='account.account.template'>
+            <field name='name'>Cuotas al IMSS</field>
+            <field name='code'>602.26</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602'), ref('account_tag_602_26')])]"/>
+        </record>
+        <record id='cuenta602_27' model='account.account.template'>
+            <field name='name'>Aportaciones al infonavit</field>
+            <field name='code'>602.27</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602'), ref('account_tag_602_27')])]"/>
+        </record>
+        <record id='cuenta602_28' model='account.account.template'>
+            <field name='name'>Aportaciones al SAR</field>
+            <field name='code'>602.28</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602'), ref('account_tag_602_28')])]"/>
+        </record>
+        <record id='cuenta602_29' model='account.account.template'>
+            <field name='name'>Impuesto estatal sobre nóminas</field>
+            <field name='code'>602.29</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602'), ref('account_tag_602_29')])]"/>
+        </record>
+        <record id='cuenta602_30' model='account.account.template'>
+            <field name='name'>Otras aportaciones</field>
+            <field name='code'>602.30</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602'), ref('account_tag_602_30')])]"/>
+        </record>
+        <record id='cuenta602_31' model='account.account.template'>
+            <field name='name'>Asimilados a salarios</field>
+            <field name='code'>602.31</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602'), ref('account_tag_602_31')])]"/>
+        </record>
+        <record id='cuenta602_32' model='account.account.template'>
+            <field name='name'>Servicios administrativos</field>
+            <field name='code'>602.32</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602'), ref('account_tag_602_32')])]"/>
+        </record>
+        <record id='cuenta602_33' model='account.account.template'>
+            <field name='name'>Servicios administrativos partes relacionadas</field>
+            <field name='code'>602.33</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602'), ref('account_tag_602_33')])]"/>
+        </record>
+        <record id='cuenta602_34' model='account.account.template'>
+            <field name='name'>Honorarios a personas físicas residentes nacionales</field>
+            <field name='code'>602.34</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602'), ref('account_tag_602_34')])]"/>
+        </record>
+        <record id='cuenta602_35' model='account.account.template'>
+            <field name='name'>Honorarios a personas físicas residentes nacionales partes relacionadas</field>
+            <field name='code'>602.35</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602'), ref('account_tag_602_35')])]"/>
+        </record>
+        <record id='cuenta602_36' model='account.account.template'>
+            <field name='name'>Honorarios a personas físicas residentes del extranjero</field>
+            <field name='code'>602.36</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602'), ref('account_tag_602_36')])]"/>
+        </record>
+        <record id='cuenta602_37' model='account.account.template'>
+            <field name='name'>Honorarios a personas físicas residentes del extranjero partes relacionadas</field>
+            <field name='code'>602.37</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602'), ref('account_tag_602_37')])]"/>
+        </record>
+        <record id='cuenta602_38' model='account.account.template'>
+            <field name='name'>Honorarios a personas morales residentes nacionales</field>
+            <field name='code'>602.38</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602'), ref('account_tag_602_38')])]"/>
+        </record>
+        <record id='cuenta602_39' model='account.account.template'>
+            <field name='name'>Honorarios a personas morales residentes nacionales partes relacionadas</field>
+            <field name='code'>602.39</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602'), ref('account_tag_602_39')])]"/>
+        </record>
+        <record id='cuenta602_40' model='account.account.template'>
+            <field name='name'>Honorarios a personas morales residentes del extranjero</field>
+            <field name='code'>602.40</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602'), ref('account_tag_602_40')])]"/>
+        </record>
+        <record id='cuenta602_41' model='account.account.template'>
+            <field name='name'>Honorarios a personas morales residentes del extranjero partes relacionadas</field>
+            <field name='code'>602.41</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602'), ref('account_tag_602_41')])]"/>
+        </record>
+        <record id='cuenta602_42' model='account.account.template'>
+            <field name='name'>Honorarios aduanales personas físicas</field>
+            <field name='code'>602.42</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602'), ref('account_tag_602_42')])]"/>
+        </record>
+        <record id='cuenta602_43' model='account.account.template'>
+            <field name='name'>Honorarios aduanales personas morales</field>
+            <field name='code'>602.43</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602'), ref('account_tag_602_43')])]"/>
+        </record>
+        <record id='cuenta602_44' model='account.account.template'>
+            <field name='name'>Honorarios al consejo de administración</field>
+            <field name='code'>602.44</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602'), ref('account_tag_602_44')])]"/>
+        </record>
+        <record id='cuenta602_45' model='account.account.template'>
+            <field name='name'>Arrendamiento a personas físicas residentes nacionales</field>
+            <field name='code'>602.45</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602'), ref('account_tag_602_45')])]"/>
+        </record>
+        <record id='cuenta602_46' model='account.account.template'>
+            <field name='name'>Arrendamiento a personas morales residentes nacionales</field>
+            <field name='code'>602.46</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602'), ref('account_tag_602_46')])]"/>
+        </record>
+        <record id='cuenta602_47' model='account.account.template'>
+            <field name='name'>Arrendamiento a residentes del extranjero</field>
+            <field name='code'>602.47</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602'), ref('account_tag_602_47')])]"/>
+        </record>
+        <record id='cuenta602_48' model='account.account.template'>
+            <field name='name'>Combustibles y lubricantes</field>
+            <field name='code'>602.48</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602'), ref('account_tag_602_48')])]"/>
+        </record>
+        <record id='cuenta602_49' model='account.account.template'>
+            <field name='name'>Viáticos y gastos de viaje</field>
+            <field name='code'>602.49</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602'), ref('account_tag_602_49')])]"/>
+        </record>
+        <record id='cuenta602_50' model='account.account.template'>
+            <field name='name'>Teléfono, internet</field>
+            <field name='code'>602.50</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602'), ref('account_tag_602_50')])]"/>
+        </record>
+        <record id='cuenta602_51' model='account.account.template'>
+            <field name='name'>Agua</field>
+            <field name='code'>602.51</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602'), ref('account_tag_602_51')])]"/>
+        </record>
+        <record id='cuenta602_52' model='account.account.template'>
+            <field name='name'>Energía eléctrica</field>
+            <field name='code'>602.52</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602'), ref('account_tag_602_52')])]"/>
+        </record>
+        <record id='cuenta602_53' model='account.account.template'>
+            <field name='name'>Vigilancia y seguridad</field>
+            <field name='code'>602.53</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602'), ref('account_tag_602_53')])]"/>
+        </record>
+        <record id='cuenta602_54' model='account.account.template'>
+            <field name='name'>Limpieza</field>
+            <field name='code'>602.54</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602'), ref('account_tag_602_54')])]"/>
+        </record>
+        <record id='cuenta602_55' model='account.account.template'>
+            <field name='name'>Papelería y artículos de oficina</field>
+            <field name='code'>602.55</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602'), ref('account_tag_602_55')])]"/>
+        </record>
+        <record id='cuenta602_56' model='account.account.template'>
+            <field name='name'>Mantenimiento y conservación</field>
+            <field name='code'>602.56</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602'), ref('account_tag_602_56')])]"/>
+        </record>
+        <record id='cuenta602_57' model='account.account.template'>
+            <field name='name'>Seguros y fianzas</field>
+            <field name='code'>602.57</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602'), ref('account_tag_602_57')])]"/>
+        </record>
+        <record id='cuenta602_58' model='account.account.template'>
+            <field name='name'>Otros impuestos y derechos</field>
+            <field name='code'>602.58</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602'), ref('account_tag_602_58')])]"/>
+        </record>
+        <record id='cuenta602_59' model='account.account.template'>
+            <field name='name'>Recargos fiscales</field>
+            <field name='code'>602.59</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602'), ref('account_tag_602_59')])]"/>
+        </record>
+        <record id='cuenta602_60' model='account.account.template'>
+            <field name='name'>Cuotas y suscripciones</field>
+            <field name='code'>602.60</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602'), ref('account_tag_602_60')])]"/>
+        </record>
+        <record id='cuenta602_61' model='account.account.template'>
+            <field name='name'>Propaganda y publicidad</field>
+            <field name='code'>602.61</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602'), ref('account_tag_602_61')])]"/>
+        </record>
+        <record id='cuenta602_62' model='account.account.template'>
+            <field name='name'>Capacitación al personal</field>
+            <field name='code'>602.62</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602'), ref('account_tag_602_62')])]"/>
+        </record>
+        <record id='cuenta602_63' model='account.account.template'>
+            <field name='name'>Donativos y ayudas</field>
+            <field name='code'>602.63</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602'), ref('account_tag_602_63')])]"/>
+        </record>
+        <record id='cuenta602_64' model='account.account.template'>
+            <field name='name'>Asistencia técnica</field>
+            <field name='code'>602.64</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602'), ref('account_tag_602_64')])]"/>
+        </record>
+        <record id='cuenta602_65' model='account.account.template'>
+            <field name='name'>Regalías sujetas a otros porcentajes</field>
+            <field name='code'>602.65</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602'), ref('account_tag_602_65')])]"/>
+        </record>
+        <record id='cuenta602_66' model='account.account.template'>
+            <field name='name'>Regalías sujetas al 5%</field>
+            <field name='code'>602.66</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602'), ref('account_tag_602_66')])]"/>
+        </record>
+        <record id='cuenta602_67' model='account.account.template'>
+            <field name='name'>Regalías sujetas al 10%</field>
+            <field name='code'>602.67</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602'), ref('account_tag_602_67')])]"/>
+        </record>
+        <record id='cuenta602_68' model='account.account.template'>
+            <field name='name'>Regalías sujetas al 15%</field>
+            <field name='code'>602.68</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602'), ref('account_tag_602_68')])]"/>
+        </record>
+        <record id='cuenta602_69' model='account.account.template'>
+            <field name='name'>Regalías sujetas al 25%</field>
+            <field name='code'>602.69</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602'), ref('account_tag_602_69')])]"/>
+        </record>
+        <record id='cuenta602_70' model='account.account.template'>
+            <field name='name'>Regalías sujetas al 30%</field>
+            <field name='code'>602.70</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602'), ref('account_tag_602_70')])]"/>
+        </record>
+        <record id='cuenta602_71' model='account.account.template'>
+            <field name='name'>Regalías sin retención</field>
+            <field name='code'>602.71</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602'), ref('account_tag_602_71')])]"/>
+        </record>
+        <record id='cuenta602_72' model='account.account.template'>
+            <field name='name'>Fletes y acarreos</field>
+            <field name='code'>602.72</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602'), ref('account_tag_602_72')])]"/>
+        </record>
+        <record id='cuenta602_73' model='account.account.template'>
+            <field name='name'>Gastos de importación</field>
+            <field name='code'>602.73</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602'), ref('account_tag_602_73')])]"/>
+        </record>
+        <record id='cuenta602_74' model='account.account.template'>
+            <field name='name'>Comisiones sobre ventas</field>
+            <field name='code'>602.74</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602'), ref('account_tag_602_74')])]"/>
+        </record>
+        <record id='cuenta602_75' model='account.account.template'>
+            <field name='name'>Comisiones por tarjetas de crédito</field>
+            <field name='code'>602.75</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602'), ref('account_tag_602_75')])]"/>
+        </record>
+        <record id='cuenta602_76' model='account.account.template'>
+            <field name='name'>Patentes y marcas</field>
+            <field name='code'>602.76</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602'), ref('account_tag_602_76')])]"/>
+        </record>
+        <record id='cuenta602_77' model='account.account.template'>
+            <field name='name'>Uniformes</field>
+            <field name='code'>602.77</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602'), ref('account_tag_602_77')])]"/>
+        </record>
+        <record id='cuenta602_78' model='account.account.template'>
+            <field name='name'>Prediales</field>
+            <field name='code'>602.78</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602'), ref('account_tag_602_78')])]"/>
+        </record>
+        <record id='cuenta602_79' model='account.account.template'>
+            <field name='name'>Gastos de venta de urbanización</field>
+            <field name='code'>602.79</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602'), ref('account_tag_602_79')])]"/>
+        </record>
+        <record id='cuenta602_80' model='account.account.template'>
+            <field name='name'>Gastos de venta de construcción</field>
+            <field name='code'>602.80</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602'), ref('account_tag_602_80')])]"/>
+        </record>
+        <record id='cuenta602_81' model='account.account.template'>
+            <field name='name'>Fletes del extranjero</field>
+            <field name='code'>602.81</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602'), ref('account_tag_602_81')])]"/>
+        </record>
+        <record id='cuenta602_82' model='account.account.template'>
+            <field name='name'>Recolección de bienes del sector agropecuario y/o ganadero</field>
+            <field name='code'>602.82</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602'), ref('account_tag_602_82')])]"/>
+        </record>
+        <record id='cuenta602_83' model='account.account.template'>
+            <field name='name'>Gastos no deducibles (sin requisitos fiscales)</field>
+            <field name='code'>602.83</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602'), ref('account_tag_602_83')])]"/>
+        </record>
+        <record id='cuenta602_84' model='account.account.template'>
+            <field name='name'>Otros gastos de venta</field>
+            <field name='code'>602.84</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_602'), ref('account_tag_602_84')])]"/>
+        </record>
+        <record id='cuenta603_01' model='account.account.template'>
+            <field name='name'>Sueldos y salarios</field>
+            <field name='code'>603.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603'), ref('account_tag_603_01')])]"/>
+        </record>
+        <record id='cuenta603_02' model='account.account.template'>
+            <field name='name'>Compensaciones</field>
+            <field name='code'>603.02</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603'), ref('account_tag_603_02')])]"/>
+        </record>
+        <record id='cuenta603_03' model='account.account.template'>
+            <field name='name'>Tiempos extras</field>
+            <field name='code'>603.03</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603'), ref('account_tag_603_03')])]"/>
+        </record>
+        <record id='cuenta603_04' model='account.account.template'>
+            <field name='name'>Premios de asistencia</field>
+            <field name='code'>603.04</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603'), ref('account_tag_603_04')])]"/>
+        </record>
+        <record id='cuenta603_05' model='account.account.template'>
+            <field name='name'>Premios de puntualidad</field>
+            <field name='code'>603.05</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603'), ref('account_tag_603_05')])]"/>
+        </record>
+        <record id='cuenta603_06' model='account.account.template'>
+            <field name='name'>Vacaciones</field>
+            <field name='code'>603.06</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603'), ref('account_tag_603_06')])]"/>
+        </record>
+        <record id='cuenta603_07' model='account.account.template'>
+            <field name='name'>Prima vacacional</field>
+            <field name='code'>603.07</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603'), ref('account_tag_603_07')])]"/>
+        </record>
+        <record id='cuenta603_08' model='account.account.template'>
+            <field name='name'>Prima dominical</field>
+            <field name='code'>603.08</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603'), ref('account_tag_603_08')])]"/>
+        </record>
+        <record id='cuenta603_09' model='account.account.template'>
+            <field name='name'>Días festivos</field>
+            <field name='code'>603.09</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603'), ref('account_tag_603_09')])]"/>
+        </record>
+        <record id='cuenta603_10' model='account.account.template'>
+            <field name='name'>Gratificaciones</field>
+            <field name='code'>603.10</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603'), ref('account_tag_603_10')])]"/>
+        </record>
+        <record id='cuenta603_11' model='account.account.template'>
+            <field name='name'>Primas de antigüedad</field>
+            <field name='code'>603.11</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603'), ref('account_tag_603_11')])]"/>
+        </record>
+        <record id='cuenta603_12' model='account.account.template'>
+            <field name='name'>Aguinaldo</field>
+            <field name='code'>603.12</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603'), ref('account_tag_603_12')])]"/>
+        </record>
+        <record id='cuenta603_13' model='account.account.template'>
+            <field name='name'>Indemnizaciones</field>
+            <field name='code'>603.13</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603'), ref('account_tag_603_13')])]"/>
+        </record>
+        <record id='cuenta603_14' model='account.account.template'>
+            <field name='name'>Destajo</field>
+            <field name='code'>603.14</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603'), ref('account_tag_603_14')])]"/>
+        </record>
+        <record id='cuenta603_15' model='account.account.template'>
+            <field name='name'>Despensa</field>
+            <field name='code'>603.15</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603'), ref('account_tag_603_15')])]"/>
+        </record>
+        <record id='cuenta603_16' model='account.account.template'>
+            <field name='name'>Transporte</field>
+            <field name='code'>603.16</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603'), ref('account_tag_603_16')])]"/>
+        </record>
+        <record id='cuenta603_17' model='account.account.template'>
+            <field name='name'>Servicio médico</field>
+            <field name='code'>603.17</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603'), ref('account_tag_603_17')])]"/>
+        </record>
+        <record id='cuenta603_18' model='account.account.template'>
+            <field name='name'>Ayuda en gastos funerarios</field>
+            <field name='code'>603.18</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603'), ref('account_tag_603_18')])]"/>
+        </record>
+        <record id='cuenta603_19' model='account.account.template'>
+            <field name='name'>Fondo de ahorro</field>
+            <field name='code'>603.19</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603'), ref('account_tag_603_19')])]"/>
+        </record>
+        <record id='cuenta603_20' model='account.account.template'>
+            <field name='name'>Cuotas sindicales</field>
+            <field name='code'>603.20</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603'), ref('account_tag_603_20')])]"/>
+        </record>
+        <record id='cuenta603_21' model='account.account.template'>
+            <field name='name'>PTU</field>
+            <field name='code'>603.21</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603'), ref('account_tag_603_21')])]"/>
+        </record>
+        <record id='cuenta603_22' model='account.account.template'>
+            <field name='name'>Estímulo al personal</field>
+            <field name='code'>603.22</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603'), ref('account_tag_603_22')])]"/>
+        </record>
+        <record id='cuenta603_23' model='account.account.template'>
+            <field name='name'>Previsión social</field>
+            <field name='code'>603.23</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603'), ref('account_tag_603_23')])]"/>
+        </record>
+        <record id='cuenta603_24' model='account.account.template'>
+            <field name='name'>Aportaciones para el plan de jubilación</field>
+            <field name='code'>603.24</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603'), ref('account_tag_603_24')])]"/>
+        </record>
+        <record id='cuenta603_25' model='account.account.template'>
+            <field name='name'>Otras prestaciones al personal</field>
+            <field name='code'>603.25</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603'), ref('account_tag_603_25')])]"/>
+        </record>
+        <record id='cuenta603_26' model='account.account.template'>
+            <field name='name'>Cuotas al IMSS</field>
+            <field name='code'>603.26</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603'), ref('account_tag_603_26')])]"/>
+        </record>
+        <record id='cuenta603_27' model='account.account.template'>
+            <field name='name'>Aportaciones al infonavit</field>
+            <field name='code'>603.27</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603'), ref('account_tag_603_27')])]"/>
+        </record>
+        <record id='cuenta603_28' model='account.account.template'>
+            <field name='name'>Aportaciones al SAR</field>
+            <field name='code'>603.28</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603'), ref('account_tag_603_28')])]"/>
+        </record>
+        <record id='cuenta603_29' model='account.account.template'>
+            <field name='name'>Impuesto estatal sobre nóminas</field>
+            <field name='code'>603.29</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603'), ref('account_tag_603_29')])]"/>
+        </record>
+        <record id='cuenta603_30' model='account.account.template'>
+            <field name='name'>Otras aportaciones</field>
+            <field name='code'>603.30</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603'), ref('account_tag_603_30')])]"/>
+        </record>
+        <record id='cuenta603_31' model='account.account.template'>
+            <field name='name'>Asimilados a salarios</field>
+            <field name='code'>603.31</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603'), ref('account_tag_603_31')])]"/>
+        </record>
+        <record id='cuenta603_32' model='account.account.template'>
+            <field name='name'>Servicios administrativos</field>
+            <field name='code'>603.32</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603'), ref('account_tag_603_32')])]"/>
+        </record>
+        <record id='cuenta603_33' model='account.account.template'>
+            <field name='name'>Servicios administrativos partes relacionadas</field>
+            <field name='code'>603.33</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603'), ref('account_tag_603_33')])]"/>
+        </record>
+        <record id='cuenta603_34' model='account.account.template'>
+            <field name='name'>Honorarios a personas físicas residentes nacionales</field>
+            <field name='code'>603.34</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603'), ref('account_tag_603_34')])]"/>
+        </record>
+        <record id='cuenta603_35' model='account.account.template'>
+            <field name='name'>Honorarios a personas físicas residentes nacionales partes relacionadas</field>
+            <field name='code'>603.35</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603'), ref('account_tag_603_35')])]"/>
+        </record>
+        <record id='cuenta603_36' model='account.account.template'>
+            <field name='name'>Honorarios a personas físicas residentes del extranjero</field>
+            <field name='code'>603.36</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603'), ref('account_tag_603_36')])]"/>
+        </record>
+        <record id='cuenta603_37' model='account.account.template'>
+            <field name='name'>Honorarios a personas físicas residentes del extranjero partes relacionadas</field>
+            <field name='code'>603.37</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603'), ref('account_tag_603_37')])]"/>
+        </record>
+        <record id='cuenta603_38' model='account.account.template'>
+            <field name='name'>Honorarios a personas morales residentes nacionales</field>
+            <field name='code'>603.38</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603'), ref('account_tag_603_38')])]"/>
+        </record>
+        <record id='cuenta603_39' model='account.account.template'>
+            <field name='name'>Honorarios a personas morales residentes nacionales partes relacionadas</field>
+            <field name='code'>603.39</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603'), ref('account_tag_603_39')])]"/>
+        </record>
+        <record id='cuenta603_40' model='account.account.template'>
+            <field name='name'>Honorarios a personas morales residentes del extranjero</field>
+            <field name='code'>603.40</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603'), ref('account_tag_603_40')])]"/>
+        </record>
+        <record id='cuenta603_41' model='account.account.template'>
+            <field name='name'>Honorarios a personas morales residentes del extranjero partes relacionadas</field>
+            <field name='code'>603.41</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603'), ref('account_tag_603_41')])]"/>
+        </record>
+        <record id='cuenta603_42' model='account.account.template'>
+            <field name='name'>Honorarios aduanales personas físicas</field>
+            <field name='code'>603.42</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603'), ref('account_tag_603_42')])]"/>
+        </record>
+        <record id='cuenta603_43' model='account.account.template'>
+            <field name='name'>Honorarios aduanales personas morales</field>
+            <field name='code'>603.43</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603'), ref('account_tag_603_43')])]"/>
+        </record>
+        <record id='cuenta603_44' model='account.account.template'>
+            <field name='name'>Honorarios al consejo de administración</field>
+            <field name='code'>603.44</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603'), ref('account_tag_603_44')])]"/>
+        </record>
+        <record id='cuenta603_45' model='account.account.template'>
+            <field name='name'>Arrendamiento a personas físicas residentes nacionales</field>
+            <field name='code'>603.45</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603'), ref('account_tag_603_45')])]"/>
+        </record>
+        <record id='cuenta603_46' model='account.account.template'>
+            <field name='name'>Arrendamiento a personas morales residentes nacionales</field>
+            <field name='code'>603.46</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603'), ref('account_tag_603_46')])]"/>
+        </record>
+        <record id='cuenta603_47' model='account.account.template'>
+            <field name='name'>Arrendamiento a residentes del extranjero</field>
+            <field name='code'>603.47</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603'), ref('account_tag_603_47')])]"/>
+        </record>
+        <record id='cuenta603_48' model='account.account.template'>
+            <field name='name'>Combustibles y lubricantes</field>
+            <field name='code'>603.48</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603'), ref('account_tag_603_48')])]"/>
+        </record>
+        <record id='cuenta603_49' model='account.account.template'>
+            <field name='name'>Viáticos y gastos de viaje</field>
+            <field name='code'>603.49</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603'), ref('account_tag_603_49')])]"/>
+        </record>
+        <record id='cuenta603_50' model='account.account.template'>
+            <field name='name'>Teléfono, internet</field>
+            <field name='code'>603.50</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603'), ref('account_tag_603_50')])]"/>
+        </record>
+        <record id='cuenta603_51' model='account.account.template'>
+            <field name='name'>Agua</field>
+            <field name='code'>603.51</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603'), ref('account_tag_603_51')])]"/>
+        </record>
+        <record id='cuenta603_52' model='account.account.template'>
+            <field name='name'>Energía eléctrica</field>
+            <field name='code'>603.52</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603'), ref('account_tag_603_52')])]"/>
+        </record>
+        <record id='cuenta603_53' model='account.account.template'>
+            <field name='name'>Vigilancia y seguridad</field>
+            <field name='code'>603.53</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603'), ref('account_tag_603_53')])]"/>
+        </record>
+        <record id='cuenta603_54' model='account.account.template'>
+            <field name='name'>Limpieza</field>
+            <field name='code'>603.54</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603'), ref('account_tag_603_54')])]"/>
+        </record>
+        <record id='cuenta603_55' model='account.account.template'>
+            <field name='name'>Papelería y artículos de oficina</field>
+            <field name='code'>603.55</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603'), ref('account_tag_603_55')])]"/>
+        </record>
+        <record id='cuenta603_56' model='account.account.template'>
+            <field name='name'>Mantenimiento y conservación</field>
+            <field name='code'>603.56</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603'), ref('account_tag_603_56')])]"/>
+        </record>
+        <record id='cuenta603_57' model='account.account.template'>
+            <field name='name'>Seguros y fianzas</field>
+            <field name='code'>603.57</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603'), ref('account_tag_603_57')])]"/>
+        </record>
+        <record id='cuenta603_58' model='account.account.template'>
+            <field name='name'>Otros impuestos y derechos</field>
+            <field name='code'>603.58</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603'), ref('account_tag_603_58')])]"/>
+        </record>
+        <record id='cuenta603_59' model='account.account.template'>
+            <field name='name'>Recargos fiscales</field>
+            <field name='code'>603.59</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603'), ref('account_tag_603_59')])]"/>
+        </record>
+        <record id='cuenta603_60' model='account.account.template'>
+            <field name='name'>Cuotas y suscripciones</field>
+            <field name='code'>603.60</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603'), ref('account_tag_603_60')])]"/>
+        </record>
+        <record id='cuenta603_61' model='account.account.template'>
+            <field name='name'>Propaganda y publicidad</field>
+            <field name='code'>603.61</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603'), ref('account_tag_603_61')])]"/>
+        </record>
+        <record id='cuenta603_62' model='account.account.template'>
+            <field name='name'>Capacitación al personal</field>
+            <field name='code'>603.62</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603'), ref('account_tag_603_62')])]"/>
+        </record>
+        <record id='cuenta603_63' model='account.account.template'>
+            <field name='name'>Donativos y ayudas</field>
+            <field name='code'>603.63</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603'), ref('account_tag_603_63')])]"/>
+        </record>
+        <record id='cuenta603_64' model='account.account.template'>
+            <field name='name'>Asistencia técnica</field>
+            <field name='code'>603.64</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603'), ref('account_tag_603_64')])]"/>
+        </record>
+        <record id='cuenta603_65' model='account.account.template'>
+            <field name='name'>Regalías sujetas a otros porcentajes</field>
+            <field name='code'>603.65</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603'), ref('account_tag_603_65')])]"/>
+        </record>
+        <record id='cuenta603_66' model='account.account.template'>
+            <field name='name'>Regalías sujetas al 5%</field>
+            <field name='code'>603.66</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603'), ref('account_tag_603_66')])]"/>
+        </record>
+        <record id='cuenta603_67' model='account.account.template'>
+            <field name='name'>Regalías sujetas al 10%</field>
+            <field name='code'>603.67</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603'), ref('account_tag_603_67')])]"/>
+        </record>
+        <record id='cuenta603_68' model='account.account.template'>
+            <field name='name'>Regalías sujetas al 15%</field>
+            <field name='code'>603.68</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603'), ref('account_tag_603_68')])]"/>
+        </record>
+        <record id='cuenta603_69' model='account.account.template'>
+            <field name='name'>Regalías sujetas al 25%</field>
+            <field name='code'>603.69</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603'), ref('account_tag_603_69')])]"/>
+        </record>
+        <record id='cuenta603_70' model='account.account.template'>
+            <field name='name'>Regalías sujetas al 30%</field>
+            <field name='code'>603.70</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603'), ref('account_tag_603_70')])]"/>
+        </record>
+        <record id='cuenta603_71' model='account.account.template'>
+            <field name='name'>Regalías sin retención</field>
+            <field name='code'>603.71</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603'), ref('account_tag_603_71')])]"/>
+        </record>
+        <record id='cuenta603_72' model='account.account.template'>
+            <field name='name'>Fletes y acarreos</field>
+            <field name='code'>603.72</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603'), ref('account_tag_603_72')])]"/>
+        </record>
+        <record id='cuenta603_73' model='account.account.template'>
+            <field name='name'>Gastos de importación</field>
+            <field name='code'>603.73</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603'), ref('account_tag_603_73')])]"/>
+        </record>
+        <record id='cuenta603_74' model='account.account.template'>
+            <field name='name'>Patentes y marcas</field>
+            <field name='code'>603.74</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603'), ref('account_tag_603_74')])]"/>
+        </record>
+        <record id='cuenta603_75' model='account.account.template'>
+            <field name='name'>Uniformes</field>
+            <field name='code'>603.75</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603'), ref('account_tag_603_75')])]"/>
+        </record>
+        <record id='cuenta603_76' model='account.account.template'>
+            <field name='name'>Prediales</field>
+            <field name='code'>603.76</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603'), ref('account_tag_603_76')])]"/>
+        </record>
+        <record id='cuenta603_77' model='account.account.template'>
+            <field name='name'>Gastos de administración de urbanización</field>
+            <field name='code'>603.77</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603'), ref('account_tag_603_77')])]"/>
+        </record>
+        <record id='cuenta603_78' model='account.account.template'>
+            <field name='name'>Gastos de administración de construcción</field>
+            <field name='code'>603.78</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603'), ref('account_tag_603_78')])]"/>
+        </record>
+        <record id='cuenta603_79' model='account.account.template'>
+            <field name='name'>Fletes del extranjero</field>
+            <field name='code'>603.79</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603'), ref('account_tag_603_79')])]"/>
+        </record>
+        <record id='cuenta603_80' model='account.account.template'>
+            <field name='name'>Recolección de bienes del sector agropecuario y/o ganadero</field>
+            <field name='code'>603.80</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603'), ref('account_tag_603_80')])]"/>
+        </record>
+        <record id='cuenta603_81' model='account.account.template'>
+            <field name='name'>Gastos no deducibles (sin requisitos fiscales)</field>
+            <field name='code'>603.81</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603'), ref('account_tag_603_81')])]"/>
+        </record>
+        <record id='cuenta603_82' model='account.account.template'>
+            <field name='name'>Otros gastos de administración</field>
+            <field name='code'>603.82</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_603'), ref('account_tag_603_82')])]"/>
+        </record>
+        <record id='cuenta604_01' model='account.account.template'>
+            <field name='name'>Sueldos y salarios</field>
+            <field name='code'>604.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604'), ref('account_tag_604_01')])]"/>
+        </record>
+        <record id='cuenta604_02' model='account.account.template'>
+            <field name='name'>Compensaciones</field>
+            <field name='code'>604.02</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604'), ref('account_tag_604_02')])]"/>
+        </record>
+        <record id='cuenta604_03' model='account.account.template'>
+            <field name='name'>Tiempos extras</field>
+            <field name='code'>604.03</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604'), ref('account_tag_604_03')])]"/>
+        </record>
+        <record id='cuenta604_04' model='account.account.template'>
+            <field name='name'>Premios de asistencia</field>
+            <field name='code'>604.04</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604'), ref('account_tag_604_04')])]"/>
+        </record>
+        <record id='cuenta604_05' model='account.account.template'>
+            <field name='name'>Premios de puntualidad</field>
+            <field name='code'>604.05</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604'), ref('account_tag_604_05')])]"/>
+        </record>
+        <record id='cuenta604_06' model='account.account.template'>
+            <field name='name'>Vacaciones</field>
+            <field name='code'>604.06</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604'), ref('account_tag_604_06')])]"/>
+        </record>
+        <record id='cuenta604_07' model='account.account.template'>
+            <field name='name'>Prima vacacional</field>
+            <field name='code'>604.07</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604'), ref('account_tag_604_07')])]"/>
+        </record>
+        <record id='cuenta604_08' model='account.account.template'>
+            <field name='name'>Prima dominical</field>
+            <field name='code'>604.08</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604'), ref('account_tag_604_08')])]"/>
+        </record>
+        <record id='cuenta604_09' model='account.account.template'>
+            <field name='name'>Días festivos</field>
+            <field name='code'>604.09</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604'), ref('account_tag_604_09')])]"/>
+        </record>
+        <record id='cuenta604_10' model='account.account.template'>
+            <field name='name'>Gratificaciones</field>
+            <field name='code'>604.10</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604'), ref('account_tag_604_10')])]"/>
+        </record>
+        <record id='cuenta604_11' model='account.account.template'>
+            <field name='name'>Primas de antigüedad</field>
+            <field name='code'>604.11</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604'), ref('account_tag_604_11')])]"/>
+        </record>
+        <record id='cuenta604_12' model='account.account.template'>
+            <field name='name'>Aguinaldo</field>
+            <field name='code'>604.12</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604'), ref('account_tag_604_12')])]"/>
+        </record>
+        <record id='cuenta604_13' model='account.account.template'>
+            <field name='name'>Indemnizaciones</field>
+            <field name='code'>604.13</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604'), ref('account_tag_604_13')])]"/>
+        </record>
+        <record id='cuenta604_14' model='account.account.template'>
+            <field name='name'>Destajo</field>
+            <field name='code'>604.14</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604'), ref('account_tag_604_14')])]"/>
+        </record>
+        <record id='cuenta604_15' model='account.account.template'>
+            <field name='name'>Despensa</field>
+            <field name='code'>604.15</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604'), ref('account_tag_604_15')])]"/>
+        </record>
+        <record id='cuenta604_16' model='account.account.template'>
+            <field name='name'>Transporte</field>
+            <field name='code'>604.16</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604'), ref('account_tag_604_16')])]"/>
+        </record>
+        <record id='cuenta604_17' model='account.account.template'>
+            <field name='name'>Servicio médico</field>
+            <field name='code'>604.17</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604'), ref('account_tag_604_17')])]"/>
+        </record>
+        <record id='cuenta604_18' model='account.account.template'>
+            <field name='name'>Ayuda en gastos funerarios</field>
+            <field name='code'>604.18</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604'), ref('account_tag_604_18')])]"/>
+        </record>
+        <record id='cuenta604_19' model='account.account.template'>
+            <field name='name'>Fondo de ahorro</field>
+            <field name='code'>604.19</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604'), ref('account_tag_604_19')])]"/>
+        </record>
+        <record id='cuenta604_20' model='account.account.template'>
+            <field name='name'>Cuotas sindicales</field>
+            <field name='code'>604.20</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604'), ref('account_tag_604_20')])]"/>
+        </record>
+        <record id='cuenta604_21' model='account.account.template'>
+            <field name='name'>PTU</field>
+            <field name='code'>604.21</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604'), ref('account_tag_604_21')])]"/>
+        </record>
+        <record id='cuenta604_22' model='account.account.template'>
+            <field name='name'>Estímulo al personal</field>
+            <field name='code'>604.22</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604'), ref('account_tag_604_22')])]"/>
+        </record>
+        <record id='cuenta604_23' model='account.account.template'>
+            <field name='name'>Previsión social</field>
+            <field name='code'>604.23</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604'), ref('account_tag_604_23')])]"/>
+        </record>
+        <record id='cuenta604_24' model='account.account.template'>
+            <field name='name'>Aportaciones para el plan de jubilación</field>
+            <field name='code'>604.24</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604'), ref('account_tag_604_24')])]"/>
+        </record>
+        <record id='cuenta604_25' model='account.account.template'>
+            <field name='name'>Otras prestaciones al personal</field>
+            <field name='code'>604.25</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604'), ref('account_tag_604_25')])]"/>
+        </record>
+        <record id='cuenta604_26' model='account.account.template'>
+            <field name='name'>Cuotas al IMSS</field>
+            <field name='code'>604.26</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604'), ref('account_tag_604_26')])]"/>
+        </record>
+        <record id='cuenta604_27' model='account.account.template'>
+            <field name='name'>Aportaciones al infonavit</field>
+            <field name='code'>604.27</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604'), ref('account_tag_604_27')])]"/>
+        </record>
+        <record id='cuenta604_28' model='account.account.template'>
+            <field name='name'>Aportaciones al SAR</field>
+            <field name='code'>604.28</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604'), ref('account_tag_604_28')])]"/>
+        </record>
+        <record id='cuenta604_29' model='account.account.template'>
+            <field name='name'>Impuesto estatal sobre nóminas</field>
+            <field name='code'>604.29</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604'), ref('account_tag_604_29')])]"/>
+        </record>
+        <record id='cuenta604_30' model='account.account.template'>
+            <field name='name'>Otras aportaciones</field>
+            <field name='code'>604.30</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604'), ref('account_tag_604_30')])]"/>
+        </record>
+        <record id='cuenta604_31' model='account.account.template'>
+            <field name='name'>Asimilados a salarios</field>
+            <field name='code'>604.31</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604'), ref('account_tag_604_31')])]"/>
+        </record>
+        <record id='cuenta604_32' model='account.account.template'>
+            <field name='name'>Servicios administrativos</field>
+            <field name='code'>604.32</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604'), ref('account_tag_604_32')])]"/>
+        </record>
+        <record id='cuenta604_33' model='account.account.template'>
+            <field name='name'>Servicios administrativos partes relacionadas</field>
+            <field name='code'>604.33</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604'), ref('account_tag_604_33')])]"/>
+        </record>
+        <record id='cuenta604_34' model='account.account.template'>
+            <field name='name'>Honorarios a personas físicas residentes nacionales</field>
+            <field name='code'>604.34</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604'), ref('account_tag_604_34')])]"/>
+        </record>
+        <record id='cuenta604_35' model='account.account.template'>
+            <field name='name'>Honorarios a personas físicas residentes nacionales partes relacionadas</field>
+            <field name='code'>604.35</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604'), ref('account_tag_604_35')])]"/>
+        </record>
+        <record id='cuenta604_36' model='account.account.template'>
+            <field name='name'>Honorarios a personas físicas residentes del extranjero</field>
+            <field name='code'>604.36</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604'), ref('account_tag_604_36')])]"/>
+        </record>
+        <record id='cuenta604_37' model='account.account.template'>
+            <field name='name'>Honorarios a personas físicas residentes del extranjero partes relacionadas</field>
+            <field name='code'>604.37</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604'), ref('account_tag_604_37')])]"/>
+        </record>
+        <record id='cuenta604_38' model='account.account.template'>
+            <field name='name'>Honorarios a personas morales residentes nacionales</field>
+            <field name='code'>604.38</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604'), ref('account_tag_604_38')])]"/>
+        </record>
+        <record id='cuenta604_39' model='account.account.template'>
+            <field name='name'>Honorarios a personas morales residentes nacionales partes relacionadas</field>
+            <field name='code'>604.39</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604'), ref('account_tag_604_39')])]"/>
+        </record>
+        <record id='cuenta604_40' model='account.account.template'>
+            <field name='name'>Honorarios a personas morales residentes del extranjero</field>
+            <field name='code'>604.40</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604'), ref('account_tag_604_40')])]"/>
+        </record>
+        <record id='cuenta604_41' model='account.account.template'>
+            <field name='name'>Honorarios a personas morales residentes del extranjero partes relacionadas</field>
+            <field name='code'>604.41</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604'), ref('account_tag_604_41')])]"/>
+        </record>
+        <record id='cuenta604_42' model='account.account.template'>
+            <field name='name'>Honorarios aduanales personas físicas</field>
+            <field name='code'>604.42</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604'), ref('account_tag_604_42')])]"/>
+        </record>
+        <record id='cuenta604_43' model='account.account.template'>
+            <field name='name'>Honorarios aduanales personas morales</field>
+            <field name='code'>604.43</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604'), ref('account_tag_604_43')])]"/>
+        </record>
+        <record id='cuenta604_44' model='account.account.template'>
+            <field name='name'>Honorarios al consejo de administración</field>
+            <field name='code'>604.44</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604'), ref('account_tag_604_44')])]"/>
+        </record>
+        <record id='cuenta604_45' model='account.account.template'>
+            <field name='name'>Arrendamiento a personas físicas residentes nacionales</field>
+            <field name='code'>604.45</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604'), ref('account_tag_604_45')])]"/>
+        </record>
+        <record id='cuenta604_46' model='account.account.template'>
+            <field name='name'>Arrendamiento a personas morales residentes nacionales</field>
+            <field name='code'>604.46</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604'), ref('account_tag_604_46')])]"/>
+        </record>
+        <record id='cuenta604_47' model='account.account.template'>
+            <field name='name'>Arrendamiento a residentes del extranjero</field>
+            <field name='code'>604.47</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604'), ref('account_tag_604_47')])]"/>
+        </record>
+        <record id='cuenta604_48' model='account.account.template'>
+            <field name='name'>Combustibles y lubricantes</field>
+            <field name='code'>604.48</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604'), ref('account_tag_604_48')])]"/>
+        </record>
+        <record id='cuenta604_49' model='account.account.template'>
+            <field name='name'>Viáticos y gastos de viaje</field>
+            <field name='code'>604.49</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604'), ref('account_tag_604_49')])]"/>
+        </record>
+        <record id='cuenta604_50' model='account.account.template'>
+            <field name='name'>Teléfono, internet</field>
+            <field name='code'>604.50</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604'), ref('account_tag_604_50')])]"/>
+        </record>
+        <record id='cuenta604_51' model='account.account.template'>
+            <field name='name'>Agua</field>
+            <field name='code'>604.51</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604'), ref('account_tag_604_51')])]"/>
+        </record>
+        <record id='cuenta604_52' model='account.account.template'>
+            <field name='name'>Energía eléctrica</field>
+            <field name='code'>604.52</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604'), ref('account_tag_604_52')])]"/>
+        </record>
+        <record id='cuenta604_53' model='account.account.template'>
+            <field name='name'>Vigilancia y seguridad</field>
+            <field name='code'>604.53</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604'), ref('account_tag_604_53')])]"/>
+        </record>
+        <record id='cuenta604_54' model='account.account.template'>
+            <field name='name'>Limpieza</field>
+            <field name='code'>604.54</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604'), ref('account_tag_604_54')])]"/>
+        </record>
+        <record id='cuenta604_55' model='account.account.template'>
+            <field name='name'>Papelería y artículos de oficina</field>
+            <field name='code'>604.55</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604'), ref('account_tag_604_55')])]"/>
+        </record>
+        <record id='cuenta604_56' model='account.account.template'>
+            <field name='name'>Mantenimiento y conservación</field>
+            <field name='code'>604.56</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604'), ref('account_tag_604_56')])]"/>
+        </record>
+        <record id='cuenta604_57' model='account.account.template'>
+            <field name='name'>Seguros y fianzas</field>
+            <field name='code'>604.57</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604'), ref('account_tag_604_57')])]"/>
+        </record>
+        <record id='cuenta604_58' model='account.account.template'>
+            <field name='name'>Otros impuestos y derechos</field>
+            <field name='code'>604.58</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604'), ref('account_tag_604_58')])]"/>
+        </record>
+        <record id='cuenta604_59' model='account.account.template'>
+            <field name='name'>Recargos fiscales</field>
+            <field name='code'>604.59</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604'), ref('account_tag_604_59')])]"/>
+        </record>
+        <record id='cuenta604_60' model='account.account.template'>
+            <field name='name'>Cuotas y suscripciones</field>
+            <field name='code'>604.60</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604'), ref('account_tag_604_60')])]"/>
+        </record>
+        <record id='cuenta604_61' model='account.account.template'>
+            <field name='name'>Propaganda y publicidad</field>
+            <field name='code'>604.61</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604'), ref('account_tag_604_61')])]"/>
+        </record>
+        <record id='cuenta604_62' model='account.account.template'>
+            <field name='name'>Capacitación al personal</field>
+            <field name='code'>604.62</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604'), ref('account_tag_604_62')])]"/>
+        </record>
+        <record id='cuenta604_63' model='account.account.template'>
+            <field name='name'>Donativos y ayudas</field>
+            <field name='code'>604.63</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604'), ref('account_tag_604_63')])]"/>
+        </record>
+        <record id='cuenta604_64' model='account.account.template'>
+            <field name='name'>Asistencia técnica</field>
+            <field name='code'>604.64</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604'), ref('account_tag_604_64')])]"/>
+        </record>
+        <record id='cuenta604_65' model='account.account.template'>
+            <field name='name'>Regalías sujetas a otros porcentajes</field>
+            <field name='code'>604.65</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604'), ref('account_tag_604_65')])]"/>
+        </record>
+        <record id='cuenta604_66' model='account.account.template'>
+            <field name='name'>Regalías sujetas al 5%</field>
+            <field name='code'>604.66</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604'), ref('account_tag_604_66')])]"/>
+        </record>
+        <record id='cuenta604_67' model='account.account.template'>
+            <field name='name'>Regalías sujetas al 10%</field>
+            <field name='code'>604.67</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604'), ref('account_tag_604_67')])]"/>
+        </record>
+        <record id='cuenta604_68' model='account.account.template'>
+            <field name='name'>Regalías sujetas al 15%</field>
+            <field name='code'>604.68</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604'), ref('account_tag_604_68')])]"/>
+        </record>
+        <record id='cuenta604_69' model='account.account.template'>
+            <field name='name'>Regalías sujetas al 25%</field>
+            <field name='code'>604.69</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604'), ref('account_tag_604_69')])]"/>
+        </record>
+        <record id='cuenta604_70' model='account.account.template'>
+            <field name='name'>Regalías sujetas al 30%</field>
+            <field name='code'>604.70</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604'), ref('account_tag_604_70')])]"/>
+        </record>
+        <record id='cuenta604_71' model='account.account.template'>
+            <field name='name'>Regalías sin retención</field>
+            <field name='code'>604.71</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604'), ref('account_tag_604_71')])]"/>
+        </record>
+        <record id='cuenta604_72' model='account.account.template'>
+            <field name='name'>Fletes y acarreos</field>
+            <field name='code'>604.72</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604'), ref('account_tag_604_72')])]"/>
+        </record>
+        <record id='cuenta604_73' model='account.account.template'>
+            <field name='name'>Gastos de importación</field>
+            <field name='code'>604.73</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604'), ref('account_tag_604_73')])]"/>
+        </record>
+        <record id='cuenta604_74' model='account.account.template'>
+            <field name='name'>Patentes y marcas</field>
+            <field name='code'>604.74</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604'), ref('account_tag_604_74')])]"/>
+        </record>
+        <record id='cuenta604_75' model='account.account.template'>
+            <field name='name'>Uniformes</field>
+            <field name='code'>604.75</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604'), ref('account_tag_604_75')])]"/>
+        </record>
+        <record id='cuenta604_76' model='account.account.template'>
+            <field name='name'>Prediales</field>
+            <field name='code'>604.76</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604'), ref('account_tag_604_76')])]"/>
+        </record>
+        <record id='cuenta604_77' model='account.account.template'>
+            <field name='name'>Gastos de fabricación de urbanización</field>
+            <field name='code'>604.77</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604'), ref('account_tag_604_77')])]"/>
+        </record>
+        <record id='cuenta604_78' model='account.account.template'>
+            <field name='name'>Gastos de fabricación de construcción</field>
+            <field name='code'>604.78</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604'), ref('account_tag_604_78')])]"/>
+        </record>
+        <record id='cuenta604_79' model='account.account.template'>
+            <field name='name'>Fletes del extranjero</field>
+            <field name='code'>604.79</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604'), ref('account_tag_604_79')])]"/>
+        </record>
+        <record id='cuenta604_80' model='account.account.template'>
+            <field name='name'>Recolección de bienes del sector agropecuario y/o ganadero</field>
+            <field name='code'>604.80</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604'), ref('account_tag_604_80')])]"/>
+        </record>
+        <record id='cuenta604_81' model='account.account.template'>
+            <field name='name'>Gastos no deducibles (sin requisitos fiscales)</field>
+            <field name='code'>604.81</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604'), ref('account_tag_604_81')])]"/>
+        </record>
+        <record id='cuenta604_82' model='account.account.template'>
+            <field name='name'>Otros gastos de fabricación</field>
+            <field name='code'>604.82</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_604'), ref('account_tag_604_82')])]"/>
+        </record>
+        <record id='cuenta605_01' model='account.account.template'>
+            <field name='name'>Mano de obra</field>
+            <field name='code'>605.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_605'), ref('account_tag_605_01')])]"/>
+        </record>
+        <record id='cuenta605_02' model='account.account.template'>
+            <field name='name'>Sueldos y Salarios</field>
+            <field name='code'>605.02</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_605'), ref('account_tag_605_02')])]"/>
+        </record>
+        <record id='cuenta605_03' model='account.account.template'>
+            <field name='name'>Compensaciones</field>
+            <field name='code'>605.03</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_605'), ref('account_tag_605_03')])]"/>
+        </record>
+        <record id='cuenta605_04' model='account.account.template'>
+            <field name='name'>Tiempos extras</field>
+            <field name='code'>605.04</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_605'), ref('account_tag_605_04')])]"/>
+        </record>
+        <record id='cuenta605_05' model='account.account.template'>
+            <field name='name'>Premios de asistencia</field>
+            <field name='code'>605.05</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_605'), ref('account_tag_605_05')])]"/>
+        </record>
+        <record id='cuenta605_06' model='account.account.template'>
+            <field name='name'>Premios de puntualidad</field>
+            <field name='code'>605.06</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_605'), ref('account_tag_605_06')])]"/>
+        </record>
+        <record id='cuenta605_07' model='account.account.template'>
+            <field name='name'>Vacaciones</field>
+            <field name='code'>605.07</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_605'), ref('account_tag_605_07')])]"/>
+        </record>
+        <record id='cuenta605_08' model='account.account.template'>
+            <field name='name'>Prima vacacional</field>
+            <field name='code'>605.08</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_605'), ref('account_tag_605_08')])]"/>
+        </record>
+        <record id='cuenta605_09' model='account.account.template'>
+            <field name='name'>Prima dominical</field>
+            <field name='code'>605.09</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_605'), ref('account_tag_605_09')])]"/>
+        </record>
+        <record id='cuenta605_1' model='account.account.template'>
+            <field name='name'>Días festivos</field>
+            <field name='code'>605.10</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_605'), ref('account_tag_605_10')])]"/>
+        </record>
+        <record id='cuenta605_11' model='account.account.template'>
+            <field name='name'>Gratificaciones</field>
+            <field name='code'>605.11</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_605'), ref('account_tag_605_11')])]"/>
+        </record>
+        <record id='cuenta605_12' model='account.account.template'>
+            <field name='name'>Primas de antigüedad</field>
+            <field name='code'>605.12</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_605'), ref('account_tag_605_12')])]"/>
+        </record>
+        <record id='cuenta605_13' model='account.account.template'>
+            <field name='name'>Aguinaldo</field>
+            <field name='code'>605.13</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_605'), ref('account_tag_605_13')])]"/>
+        </record>
+        <record id='cuenta605_14' model='account.account.template'>
+            <field name='name'>Indemnizaciones</field>
+            <field name='code'>605.14</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_605'), ref('account_tag_605_14')])]"/>
+        </record>
+        <record id='cuenta605_15' model='account.account.template'>
+            <field name='name'>Destajo</field>
+            <field name='code'>605.15</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_605'), ref('account_tag_605_15')])]"/>
+        </record>
+        <record id='cuenta605_16' model='account.account.template'>
+            <field name='name'>Despensa</field>
+            <field name='code'>605.16</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_605'), ref('account_tag_605_16')])]"/>
+        </record>
+        <record id='cuenta605_17' model='account.account.template'>
+            <field name='name'>Transporte</field>
+            <field name='code'>605.17</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_605'), ref('account_tag_605_17')])]"/>
+        </record>
+        <record id='cuenta605_18' model='account.account.template'>
+            <field name='name'>Servicio médico</field>
+            <field name='code'>605.18</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_605'), ref('account_tag_605_18')])]"/>
+        </record>
+        <record id='cuenta605_19' model='account.account.template'>
+            <field name='name'>Ayuda en gastos funerarios</field>
+            <field name='code'>605.19</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_605'), ref('account_tag_605_19')])]"/>
+        </record>
+        <record id='cuenta605_20' model='account.account.template'>
+            <field name='name'>Fondo de ahorro</field>
+            <field name='code'>605.20</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_605'), ref('account_tag_605_20')])]"/>
+        </record>
+        <record id='cuenta605_21' model='account.account.template'>
+            <field name='name'>Cuotas sindicales</field>
+            <field name='code'>605.21</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_605'), ref('account_tag_605_21')])]"/>
+        </record>
+        <record id='cuenta605_22' model='account.account.template'>
+            <field name='name'>PTU</field>
+            <field name='code'>605.22</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_605'), ref('account_tag_605_22')])]"/>
+        </record>
+        <record id='cuenta605_23' model='account.account.template'>
+            <field name='name'>Estímulo al personal</field>
+            <field name='code'>605.23</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_605'), ref('account_tag_605_23')])]"/>
+        </record>
+        <record id='cuenta605_24' model='account.account.template'>
+            <field name='name'>Previsión social</field>
+            <field name='code'>605.24</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_605'), ref('account_tag_605_24')])]"/>
+        </record>
+        <record id='cuenta605_25' model='account.account.template'>
+            <field name='name'>Aportaciones para el plan de jubilación</field>
+            <field name='code'>605.25</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_605'), ref('account_tag_605_25')])]"/>
+        </record>
+        <record id='cuenta605_26' model='account.account.template'>
+            <field name='name'>Otras prestaciones al personal</field>
+            <field name='code'>605.26</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_605'), ref('account_tag_605_26')])]"/>
+        </record>
+        <record id='cuenta605_27' model='account.account.template'>
+            <field name='name'>Asimilados a salarios</field>
+            <field name='code'>605.27</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_605'), ref('account_tag_605_27')])]"/>
+        </record>
+        <record id='cuenta605_28' model='account.account.template'>
+            <field name='name'>Cuotas al IMSS</field>
+            <field name='code'>605.28</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_605'), ref('account_tag_605_28')])]"/>
+        </record>
+        <record id='cuenta605_29' model='account.account.template'>
+            <field name='name'>Aportaciones al infonavit</field>
+            <field name='code'>605.29</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_605'), ref('account_tag_605_29')])]"/>
+        </record>
+        <record id='cuenta605_3' model='account.account.template'>
+            <field name='name'>Aportaciones al SAR</field>
+            <field name='code'>605.30</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_605'), ref('account_tag_605_30')])]"/>
+        </record>
+        <record id='cuenta605_31' model='account.account.template'>
+            <field name='name'>Otros costos de mano de obra directa</field>
+            <field name='code'>605.31</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_605'), ref('account_tag_605_31')])]"/>
+        </record>
+        <record id='cuenta606_01' model='account.account.template'>
+            <field name='name'>Facilidades administrativas fiscales</field>
+            <field name='code'>606.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_606'), ref('account_tag_606_01')])]"/>
+        </record>
+        <record id='cuenta607_01' model='account.account.template'>
+            <field name='name'>Participación de los trabajadores en las utilidades</field>
+            <field name='code'>607.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_607'), ref('account_tag_607_01')])]"/>
+        </record>
+        <record id='cuenta608_01' model='account.account.template'>
+            <field name='name'>Participación en resultados de subsidiarias</field>
+            <field name='code'>608.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_608'), ref('account_tag_608_01')])]"/>
+        </record>
+        <record id='cuenta609_01' model='account.account.template'>
+            <field name='name'>Participación en resultados de asociadas</field>
+            <field name='code'>609.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_609'), ref('account_tag_609_01')])]"/>
+        </record>
+        <record id='cuenta610_01' model='account.account.template'>
+            <field name='name'>Participación de los trabajadores en las utilidades diferida</field>
+            <field name='code'>610.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_610'), ref('account_tag_610_01')])]"/>
+        </record>
+        <record id='cuenta611_01' model='account.account.template'>
+            <field name='name'>Impuesto Sobre la renta</field>
+            <field name='code'>611.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_611'), ref('account_tag_611_01')])]"/>
+        </record>
+        <record id='cuenta611_02' model='account.account.template'>
+            <field name='name'>Impuesto Sobre la renta por remanente distribuible</field>
+            <field name='code'>611.02</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_611'), ref('account_tag_611_02')])]"/>
+        </record>
+        <record id='cuenta612_01' model='account.account.template'>
+            <field name='name'>Gastos no deducibles para CUFIN</field>
+            <field name='code'>612.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_612'), ref('account_tag_612_01')])]"/>
+        </record>
+        <record id='cuenta613_01' model='account.account.template'>
+            <field name='name'>Depreciación de edificios</field>
+            <field name='code'>613.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_613'), ref('account_tag_613_01')])]"/>
+        </record>
+        <record id='cuenta613_02' model='account.account.template'>
+            <field name='name'>Depreciación de maquinaria y equipo</field>
+            <field name='code'>613.02</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_613'), ref('account_tag_613_02')])]"/>
+        </record>
+        <record id='cuenta613_03' model='account.account.template'>
+            <field name='name'>Depreciación de automóviles, autobuses, camiones de carga, tractocamiones, montacargas y remolques</field>
+            <field name='code'>613.03</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_613'), ref('account_tag_613_03')])]"/>
+        </record>
+        <record id='cuenta613_04' model='account.account.template'>
+            <field name='name'>Depreciación de mobiliario y equipo de oficina</field>
+            <field name='code'>613.04</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_613'), ref('account_tag_613_04')])]"/>
+        </record>
+        <record id='cuenta613_05' model='account.account.template'>
+            <field name='name'>Depreciación de equipo de cómputo</field>
+            <field name='code'>613.05</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_613'), ref('account_tag_613_05')])]"/>
+        </record>
+        <record id='cuenta613_06' model='account.account.template'>
+            <field name='name'>Depreciación de equipo de comunicación</field>
+            <field name='code'>613.06</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_613'), ref('account_tag_613_06')])]"/>
+        </record>
+        <record id='cuenta613_07' model='account.account.template'>
+            <field name='name'>Depreciación de activos biológicos, vegetales y semovientes</field>
+            <field name='code'>613.07</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_613'), ref('account_tag_613_07')])]"/>
+        </record>
+        <record id='cuenta613_08' model='account.account.template'>
+            <field name='name'>Depreciación de otros activos fijos</field>
+            <field name='code'>613.08</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_613'), ref('account_tag_613_08')])]"/>
+        </record>
+        <record id='cuenta613_09' model='account.account.template'>
+            <field name='name'>Depreciación de ferrocarriles</field>
+            <field name='code'>613.09</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_613'), ref('account_tag_613_09')])]"/>
+        </record>
+        <record id='cuenta613_10' model='account.account.template'>
+            <field name='name'>Depreciación de embarcaciones</field>
+            <field name='code'>613.10</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_613'), ref('account_tag_613_10')])]"/>
+        </record>
+        <record id='cuenta613_11' model='account.account.template'>
+            <field name='name'>Depreciación de aviones</field>
+            <field name='code'>613.11</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_613'), ref('account_tag_613_11')])]"/>
+        </record>
+        <record id='cuenta613_12' model='account.account.template'>
+            <field name='name'>Depreciación de troqueles, moldes, matrices y herramental</field>
+            <field name='code'>613.12</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_613'), ref('account_tag_613_12')])]"/>
+        </record>
+        <record id='cuenta613_13' model='account.account.template'>
+            <field name='name'>Depreciación de equipo de comunicaciones telefónicas</field>
+            <field name='code'>613.13</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_613'), ref('account_tag_613_13')])]"/>
+        </record>
+        <record id='cuenta613_14' model='account.account.template'>
+            <field name='name'>Depreciación de equipo de comunicación satelital</field>
+            <field name='code'>613.14</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_613'), ref('account_tag_613_14')])]"/>
+        </record>
+        <record id='cuenta613_15' model='account.account.template'>
+            <field name='name'>Depreciación de equipo de adaptaciones para personas con capacidades diferentes</field>
+            <field name='code'>613.15</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_613'), ref('account_tag_613_15')])]"/>
+        </record>
+        <record id='cuenta613_16' model='account.account.template'>
+            <field name='name'>Depreciación de maquinaria y equipo de generación de energía de fuentes renovables o de sistemas de cogeneración de electricidad eficiente</field>
+            <field name='code'>613.16</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_613'), ref('account_tag_613_16')])]"/>
+        </record>
+        <record id='cuenta613_17' model='account.account.template'>
+            <field name='name'>Depreciación de adaptaciones y mejoras</field>
+            <field name='code'>613.17</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_613'), ref('account_tag_613_17')])]"/>
+        </record>
+        <record id='cuenta613_18' model='account.account.template'>
+            <field name='name'>Depreciación de otra maquinaria y equipo</field>
+            <field name='code'>613.18</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_613'), ref('account_tag_613_18')])]"/>
+        </record>
+        <record id='cuenta614_01' model='account.account.template'>
+            <field name='name'>Amortización de gastos diferidos</field>
+            <field name='code'>614.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_614'), ref('account_tag_614_01')])]"/>
+        </record>
+        <record id='cuenta614_02' model='account.account.template'>
+            <field name='name'>Amortización de gastos pre operativos</field>
+            <field name='code'>614.02</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_614'), ref('account_tag_614_02')])]"/>
+        </record>
+        <record id='cuenta614_03' model='account.account.template'>
+            <field name='name'>Amortización de regalías, asistencia técnica y otros gastos diferidos</field>
+            <field name='code'>614.03</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_614'), ref('account_tag_614_03')])]"/>
+        </record>
+        <record id='cuenta614_04' model='account.account.template'>
+            <field name='name'>Amortización de activos intangibles</field>
+            <field name='code'>614.04</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_614'), ref('account_tag_614_04')])]"/>
+        </record>
+        <record id='cuenta614_05' model='account.account.template'>
+            <field name='name'>Amortización de gastos de organización</field>
+            <field name='code'>614.05</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_614'), ref('account_tag_614_05')])]"/>
+        </record>
+        <record id='cuenta614_06' model='account.account.template'>
+            <field name='name'>Amortización de investigación y desarrollo de mercado</field>
+            <field name='code'>614.06</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_614'), ref('account_tag_614_06')])]"/>
+        </record>
+        <record id='cuenta614_07' model='account.account.template'>
+            <field name='name'>Amortización de marcas y patentes</field>
+            <field name='code'>614.07</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_614'), ref('account_tag_614_07')])]"/>
+        </record>
+        <record id='cuenta614_08' model='account.account.template'>
+            <field name='name'>Amortización de crédito mercantil</field>
+            <field name='code'>614.08</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_614'), ref('account_tag_614_08')])]"/>
+        </record>
+        <record id='cuenta614_09' model='account.account.template'>
+            <field name='name'>Amortización de gastos de instalación</field>
+            <field name='code'>614.09</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_614'), ref('account_tag_614_09')])]"/>
+        </record>
+        <record id='cuenta614_10' model='account.account.template'>
+            <field name='name'>Amortización de otros activos diferidos</field>
+            <field name='code'>614.10</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_614'), ref('account_tag_614_10')])]"/>
+        </record>
+        <record id='cuenta701_01' model='account.account.template'>
+            <field name='name'>Pérdida cambiaria</field>
+            <field name='code'>701.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_701'), ref('account_tag_701_01')])]"/>
+        </record>
+        <record id='cuenta701_02' model='account.account.template'>
+            <field name='name'>Pérdida cambiaria nacional parte relacionada</field>
+            <field name='code'>701.02</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_701'), ref('account_tag_701_02')])]"/>
+        </record>
+        <record id='cuenta701_03' model='account.account.template'>
+            <field name='name'>Pérdida cambiaria extranjero parte relacionada</field>
+            <field name='code'>701.03</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_701'), ref('account_tag_701_03')])]"/>
+        </record>
+        <record id='cuenta701_04' model='account.account.template'>
+            <field name='name'>Intereses a cargo bancario nacional</field>
+            <field name='code'>701.04</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_701'), ref('account_tag_701_04')])]"/>
+        </record>
+        <record id='cuenta701_05' model='account.account.template'>
+            <field name='name'>Intereses a cargo bancario extranjero</field>
+            <field name='code'>701.05</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_701'), ref('account_tag_701_05')])]"/>
+        </record>
+        <record id='cuenta701_06' model='account.account.template'>
+            <field name='name'>Intereses a cargo de personas físicas nacional</field>
+            <field name='code'>701.06</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_701'), ref('account_tag_701_06')])]"/>
+        </record>
+        <record id='cuenta701_07' model='account.account.template'>
+            <field name='name'>Intereses a cargo de personas físicas extranjero</field>
+            <field name='code'>701.07</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_701'), ref('account_tag_701_07')])]"/>
+        </record>
+        <record id='cuenta701_08' model='account.account.template'>
+            <field name='name'>Intereses a cargo de personas morales nacional</field>
+            <field name='code'>701.08</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_701'), ref('account_tag_701_08')])]"/>
+        </record>
+        <record id='cuenta701_09' model='account.account.template'>
+            <field name='name'>Intereses a cargo de personas morales extranjero</field>
+            <field name='code'>701.09</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_701'), ref('account_tag_701_09')])]"/>
+        </record>
+        <record id='cuenta701_1' model='account.account.template'>
+            <field name='name'>Comisiones bancarias</field>
+            <field name='code'>701.10</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_701'), ref('account_tag_701_10')])]"/>
+        </record>
+        <record id='cuenta701_11' model='account.account.template'>
+            <field name='name'>Otros gastos financieros</field>
+            <field name='code'>701.11</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_701'), ref('account_tag_701_11')])]"/>
+        </record>
+        <record id='cuenta702_01' model='account.account.template'>
+            <field name='name'>Utilidad cambiaria</field>
+            <field name='code'>702.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_702'), ref('account_tag_702_01')])]"/>
+        </record>
+        <record id='cuenta702_02' model='account.account.template'>
+            <field name='name'>Utilidad cambiaria nacional parte relacionada</field>
+            <field name='code'>702.02</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_702'), ref('account_tag_702_02')])]"/>
+        </record>
+        <record id='cuenta702_03' model='account.account.template'>
+            <field name='name'>Utilidad cambiaria extranjero parte relacionada</field>
+            <field name='code'>702.03</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_702'), ref('account_tag_702_03')])]"/>
+        </record>
+        <record id='cuenta702_04' model='account.account.template'>
+            <field name='name'>Intereses a favor bancarios nacional</field>
+            <field name='code'>702.04</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_702'), ref('account_tag_702_04')])]"/>
+        </record>
+        <record id='cuenta702_05' model='account.account.template'>
+            <field name='name'>Intereses a favor bancarios extranjero</field>
+            <field name='code'>702.05</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_702'), ref('account_tag_702_05')])]"/>
+        </record>
+        <record id='cuenta702_06' model='account.account.template'>
+            <field name='name'>Intereses a favor de personas físicas nacional</field>
+            <field name='code'>702.06</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_702'), ref('account_tag_702_06')])]"/>
+        </record>
+        <record id='cuenta702_07' model='account.account.template'>
+            <field name='name'>Intereses a favor de personas físicas extranjero</field>
+            <field name='code'>702.07</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_702'), ref('account_tag_702_07')])]"/>
+        </record>
+        <record id='cuenta702_08' model='account.account.template'>
+            <field name='name'>Intereses a favor de personas morales nacional</field>
+            <field name='code'>702.08</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_702'), ref('account_tag_702_08')])]"/>
+        </record>
+        <record id='cuenta702_09' model='account.account.template'>
+            <field name='name'>Intereses a favor de personas morales extranjero</field>
+            <field name='code'>702.09</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_702'), ref('account_tag_702_09')])]"/>
+        </record>
+        <record id='cuenta702_10' model='account.account.template'>
+            <field name='name'>Otros productos financieros</field>
+            <field name='code'>702.10</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_702'), ref('account_tag_702_10')])]"/>
+        </record>
+        <record id='cuenta703_01' model='account.account.template'>
+            <field name='name'>Pérdida en venta y/o baja de terrenos</field>
+            <field name='code'>703.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_703'), ref('account_tag_703_01')])]"/>
+        </record>
+        <record id='cuenta703_02' model='account.account.template'>
+            <field name='name'>Pérdida en venta y/o baja de edificios</field>
+            <field name='code'>703.02</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_703'), ref('account_tag_703_02')])]"/>
+        </record>
+        <record id='cuenta703_03' model='account.account.template'>
+            <field name='name'>Pérdida en venta y/o baja de maquinaria y equipo</field>
+            <field name='code'>703.03</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_703'), ref('account_tag_703_03')])]"/>
+        </record>
+        <record id='cuenta703_04' model='account.account.template'>
+            <field name='name'>Pérdida en venta y/o baja de automóviles, autobuses, camiones de carga, tractocamiones, montacargas y remolques</field>
+            <field name='code'>703.04</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_703'), ref('account_tag_703_04')])]"/>
+        </record>
+        <record id='cuenta703_05' model='account.account.template'>
+            <field name='name'>Pérdida en venta y/o baja de mobiliario y equipo de oficina</field>
+            <field name='code'>703.05</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_703'), ref('account_tag_703_05')])]"/>
+        </record>
+        <record id='cuenta703_06' model='account.account.template'>
+            <field name='name'>Pérdida en venta y/o baja de equipo de cómputo</field>
+            <field name='code'>703.06</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_703'), ref('account_tag_703_06')])]"/>
+        </record>
+        <record id='cuenta703_07' model='account.account.template'>
+            <field name='name'>Pérdida en venta y/o baja de equipo de comunicación</field>
+            <field name='code'>703.07</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_703'), ref('account_tag_703_07')])]"/>
+        </record>
+        <record id='cuenta703_08' model='account.account.template'>
+            <field name='name'>Pérdida en venta y/o baja de activos biológicos, vegetales y semovientes</field>
+            <field name='code'>703.08</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_703'), ref('account_tag_703_08')])]"/>
+        </record>
+        <record id='cuenta703_09' model='account.account.template'>
+            <field name='name'>Pérdida en venta y/o baja de otros activos fijos</field>
+            <field name='code'>703.09</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_703'), ref('account_tag_703_09')])]"/>
+        </record>
+        <record id='cuenta703_10' model='account.account.template'>
+            <field name='name'>Pérdida en venta y/o baja de ferrocarriles</field>
+            <field name='code'>703.10</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_703'), ref('account_tag_703_10')])]"/>
+        </record>
+        <record id='cuenta703_11' model='account.account.template'>
+            <field name='name'>Pérdida en venta y/o baja de embarcaciones</field>
+            <field name='code'>703.11</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_703'), ref('account_tag_703_11')])]"/>
+        </record>
+        <record id='cuenta703_12' model='account.account.template'>
+            <field name='name'>Pérdida en venta y/o baja de aviones</field>
+            <field name='code'>703.12</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_703'), ref('account_tag_703_12')])]"/>
+        </record>
+        <record id='cuenta703_13' model='account.account.template'>
+            <field name='name'>Pérdida en venta y/o baja de troqueles, moldes, matrices y herramental</field>
+            <field name='code'>703.13</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_703'), ref('account_tag_703_13')])]"/>
+        </record>
+        <record id='cuenta703_14' model='account.account.template'>
+            <field name='name'>Pérdida en venta y/o baja de equipo de comunicaciones telefónicas</field>
+            <field name='code'>703.14</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_703'), ref('account_tag_703_14')])]"/>
+        </record>
+        <record id='cuenta703_15' model='account.account.template'>
+            <field name='name'>Pérdida en venta y/o baja de equipo de comunicación satelital</field>
+            <field name='code'>703.15</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_703'), ref('account_tag_703_15')])]"/>
+        </record>
+        <record id='cuenta703_16' model='account.account.template'>
+            <field name='name'>Pérdida en venta y/o baja de equipo de adaptaciones para personas con capacidades diferentes</field>
+            <field name='code'>703.16</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_703'), ref('account_tag_703_16')])]"/>
+        </record>
+        <record id='cuenta703_17' model='account.account.template'>
+            <field name='name'>Pérdida en venta y/o baja de maquinaria y equipo de generación de energía de fuentes renovables o de sistemas de cogeneración de electricidad eficiente</field>
+            <field name='code'>703.17</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_703'), ref('account_tag_703_17')])]"/>
+        </record>
+        <record id='cuenta703_18' model='account.account.template'>
+            <field name='name'>Pérdida en venta y/o baja de otra maquinaria y equipo</field>
+            <field name='code'>703.18</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_703'), ref('account_tag_703_18')])]"/>
+        </record>
+        <record id='cuenta703_19' model='account.account.template'>
+            <field name='name'>Pérdida por enajenación de acciones</field>
+            <field name='code'>703.19</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_703'), ref('account_tag_703_19')])]"/>
+        </record>
+        <record id='cuenta703_20' model='account.account.template'>
+            <field name='name'>Pérdida por enajenación de partes sociales</field>
+            <field name='code'>703.20</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_703'), ref('account_tag_703_20')])]"/>
+        </record>
+        <record id='cuenta703_21' model='account.account.template'>
+            <field name='name'>Otros gastos</field>
+            <field name='code'>703.21</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_703'), ref('account_tag_703_21')])]"/>
+        </record>
+        <record id='cuenta704_01' model='account.account.template'>
+            <field name='name'>Ganancia en venta y/o baja de terrenos</field>
+            <field name='code'>704.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_704'), ref('account_tag_704_01')])]"/>
+        </record>
+        <record id='cuenta704_02' model='account.account.template'>
+            <field name='name'>Ganancia en venta y/o baja de edificios</field>
+            <field name='code'>704.02</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_704'), ref('account_tag_704_02')])]"/>
+        </record>
+        <record id='cuenta704_03' model='account.account.template'>
+            <field name='name'>Ganancia en venta y/o baja de maquinaria y equipo</field>
+            <field name='code'>704.03</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_704'), ref('account_tag_704_03')])]"/>
+        </record>
+        <record id='cuenta704_04' model='account.account.template'>
+            <field name='name'>Ganancia en venta y/o baja de automóviles, autobuses, camiones de carga, tractocamiones, montacargas y remolques</field>
+            <field name='code'>704.04</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_704'), ref('account_tag_704_04')])]"/>
+        </record>
+        <record id='cuenta704_05' model='account.account.template'>
+            <field name='name'>Ganancia en venta y/o baja de mobiliario y equipo de oficina</field>
+            <field name='code'>704.05</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_704'), ref('account_tag_704_05')])]"/>
+        </record>
+        <record id='cuenta704_06' model='account.account.template'>
+            <field name='name'>Ganancia en venta y/o baja de equipo de cómputo</field>
+            <field name='code'>704.06</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_704'), ref('account_tag_704_06')])]"/>
+        </record>
+        <record id='cuenta704_07' model='account.account.template'>
+            <field name='name'>Ganancia en venta y/o baja de equipo de comunicación</field>
+            <field name='code'>704.07</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_704'), ref('account_tag_704_07')])]"/>
+        </record>
+        <record id='cuenta704_08' model='account.account.template'>
+            <field name='name'>Ganancia en venta y/o baja de activos biológicos, vegetales y semovientes</field>
+            <field name='code'>704.08</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_704'), ref('account_tag_704_08')])]"/>
+        </record>
+        <record id='cuenta704_09' model='account.account.template'>
+            <field name='name'>Ganancia en venta y/o baja de otros activos fijos</field>
+            <field name='code'>704.09</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_704'), ref('account_tag_704_09')])]"/>
+        </record>
+        <record id='cuenta704_10' model='account.account.template'>
+            <field name='name'>Ganancia en venta y/o baja de ferrocarriles</field>
+            <field name='code'>704.10</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_704'), ref('account_tag_704_10')])]"/>
+        </record>
+        <record id='cuenta704_11' model='account.account.template'>
+            <field name='name'>Ganancia en venta y/o baja de embarcaciones</field>
+            <field name='code'>704.11</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_704'), ref('account_tag_704_11')])]"/>
+        </record>
+        <record id='cuenta704_12' model='account.account.template'>
+            <field name='name'>Ganancia en venta y/o baja de aviones</field>
+            <field name='code'>704.12</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_704'), ref('account_tag_704_12')])]"/>
+        </record>
+        <record id='cuenta704_13' model='account.account.template'>
+            <field name='name'>Ganancia en venta y/o baja de troqueles, moldes, matrices y herramental</field>
+            <field name='code'>704.13</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_704'), ref('account_tag_704_13')])]"/>
+        </record>
+        <record id='cuenta704_14' model='account.account.template'>
+            <field name='name'>Ganancia en venta y/o baja de equipo de comunicaciones telefónicas</field>
+            <field name='code'>704.14</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_704'), ref('account_tag_704_14')])]"/>
+        </record>
+        <record id='cuenta704_15' model='account.account.template'>
+            <field name='name'>Ganancia en venta y/o baja de equipo de comunicación satelital</field>
+            <field name='code'>704.15</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_704'), ref('account_tag_704_15')])]"/>
+        </record>
+        <record id='cuenta704_16' model='account.account.template'>
+            <field name='name'>Ganancia en venta y/o baja de equipo de adaptaciones para personas con capacidades diferentes</field>
+            <field name='code'>704.16</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_704'), ref('account_tag_704_16')])]"/>
+        </record>
+        <record id='cuenta704_17' model='account.account.template'>
+            <field name='name'>Ganancia en venta de maquinaria y equipo de generación de energía de fuentes renovables o de sistemas de cogeneración de electricidad eficiente</field>
+            <field name='code'>704.17</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_704'), ref('account_tag_704_17')])]"/>
+        </record>
+        <record id='cuenta704_18' model='account.account.template'>
+            <field name='name'>Ganancia en venta y/o baja de otra maquinaria y equipo</field>
+            <field name='code'>704.18</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_704'), ref('account_tag_704_18')])]"/>
+        </record>
+        <record id='cuenta704_19' model='account.account.template'>
+            <field name='name'>Ganancia por enajenación de acciones</field>
+            <field name='code'>704.19</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_704'), ref('account_tag_704_19')])]"/>
+        </record>
+        <record id='cuenta704_2' model='account.account.template'>
+            <field name='name'>Ganancia por enajenación de partes sociales</field>
+            <field name='code'>704.20</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_704'), ref('account_tag_704_20')])]"/>
+        </record>
+        <record id='cuenta704_21' model='account.account.template'>
+            <field name='name'>Ingresos por estímulos fiscales</field>
+            <field name='code'>704.21</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_704'), ref('account_tag_704_21')])]"/>
+        </record>
+        <record id='cuenta704_22' model='account.account.template'>
+            <field name='name'>Ingresos por condonación de adeudo</field>
+            <field name='code'>704.22</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_704'), ref('account_tag_704_22')])]"/>
+        </record>
+        <record id='cuenta704_23' model='account.account.template'>
+            <field name='name'>Otros productos</field>
+            <field name='code'>704.23</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_704'), ref('account_tag_704_23')])]"/>
+        </record>
+        <record id='cuenta801_01' model='account.account.template'>
+            <field name='name'>UFIN</field>
+            <field name='code'>801.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_801'), ref('account_tag_801_01')])]"/>
+        </record>
+        <record id='cuenta801_02' model='account.account.template'>
+            <field name='name'>Contra cuenta UFIN</field>
+            <field name='code'>801.02</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_801'), ref('account_tag_801_02')])]"/>
+        </record>
+        <record id='cuenta802_01' model='account.account.template'>
+            <field name='name'>CUFIN</field>
+            <field name='code'>802.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_802'), ref('account_tag_802_01')])]"/>
+        </record>
+        <record id='cuenta802_02' model='account.account.template'>
+            <field name='name'>Contra cuenta CUFIN</field>
+            <field name='code'>802.02</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_802'), ref('account_tag_802_02')])]"/>
+        </record>
+        <record id='cuenta803_01' model='account.account.template'>
+            <field name='name'>CUFIN de ejercicios anteriores</field>
+            <field name='code'>803.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_803'), ref('account_tag_803_01')])]"/>
+        </record>
+        <record id='cuenta803_02' model='account.account.template'>
+            <field name='name'>Contra cuenta CUFIN de ejercicios anteriores</field>
+            <field name='code'>803.02</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_803'), ref('account_tag_803_02')])]"/>
+        </record>
+        <record id='cuenta804_01' model='account.account.template'>
+            <field name='name'>CUFINRE</field>
+            <field name='code'>804.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_804'), ref('account_tag_804_01')])]"/>
+        </record>
+        <record id='cuenta804_02' model='account.account.template'>
+            <field name='name'>Contra cuenta CUFINRE</field>
+            <field name='code'>804.02</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_804'), ref('account_tag_804_02')])]"/>
+        </record>
+        <record id='cuenta805_01' model='account.account.template'>
+            <field name='name'>CUFINRE de ejercicios anteriores</field>
+            <field name='code'>805.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_805'), ref('account_tag_805_01')])]"/>
+        </record>
+        <record id='cuenta805_02' model='account.account.template'>
+            <field name='name'>Contra cuenta CUFINRE de ejercicios anteriores</field>
+            <field name='code'>805.02</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_805'), ref('account_tag_805_02')])]"/>
+        </record>
+        <record id='cuenta806_01' model='account.account.template'>
+            <field name='name'>CUCA</field>
+            <field name='code'>806.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_806'), ref('account_tag_806_01')])]"/>
+        </record>
+        <record id='cuenta806_02' model='account.account.template'>
+            <field name='name'>Contra cuenta CUCA</field>
+            <field name='code'>806.02</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_806'), ref('account_tag_806_02')])]"/>
+        </record>
+        <record id='cuenta807_01' model='account.account.template'>
+            <field name='name'>CUCA de ejercicios anteriores</field>
+            <field name='code'>807.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_807'), ref('account_tag_807_01')])]"/>
+        </record>
+        <record id='cuenta807_02' model='account.account.template'>
+            <field name='name'>Contra cuenta CUCA de ejercicios anteriores</field>
+            <field name='code'>807.02</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_807'), ref('account_tag_807_02')])]"/>
+        </record>
+        <record id='cuenta808_01' model='account.account.template'>
+            <field name='name'>Ajuste anual por inflación acumulable</field>
+            <field name='code'>808.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_808'), ref('account_tag_808_01')])]"/>
+        </record>
+        <record id='cuenta808_02' model='account.account.template'>
+            <field name='name'>Acumulación del ajuste anual inflacionario</field>
+            <field name='code'>808.02</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_808'), ref('account_tag_808_02')])]"/>
+        </record>
+        <record id='cuenta809_01' model='account.account.template'>
+            <field name='name'>Ajuste anual por inflación deducible</field>
+            <field name='code'>809.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_809'), ref('account_tag_809_01')])]"/>
+        </record>
+        <record id='cuenta809_02' model='account.account.template'>
+            <field name='name'>Deducción del ajuste anual inflacionario</field>
+            <field name='code'>809.02</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_809'), ref('account_tag_809_02')])]"/>
+        </record>
+        <record id='cuenta810_01' model='account.account.template'>
+            <field name='name'>Deducción de inversión</field>
+            <field name='code'>810.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_810'), ref('account_tag_810_01')])]"/>
+        </record>
+        <record id='cuenta810_02' model='account.account.template'>
+            <field name='name'>Contra cuenta deducción de inversiones</field>
+            <field name='code'>810.02</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_810'), ref('account_tag_810_02')])]"/>
+        </record>
+        <record id='cuenta811_01' model='account.account.template'>
+            <field name='name'>Utilidad o pérdida fiscal en venta y/o baja de activo fijo</field>
+            <field name='code'>811.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_811'), ref('account_tag_811_01')])]"/>
+        </record>
+        <record id='cuenta811_02' model='account.account.template'>
+            <field name='name'>Contra cuenta utilidad o pérdida fiscal en venta y/o baja de activo fijo</field>
+            <field name='code'>811.02</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_811'), ref('account_tag_811_02')])]"/>
+        </record>
+        <record id='cuenta812_01' model='account.account.template'>
+            <field name='name'>Utilidad o pérdida fiscal en venta acciones o partes sociales</field>
+            <field name='code'>812.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_812'), ref('account_tag_812_01')])]"/>
+        </record>
+        <record id='cuenta812_02' model='account.account.template'>
+            <field name='name'>Contra cuenta utilidad o pérdida fiscal en venta acciones o partes sociales</field>
+            <field name='code'>812.02</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_812'), ref('account_tag_812_02')])]"/>
+        </record>
+        <record id='cuenta813_01' model='account.account.template'>
+            <field name='name'>Pérdidas fiscales pendientes de amortizar actualizadas de ejercicios anteriores</field>
+            <field name='code'>813.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_813'), ref('account_tag_813_01')])]"/>
+        </record>
+        <record id='cuenta813_02' model='account.account.template'>
+            <field name='name'>Actualización de pérdidas fiscales pendientes de amortizar de ejercicios anteriores</field>
+            <field name='code'>813.02</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_813'), ref('account_tag_813_02')])]"/>
+        </record>
+        <record id='cuenta814_01' model='account.account.template'>
+            <field name='name'>Mercancías recibidas en consignación</field>
+            <field name='code'>814.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_814'), ref('account_tag_814_01')])]"/>
+        </record>
+        <record id='cuenta814_02' model='account.account.template'>
+            <field name='name'>Consignación de mercancías recibidas</field>
+            <field name='code'>814.02</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_814'), ref('account_tag_814_02')])]"/>
+        </record>
+        <record id='cuenta815_01' model='account.account.template'>
+            <field name='name'>Crédito fiscal de IVA e IEPS por la importación de mercancías</field>
+            <field name='code'>815.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_815'), ref('account_tag_815_01')])]"/>
+        </record>
+        <record id='cuenta815_02' model='account.account.template'>
+            <field name='name'>Importación de mercancías con aplicación de crédito fiscal de IVA e IEPS</field>
+            <field name='code'>815.02</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_815'), ref('account_tag_815_02')])]"/>
+        </record>
+        <record id='cuenta816_01' model='account.account.template'>
+            <field name='name'>Crédito fiscal de IVA e IEPS por la importación de activo fijo</field>
+            <field name='code'>816.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_816'), ref('account_tag_816_01')])]"/>
+        </record>
+        <record id='cuenta816_02' model='account.account.template'>
+            <field name='name'>Importación de activo fijo con aplicación de crédito fiscal de IVA e IEPS</field>
+            <field name='code'>816.02</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_816'), ref('account_tag_816_02')])]"/>
+        </record>
+        <record id='cuenta899_01' model='account.account.template'>
+            <field name='name'>Otras cuentas de orden</field>
+            <field name='code'>899.01</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_899'), ref('account_tag_899_01')])]"/>
+        </record>
+        <record id='cuenta899_02' model='account.account.template'>
+            <field name='name'>Contra cuenta otras cuentas de orden</field>
+            <field name='code'>899.02</field>
+            <field name="chart_template_id" ref="vauxoo_mx_chart_template"/>
+            <field name="user_type_id" ref="account_type_other"/>
+            <field name="tag_ids" eval="[(6,0,[ref('account_tag_899'), ref('account_tag_899_02')])]"/>
+        </record>
+
+        <record id="vauxoo_mx_chart_template" model="account.chart.template">
+            <field name="property_account_receivable_id" ref="cuenta105_01"/>
+            <field name="property_account_payable_id" ref="cuenta201_01"/>
+            <field name="property_account_expense_categ_id" ref="cuenta501_01"/>
+            <field name="property_account_income_categ_id" ref="cuenta401_01"/>
+            <field name="income_currency_exchange_account_id" ref="cuenta702_01"/>
+            <field name="expense_currency_exchange_account_id" ref="cuenta701_01"/>
+        </record>
+
+    </data>
 </odoo>

--- a/addons/l10n_mx/data/res_company_data.xml
+++ b/addons/l10n_mx/data/res_company_data.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="0">
+        <record id="base.main_company" model="res.company">
+            <field name="tax_cash_basis_journal_id" ref="journal_effectively_paid"/>
+        </record>
+    </data>
+</odoo>

--- a/addons/l10n_mx/models/__init__.py
+++ b/addons/l10n_mx/models/__init__.py
@@ -1,0 +1,5 @@
+# coding: utf-8
+# Copyright 2016 Vauxoo (https://www.vauxoo.com) <info@vauxoo.com>
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+from . import chart_template

--- a/addons/l10n_mx/models/chart_template.py
+++ b/addons/l10n_mx/models/chart_template.py
@@ -1,0 +1,91 @@
+# coding: utf-8
+# Copyright 2016 Vauxoo (https://www.vauxoo.com) <info@vauxoo.com>
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+from odoo import models, fields, api
+
+
+class AccountTaxTemplate(models.Model):
+    _inherit = 'account.tax.template'
+
+    use_cash_basis = fields.Boolean(
+        help='Select this if the tax should use cash basis, which will '
+        'create an entry for this tax on a given account during '
+        'reconciliation')
+    cash_basis_account = fields.Many2one(
+        'account.account.template', string='Tax Received Account',
+        ondelete='restrict',
+        help='Account use when creating entry for tax cash basis')
+
+    def _get_tax_vals(self, company):
+        """ This method add in dictionnary of all the values for the tax that
+        will be created if will be assigned the cash basis account.
+        """
+        self.ensure_one()
+        res = super(AccountTaxTemplate, self)._get_tax_vals(company)
+        res.update({
+            'use_cash_basis': self.use_cash_basis,
+        })
+        return res
+
+    @api.multi
+    def _generate_tax(self, company):
+        """ This method update the return that generate taxes from templates.
+            :param company: the company for which the taxes should be created
+                from templates in self
+            :returns: {
+                'tax_template_to_tax': mapping between tax template and the
+                    newly generated taxes corresponding,
+                'account_dict': dictionary containing a to-do list with all
+                    the accounts to assign on new taxes
+            }
+        """
+        res = super(AccountTaxTemplate, self)._generate_tax(company)
+        for tax in self:
+            res.get('account_dict', {}).get(tax.id, {}).update({
+                'cash_basis_account': tax.cash_basis_account.id})
+        return res
+
+
+class AccountChartTemplate(models.Model):
+    _inherit = "account.chart.template"
+
+    @api.multi
+    def _load_template(
+            self, company, code_digits=None, transfer_account_id=None,
+            account_ref=None, taxes_ref=None):
+        """ Generate all the objects from the templates
+            :param company: company the wizard is running for
+            :param code_digits: number of digits the accounts code should have
+                in the COA
+            :param transfer_account_id: reference to the account template
+                that will be used as intermediary account for transfers between
+                2 liquidity accounts
+            :param acc_ref: Mapping between ids of account templates and real
+                accounts created from them
+            :param taxes_ref: Mapping between ids of tax templates and real
+                taxes created from them
+            :returns: tuple with a dictionary containing
+                * the mapping between the account template ids and the ids of
+                    the real accounts that have been generated
+                    from them, as first item,
+                * a similar dictionary for mapping the tax templates and taxes,
+                    as second item,
+            :rtype: tuple(dict, dict, dict)
+            inherited to write the cash_basis_account in the created taxes
+        """
+        self.ensure_one()
+        accounts, taxes = super(AccountChartTemplate, self)._load_template(
+            company, code_digits=code_digits,
+            transfer_account_id=transfer_account_id, account_ref=account_ref,
+            taxes_ref=taxes_ref)
+        if account_ref is None:
+            account_ref = {}
+        account_tax_obj = self.env['account.tax']
+
+        for tax in self.tax_template_ids:
+            account_tax_obj.browse(taxes.get(tax.id)).write({
+                'cash_basis_account': account_ref.get(
+                    tax.cash_basis_account.id, False),
+            })
+        return accounts, taxes


### PR DESCRIPTION
- Changed the mexican chart template by the accounts provided by the SAT
  in electronic accounting, in this file: http://goo.gl/7Olr4J

- Assigned the account tags with data data in the Mexican chart
  template.

- Created the account tag data based in the SAT document
  (http://goo.gl/xTGz7s), where each account parent is a new tag in
  this data.

  The name is the concatenation of tag.code + tag.name, because
  the account.tag model have not the code field.

  The green color is assigned to this tags.

- Generate an account tag by each account in SAT catalog, and assign to
  the corresponding account.
  This tags are red color.

  And are created, because could be created more accounts out of SAT
  catalog, and that have relation to one same tag.

  Sample:

  Bank1------102.01 Bancos nacionales
  Bank2------102.01 Bancos nacionales
  Bank3------102.01 Bancos nacionales

Merging: https://github.com/odoo/odoo/pull/13946