### PR TITLE
[FIX] odoo v10.0: fix AddonsImportHook find_module method to follow PEP302

### DIFF
--- a/odoo/modules/module.py
+++ b/odoo/modules/module.py
@@ -39,7 +39,7 @@ loaded = []
 class AddonsHook(object):
     """ Makes modules accessible through openerp.addons.* and odoo.addons.* """
 
-    def find_module(self, name, path):
+    def find_module(self, name, path=None):
         if name.startswith(('odoo.addons.', 'openerp.addons.'))\
                 and name.count('.') == 2:
             return self


### PR DESCRIPTION
When we try to install orchest in odoo v10.0 this error occurs:  
![image](https://cloud.githubusercontent.com/assets/12100691/19906027/d870dd8a-a03e-11e6-805b-ab065fcb700a.png)
This error was reported [here](https://github.com/odoo/odoo/issues/14087) and the solution is in this [PR](https://github.com/odoo/odoo/pull/14088) but we need this fix so we can start testing in odoo 10.
The error is because when we try to import jsonschema it uses pkgutil.find_loader to search for the correct package loader by calling the find_module method of each loader with only one parameter,
according to the [PEP302](https://www.python.org/dev/peps/pep-0302/#specification-part-1-the-importer-protocol) the find_module method of the import hooks must have None as default for the second parameter and since the odoo loader doesn't follow this spec correctly pkgutil.find_loader fails.
This was not an issue in odoo 9.0 because it was following the spec correctly in that version:  
https://github.com/odoo/odoo/blob/9.0/openerp/modules/module.py#L49
