### PR TITLE
[ADD] Point of Sale Orders Analysis now show the product qty express in product unit of measure

### DIFF
--- a/addons/point_of_sale/report/pos_order_report.py
+++ b/addons/point_of_sale/report/pos_order_report.py
@@ -24,7 +24,9 @@ class pos_order_report(osv.osv):
         'location_id':fields.many2one('stock.location', 'Location', readonly=True),
         'company_id':fields.many2one('res.company', 'Company', readonly=True),
         'nbr':fields.integer('# of Lines', readonly=True),  # TDE FIXME master: rename into nbr_lines
-        'product_qty':fields.integer('Product Quantity', readonly=True),
+        'product_qty_wo_conversion':fields.float('Qty in Transaction UoM', readonly=True),
+        'product_uom_id':fields.many2one('product.uom', 'Unit of Measure', readonly=True),
+        'product_qty':fields.float('Qty in Default UoM', readonly=True),
         'journal_id': fields.many2one('account.journal', 'Journal'),
         'delay_validation': fields.integer('Delay Validation'),
         'product_categ_id': fields.many2one('product.category', 'Product Category', readonly=True),
@@ -45,6 +47,8 @@ class pos_order_report(osv.osv):
                     count(*) as nbr,
                     s.date_order as date,
                     sum(l.qty * u.factor) as product_qty,
+                    sum(l.qty) as product_qty_wo_conversion,
+                    pt.uom_id as product_uom_id,
                     sum(l.qty * l.price_unit) as price_sub_total,
                     sum((l.qty * l.price_unit) * (100 - l.discount) / 100) as price_total,
                     sum((l.qty * l.price_unit) * (l.discount / 100)) as total_discount,
@@ -73,6 +77,7 @@ class pos_order_report(osv.osv):
                     left join pos_config pc on (ps.config_id=pc.id)
                 group by
                     s.date_order, s.partner_id,s.state, pt.categ_id,
+                    pt.uom_id,
                     s.user_id,s.location_id,s.company_id,s.sale_journal,s.pricelist_id,s.invoice_id,l.product_id,s.create_date,pt.categ_id,pt.pos_categ_id,p.product_tmpl_id,ps.config_id,pc.stock_location_id
                 having
                     sum(l.qty * u.factor) != 0)""")

--- a/addons/point_of_sale/report/pos_order_report_view.xml
+++ b/addons/point_of_sale/report/pos_order_report_view.xml
@@ -9,6 +9,7 @@
                     <field name="product_categ_id" type="row"/>
                     <field name="date" interval="month" type="col"/>
                     <field name="product_qty" type="measure"/>
+                    <field name="product_qty_wo_conversion" type="measure"/>
                     <field name="price_total" type="measure"/>
                 </pivot>
             </field>


### PR DESCRIPTION
Related to [task#6473](https://www.vauxoo.com/web#id=6473&view_type=form&model=project.task)

---

1. Update the product_qty field. Formerly was a integer field, now is a float field.
2. Add new field Unit of Measure that let us to filter the data taking into account the product unit of measure used when the product was sale.
3. Update sql operation to update the way that product_qty is compute. 
4. Compute the product uom and add a group by in order to let us filter the products using this measure.

*NOTE: First, I try to add a new product_qty_wo_conversion field and leave the product_qty field untouched. but I figured out that in a production database If I try to remove the product_qty or any column that already exist in the report view, and then I try to update the database the changes do not apply for some reason.**
 