### PR TITLE
[IMP] l10n_mx: Assign the correct description in tax.

### DIFF
--- a/addons/l10n_mx/data/account_tax_data.xml
+++ b/addons/l10n_mx/data/account_tax_data.xml
@@ -46,7 +46,7 @@
     <record id="tax9" model="account.tax.template">
         <field name="chart_template_id" ref="mx_coa"/>
         <field name="name">IVA(0%) VENTAS</field>
-        <field name="description">ITAX_010-IN</field>
+        <field name="description">IVA</field>
         <field name="amount">0</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">sale</field>
@@ -59,7 +59,7 @@
     <record id="tax12" model="account.tax.template">
         <field name="chart_template_id" ref="mx_coa"/>
         <field name="name">IVA(16%) VENTAS</field>
-        <field name="description">ITAX_160-IN</field>
+        <field name="description">IVA</field>
         <field name="amount">16</field>
         <field name="amount_type">percent</field>
         <field name="type_tax_use">sale</field>

--- a/addons/l10n_mx/models/chart_template.py
+++ b/addons/l10n_mx/models/chart_template.py
@@ -29,8 +29,7 @@ class AccountChartTemplate(models.Model):
         account_tax_obj = self.env['account.tax']
         account_obj = self.env['account.account']
         taxes_acc = {
-            'ITAX_010-IN': account_obj.search([('code', '=', '208.01.01')]),
-            'ITAX_160-IN': account_obj.search([('code', '=', '208.01.01')]),
+            'IVA': account_obj.search([('code', '=', '208.01.01')]),
             'ITAXR_04-OUT': account_obj.search([('code', '=', '216.10.20')]),
             'ITAXR_10-OUT': account_obj.search([('code', '=', '216.10.20')]),
             'ITAX_1067-OUT': account_obj.search([('code', '=', '216.10.20')]),


### PR DESCRIPTION
This value will be used in the XML generation and must be assigned
to sale taxes.

Could be used "IVA", "ISR" or "IEPS"