### PR TITLE
[FIX] l10n_mx: Assign the correct account in journal to tax basis

### DIFF
--- a/addons/l10n_mx/models/chart_template.py
+++ b/addons/l10n_mx/models/chart_template.py
@@ -66,15 +66,14 @@ class AccountChartTemplate(models.Model):
             acc_template_ref, company, journals_dict=journals_dict)
         if not self == self.env.ref('l10n_mx.mx_coa'):
             return res
+        account = self.env.ref('l10n_mx.1_cuenta118_01')
         res.append({
             'type': 'general',
             'name': _('Effectively Paid'),
             'code': 'CBMX',
             'company_id': company.id,
-            'default_credit_account_id': acc_template_ref.get(
-                self.income_currency_exchange_account_id.id),
-            'default_debit_account_id': acc_template_ref.get(
-                self.expense_currency_exchange_account_id.id),
+            'default_credit_account_id': account.id,
+            'default_debit_account_id': account.id,
             'show_on_dashboard': True,
         })
         return res


### PR DESCRIPTION
The 'Effectively Paid' journal must be have the account '118.01.01' like debit/credit account

Fixes https://github.com/Vauxoo/odoo/issues/154