### PR TITLE
[REF] Cherry-pick to base_address_* modules from Odoo master

### DIFF
--- a/addons/base_address_city/__init__.py
+++ b/addons/base_address_city/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import models

--- a/addons/base_address_city/__manifest__.py
+++ b/addons/base_address_city/__manifest__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+{
+    'name': 'City Addresses',
+    'summary': 'Add a many2one field city on addresses',
+    'sequence': '19',
+    'category': 'Base',
+    'complexity': 'easy',
+    'description': """
+City Management in Addresses
+============================
+
+This module allows to enforce users to choose the city of a partner inside a given list instead of a free text field.
+        """,
+    'data': [
+        'security/ir.model.access.csv',
+        'views/res_city_view.xml',
+        'views/res_country_view.xml',
+    ],
+    'depends': ['base'],
+}

--- a/addons/base_address_city/models/__init__.py
+++ b/addons/base_address_city/models/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import res_city
+import res_country
+import res_partner

--- a/addons/base_address_city/models/res_city.py
+++ b/addons/base_address_city/models/res_city.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models
+
+
+class City(models.Model):
+    _name = 'res.city'
+    _description = 'City'
+    _order = 'name'
+
+    name = fields.Char("Name", required=True, translate=True)
+    zipcode = fields.Char("Zip")
+    country_id = fields.Many2one('res.country', string='Country', required=True)
+    state_id = fields.Many2one(
+        'res.country.state', 'State', domain="[('country_id', '=', country_id)]")

--- a/addons/base_address_city/models/res_country.py
+++ b/addons/base_address_city/models/res_country.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models
+
+
+class Country(models.Model):
+    _inherit = 'res.country'
+
+    enforce_cities = fields.Boolean(
+        string='Enforce Cities',
+        help="Check this box to ensure every address created in that country has a 'City' chosen "
+             "in the list of the country's cities.")

--- a/addons/base_address_city/models/res_partner.py
+++ b/addons/base_address_city/models/res_partner.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from lxml import etree
+
+from odoo import api, models, fields
+
+class FormatAddressMixin(models.AbstractModel):
+    _inherit = "format.address.mixin"
+
+    @api.model
+    def fields_view_get_address(self, arch):
+        arch = super(FormatAddressMixin, self).fields_view_get_address(arch)
+        #render the partner address accordingly to address_view_id
+        doc = etree.fromstring(arch)
+        for city_node in doc.xpath("//field[@name='city']"):
+            replacement_xml = """
+            <div>
+            <field name="country_enforce_cities" invisible="1"/>
+            <div attrs="{'invisible': [('country_enforce_cities', '=', False)]}">
+                <field name='city' attrs="{'invisible': ['|', ('city_id', '!=', False), ('city', '=', False)]}"/>
+                <field name='city_id'/>
+            </div>
+            </div>
+            """
+            city_id_node = etree.fromstring(replacement_xml)
+            city_node.getparent().replace(city_node, city_id_node)
+
+        arch = etree.tostring(doc)
+        return arch
+
+
+class Partner(models.Model):
+    _inherit = 'res.partner'
+
+    country_enforce_cities = fields.Boolean(related='country_id.enforce_cities')
+    city_id = fields.Many2one('res.city', string='Company')
+
+    @api.onchange('city_id')
+    def _onchange_city_id(self):
+        self.city = self.city_id.name
+        self.zip = self.city_id.zipcode
+        self.state_id = self.city_id.state_id

--- a/addons/base_address_city/security/ir.model.access.csv
+++ b/addons/base_address_city/security/ir.model.access.csv
@@ -1,0 +1,3 @@
+"id","name","model_id:id","group_id:id","perm_read","perm_write","perm_create","perm_unlink"
+"access_res_city_group_user","res_city group_user","model_res_city","base.group_partner_manager",1,1,1,1
+"access_res_city_group_all","res_city group_user_all","model_res_city",,1,0,0,0

--- a/addons/base_address_city/views/res_city_view.xml
+++ b/addons/base_address_city/views/res_city_view.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="view_city_tree" model="ir.ui.view">
+            <field name="model">res.city</field>
+            <field name="arch" type="xml">
+                <tree string="City" editable="top">
+                    <field name="name"/>
+                    <field name="zipcode"/>
+                    <field name="country_id"/>
+                    <field name="state_id"/>
+                </tree>
+            </field>
+        </record>
+        <record id="view_city_filter" model="ir.ui.view">
+            <field name="model">res.city</field>
+            <field name="arch" type="xml">
+                <search string="Search City">
+                    <field name="name" filter_domain="['|', ('name','ilike',self), ('zipcode','ilike',self)]"
+                           string="City"/>
+                    <separator/>
+                    <field name="country_id"/>
+                </search>
+            </field>
+        </record>
+
+        <record id="action_res_city_tree" model="ir.actions.act_window">
+            <field name="name">Cities</field>
+            <field name="type">ir.actions.act_window</field>
+            <field name="res_model">res.city</field>
+            <field name="view_type">form</field>
+            <field name="view_mode">tree</field>
+            <field name="help">
+                Display and manage the list of all cities that can be assigned to
+                your partner records. Note that an option can be set on each country separately
+                to enforce any address of it to have a city in this list.
+            </field>
+        </record>
+    </data>
+</odoo>
+

--- a/addons/base_address_city/views/res_country_view.xml
+++ b/addons/base_address_city/views/res_country_view.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+    <record id="view_res_country_city_extended_form" model="ir.ui.view">
+        <field name="model">res.country</field>
+        <field name="inherit_id" ref="base.view_country_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//div[@class='oe_button_box']" position="inside">
+                <button name="%(action_res_city_tree)d"
+                    class="oe_stat_button"
+                    icon="fa-globe"
+                    type="action"
+                    context="{'default_country_id': active_id, 'search_default_country_id': active_id}"
+                    string="Cities">
+                </button>
+            </xpath>
+            <xpath expr="//field[@name='phone_code']" position="after">
+                <field name="enforce_cities"/>
+            </xpath>
+        </field>
+    </record>
+    </data>
+</odoo>

--- a/addons/base_address_extended/models/base_address_extended.py
+++ b/addons/base_address_extended/models/base_address_extended.py
@@ -4,6 +4,7 @@
 import re
 
 from odoo import api, fields, models, _
+from odoo.exceptions import UserError
 
 
 STREET_FIELDS = ('street_name', 'street_number', 'street_number2')
@@ -12,77 +13,128 @@ STREET_FIELDS = ('street_name', 'street_number', 'street_number2')
 class ResCountry(models.Model):
     _inherit = 'res.country'
 
-    street_format = fields.Text(help="""You can state here the usual format to use for the \
-streets belonging to this country.\n\nYou can use the python-style string patern with all the field of the street \
-(for example, use '%(street_name)s, %(street_number)s' if you want to display the street name, followed by a coma and the house number)
-            \n%(street_name)s: the name of the street
-            \n%(street_number)s: the house number
-            \n%(street_number2)s: the door number""",
-            default='%(street_number)s/%(street_number2)s %(street_name)s', required=True)
-
+    street_format = fields.Text(
+        help="Format to use for streets belonging to this country.\n\n"
+             "You can use the python-style string pattern with all the fields of the street "
+             "(for example, use '%(street_name)s, %(street_number)s' if you want to display "
+             "the street name, followed by a comma and the house number)"
+             "\n%(street_name)s: the name of the street"
+             "\n%(street_number)s: the house number"
+             "\n%(street_number2)s: the door number",
+        default='%(street_number)s/%(street_number2)s %(street_name)s', required=True)
 
 class Partner(models.Model):
     _inherit = ['res.partner']
     _name = 'res.partner'
 
-    street_name = fields.Char('Street Name', compute='_split_street', inverse='_set_street', store=True)
-    street_number = fields.Char('House Number', compute='_split_street', inverse='_set_street', store=True)
-    street_number2 = fields.Char('Door Number', compute='_split_street', inverse='_set_street', store=True)
-
+    street_name = fields.Char('Street Name', compute='_split_street',
+                              inverse='_set_street', store=True)
+    street_number = fields.Char('House Number', compute='_split_street',
+                                inverse='_set_street', store=True)
+    street_number2 = fields.Char('Door Number', compute='_split_street',
+                                 inverse='_set_street', store=True)
 
     def get_street_fields(self):
-        """Returns the fields that can be used in a street format. Overwrite this function if you want to add your own fields."""
+        """Returns the fields that can be used in a street format.
+        Overwrite this function if you want to add your own fields."""
         return STREET_FIELDS
 
     @api.multi
     def _set_street(self):
-        """Write the street field on the partners when one of the fields in STREET_FIELDS has been touched"""
+        """Updates the street field.
+        Writes the `street` field on the partners when one of the sub-fields in STREET_FIELDS
+        has been touched"""
+        street_fields = self.get_street_fields()
         for partner in self:
-            street_format = partner.country_id.street_format or '%(street_number)s/%(street_number2)s %(street_name)s'
-            street_vals = {field: getattr(partner, field) for field in self.get_street_fields()}
-            partner.street = street_format % street_vals
+            street_format = (partner.country_id.street_format or
+                '%(street_number)s/%(street_number2)s %(street_name)s')
+            previous_field = None
+            previous_pos = 0
+            street_value = ""
+            separator = ""
+            # iter on fields in street_format, detected as '%(<field_name>)s'
+            for re_match in re.finditer(r'%\(\w+\)s', street_format):
+                # [2:-2] is used to remove the extra chars '%(' and ')s'
+                field_name = re_match.group()[2:-2]
+                field_pos = re_match.start()
+                if field_name not in street_fields:
+                    raise UserError(_("Unrecognized field %s in street format.") % field_name)
+                if not previous_field:
+                    # first iteration: add heading chars in street_format
+                    if partner[field_name]:
+                        street_value += street_format[0:field_pos] + partner[field_name]
+                else:
+                    # get the substring between 2 fields, to be used as separator
+                    separator = street_format[previous_pos:field_pos]
+                    if street_value and partner[field_name]:
+                        street_value += separator
+                    if partner[field_name]:
+                        street_value += partner[field_name]
+                previous_field = field_name
+                previous_pos = re_match.end()
+
+            # add trailing chars in street_format
+            street_value += street_format[previous_pos:]
+
+            # /!\ Note that we must use a sql query to bypass the orm as it would call _split_street()
+            # that would try to set the fields we just modified.
+            self._cr.execute('UPDATE res_partner SET street = %s WHERE ID = %s', (street_value, partner.id))
+            #invalidate the cache for the field we manually set
+            self.invalidate_cache(['street'], [partner.id])
 
     @api.multi
-    @api.depends('street', 'country_id.street_format')
+    @api.depends('street')
     def _split_street(self):
-        """Recompute the fields of STREET_FIELDS when a write is made on the street of a partner"""
+        """Splits street value into sub-fields.
+        Recomputes the fields of STREET_FIELDS when `street` of a partner is updated"""
+        street_fields = self.get_street_fields()
         for partner in self:
             if not partner.street:
                 partner.street_name = ''
                 partner.street_number = ''
-                partner.street_number2= ''
+                partner.street_number2 = ''
                 continue
 
-            street_format = partner.country_id.street_format or '%(street_number)s/%(street_number2)s %(street_name)s'
+            street_format = (partner.country_id.street_format or
+                '%(street_number)s/%(street_number2)s %(street_name)s')
             vals = {}
             previous_pos = 0
             street_raw = partner.street
             field_name = None
-            #iter on fields in street_format, detected as '%(' + <field_name> + ')s'
-            for re_match in re.finditer('\\%\\(\w+\\)s', street_format):
+            # iter on fields in street_format, detected as '%(<field_name>)s'
+            for re_match in re.finditer(r'%\(\w+\)s', street_format):
                 field_pos = re_match.start()
-                #get the substring between 2 fields to split street_raw and isolate the value of a field
-                splitting_string = street_format[previous_pos:field_pos]
-                skip_field = False
-                if splitting_string and field_name:
+                if not field_name:
+                    #first iteration: remove the heading chars
+                    street_raw = street_raw[field_pos:]
+
+                # get the substring between 2 fields, to be used as separator
+                separator = street_format[previous_pos:field_pos]
+                field_value = None
+                if separator and field_name:
                     #maxsplit set to 1 to unpack only the first element and let the rest untouched
-                    tmp = street_raw.split(splitting_string, 1)
-                    if len(tmp) > 1:
+                    tmp = street_raw.split(separator, 1)
+                    if len(tmp) == 2:
                         field_value, street_raw = tmp
                         vals[field_name] = field_value
-                    else:
-                        #manage optional fields: if the field is not found, we skip it and the next value will
-                        #be assigned to the previous field instead of this one.
-                        skip_field = True
-                if not skip_field:
-                    #[2:-2] is used to remove the extra chars ['%', '(', ')', 's']
+                if field_value or not field_name:
+                    # select next field to find (first pass OR field found)
+                    # [2:-2] is used to remove the extra chars '%(' and ')s'
                     field_name = re_match.group()[2:-2]
-                if field_name not in self.get_street_fields():
-                    raise UserError(_("Unrecognized field %s in street format.") % (field_name))
+                else:
+                    # value not found: keep looking for the same field
+                    pass
+                if field_name not in street_fields:
+                    raise UserError(_("Unrecognized field %s in street format.") % field_name)
                 previous_pos = re_match.end()
 
-            #the last field value is what remains in street_format minus eventual trailing chars in street_format
-            vals[field_name] = street_raw.rstrip(street_format[previous_pos:])
-            #assign the values to the fields. Note that a write(vals) would cause a recursion since it would bypass the cache
+            # last field value is what remains in street_raw minus trailing chars in street_format
+            trailing_chars = street_format[previous_pos:]
+            if trailing_chars and street_raw.endswith(trailing_chars):
+                vals[field_name] = street_raw[:-len(trailing_chars)]
+            else:
+                vals[field_name] = street_raw
+            # assign the values to the fields
+            # /!\ Note that a write(vals) would cause a recursion since it would bypass the cache
             for k, v in vals.items():
-                setattr(partner, k, v)
+                partner[k] = v

--- a/addons/base_address_extended/tests/__init__.py
+++ b/addons/base_address_extended/tests/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import test_street_fields

--- a/addons/base_address_extended/tests/test_street_fields.py
+++ b/addons/base_address_extended/tests/test_street_fields.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tests.common import TransactionCase
+
+
+class TestStreetFields(TransactionCase):
+
+    def setUp(self):
+        super(TestStreetFields, self).setUp()
+        self.Partner = self.env['res.partner']
+        self.env.ref('base.be').write({'street_format': '%(street_name)s, %(street_number)s/%(street_number2)s'})
+        self.env.ref('base.us').write({'street_format': '%(street_number)s/%(street_number2)s %(street_name)s'})
+        self.env.ref('base.ch').write({'street_format': 'header %(street_name)s, %(street_number)s - %(street_number2)s trailer'})
+
+    def create_and_assert(self, partner_name, country_id, street, street_name, street_number, street_number2):
+        partner = self.Partner.create({'name': partner_name + '-1', 'street': street, 'country_id': country_id})
+        self.assertEqual(partner.street_name or '', street_name, 'wrong street name for %s: %s' % (partner_name, partner.street_name))
+        self.assertEqual(partner.street_number or '', street_number, 'wrong house number for %s: %s' % (partner_name, partner.street_number))
+        self.assertEqual(partner.street_number2 or '', street_number2, 'wrong door number for %s: %s' % (partner_name, partner.street_number2))
+        partner = self.Partner.create({
+            'name': partner_name + '-2',
+            'street_name': street_name,
+            'street_number': street_number,
+            'street_number2': street_number2,
+            'country_id': country_id,
+        })
+        self.assertEqual(partner.street or '', street, 'wrong street for %s: %s' % (partner_name, partner.street))
+        return partner
+
+    def write_and_assert(self, partner, vals, street, street_name, street_number, street_number2):
+        partner.write(vals)
+        self.assertEqual(partner.street_name or '', street_name, 'wrong street name: %s' % partner.street_name)
+        self.assertEqual(partner.street_number or '', street_number, 'wrong house number: %s' % partner.street_number)
+        self.assertEqual(partner.street_number2 or '', street_number2, 'wrong door number: %s' % partner.street_number2)
+        self.assertEqual(partner.street or '', street, 'wrong street: %s' % partner.street)
+
+    def test_00_res_partner_name_create(self):
+        self.create_and_assert('Test00', self.env.ref('base.us').id, '40/2b Chaussee de Namur', 'Chaussee de Namur', '40', '2b')
+        self.create_and_assert('Test01', self.env.ref('base.us').id, '40 Chaussee de Namur', 'Chaussee de Namur', '40', '')
+        self.create_and_assert('Test02', self.env.ref('base.us').id, 'Chaussee de Namur', 'de Namur', 'Chaussee', '')
+
+    def test_01_header_trailer(self):
+        self.create_and_assert('Test10', self.env.ref('base.ch').id, 'header Chaussee de Namur, 40 - 2b trailer', 'Chaussee de Namur', '40', '2b')
+        self.create_and_assert('Test11', self.env.ref('base.ch').id, 'header Chaussee de Namur, 40 trailer', 'Chaussee de Namur', '40', '')
+        self.create_and_assert('Test12', self.env.ref('base.ch').id, 'header Chaussee de Namur trailer', 'Chaussee de Namur', '', '')
+
+    def test_02_res_partner_write(self):
+        p1 = self.create_and_assert('Test20', self.env.ref('base.be').id, 'Chaussee de Namur, 40/2b', 'Chaussee de Namur', '40', '2b')
+        self.write_and_assert(p1, {'street': 'Chaussee de Namur, 43'}, 'Chaussee de Namur, 43', 'Chaussee de Namur', '43', '')
+        self.write_and_assert(p1, {'street': 'Chaussee de Namur'}, 'Chaussee de Namur', 'Chaussee de Namur', '', '')
+        self.write_and_assert(p1, {'street_name': 'Chee de Namur', 'street_number': '40'}, 'Chee de Namur, 40', 'Chee de Namur', '40', '')
+        self.write_and_assert(p1, {'street_number2': '4'}, 'Chee de Namur, 40/4', 'Chee de Namur', '40', '4')
+        #we don't recompute the street fields when we change the country
+        self.write_and_assert(p1, {'country_id': self.env.ref('base.us').id}, 'Chee de Namur, 40/4', 'Chee de Namur', '40', '4')

--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -10,8 +10,6 @@ from odoo.tools.translate import _
 from odoo.tools import email_re, email_split
 from odoo.exceptions import UserError, AccessError
 
-from odoo.addons.base.res.res_partner import FormatAddress
-
 from . import crm_stage
 
 _logger = logging.getLogger(__name__)
@@ -50,12 +48,12 @@ CRM_LEAD_FIELDS_TO_MERGE = [
     'partner_name']
 
 
-class Lead(FormatAddress, models.Model):
+class Lead(models.Model):
 
     _name = "crm.lead"
     _description = "Lead/Opportunity"
     _order = "priority desc,date_action,id desc"
-    _inherit = ['mail.thread', 'ir.needaction_mixin', 'utm.mixin']
+    _inherit = ['mail.thread', 'ir.needaction_mixin', 'utm.mixin', 'format.address.mixin']
     _mail_mass_mailing = _('Leads / Opportunities')
 
     def _default_probability(self):
@@ -327,15 +325,15 @@ class Lead(FormatAddress, models.Model):
         return super(Lead, self.with_context(context)).copy(default=default)
 
     @api.model
-    def fields_view_get(self, view_id=None, view_type='form', toolbar=False, submenu=False):
+    def _fields_view_get(self, view_id=None, view_type='form', toolbar=False, submenu=False):
         if self._context.get('opportunity_id'):
             opportunity = self.browse(self._context['opportunity_id'])
             action = opportunity.get_formview_action()
             if action.get('views') and any(view_id for view_id in action['views'] if view_id[1] == view_type):
                 view_id = next(view_id[0] for view_id in action['views'] if view_id[1] == view_type)
-        res = super(Lead, self).fields_view_get(view_id=view_id, view_type=view_type, toolbar=toolbar, submenu=submenu)
+        res = super(Lead, self)._fields_view_get(view_id=view_id, view_type=view_type, toolbar=toolbar, submenu=submenu)
         if view_type == 'form':
-            res['arch'] = self.fields_view_get_address(res['arch'])
+            res['arch'] = self._fields_view_get_address(res['arch'])
         return res
 
     # ----------------------------------------

--- a/odoo/addons/base/res/res_country.py
+++ b/odoo/addons/base/res/res_country.py
@@ -32,30 +32,33 @@ class Country(models.Model):
     _description = 'Country'
     _order = 'name'
 
-    name = fields.Char(string='Country Name', required=True, translate=True, help='The full name of the country.')
-    code = fields.Char(string='Country Code', size=2,
-                help='The ISO country code in two chars. \nYou can use this field for quick search.')
-    address_format = fields.Text(help="""You can state here the usual display format to use for the \
-addresses belonging to this country.\n\nYou can use the python-style string patern with all the field of the address \
-(for example, use '%(street)s' to display the field 'street') plus
-            \n%(state_name)s: the name of the state
-            \n%(state_code)s: the code of the state
-            \n%(country_name)s: the name of the country
-            \n%(country_code)s: the code of the country""",
-            default='%(street)s\n%(street2)s\n%(city)s %(state_code)s %(zip)s\n%(country_name)s')
-    address_view_id = fields.Many2one('ir.ui.view', string="Address View", domain=[('model', '=', 'res.partner'), ('type', '=', 'form')], 
-         help="Use this field if you want to replace the usual way to encode a complete address. Note that the \
-address_format field is used to modify the way to display addresses (in reports for example), while this field \
-is used to modify the encoding of addresses (res.partner form view).")
+    name = fields.Char(
+        string='Country Name', required=True, translate=True, help='The full name of the country.')
+    code = fields.Char(
+        string='Country Code', size=2,
+        help='The ISO country code in two chars. \nYou can use this field for quick search.')
+    address_format = fields.Text(
+        help="Display format to use for addresses belonging to this country.\n\n"
+             "You can use python-style string pattern with all the fields of the address "
+             "(for example, use '%(street)s' to display the field 'street') plus"
+             "\n%(state_name)s: the name of the state"
+             "\n%(state_code)s: the code of the state"
+             "\n%(country_name)s: the name of the country"
+             "\n%(country_code)s: the code of the country",
+        default='%(street)s\n%(street2)s\n%(city)s %(state_code)s %(zip)s\n%(country_name)s')
+    address_view_id = fields.Many2one(
+        comodel_name='ir.ui.view', string="Address View",
+        domain=[('model', '=', 'res.partner'), ('type', '=', 'form')],
+        help="Use this field if you want to replace the usual way to encode a complete address. "
+             "Note that the address_format field is used to modify the way to display addresses "
+             "(in reports for example), while this field is used to modify the input form for "
+             "addresses.")
     currency_id = fields.Many2one('res.currency', string='Currency')
     image = fields.Binary(attachment=True)
     phone_code = fields.Integer(string='Country Calling Code')
     country_group_ids = fields.Many2many('res.country.group', 'res_country_res_country_group_rel',
                          'res_country_id', 'res_country_group_id', string='Country Groups')
     state_ids = fields.One2many('res.country.state', 'country_id', string='States')
-    enforce_cities = fields.Boolean(string='Enforce Cities', help="Check this box to ensure every address created \
-in that country has a value for the field 'City' chosen in the list of the country's cities. Note that users with \
-the 'Partner Manager' group are still able to create new cities for a country.")
 
     _sql_constraints = [
         ('name_uniq', 'unique (name)',

--- a/odoo/addons/base/res/res_country_view.xml
+++ b/odoo/addons/base/res/res_country_view.xml
@@ -21,14 +21,6 @@
             <field name="arch" type="xml">
                 <form>
                     <div class="oe_button_box">
-                        <button name="%(base.action_res_city_tree)d"
-                            class="oe_stat_button"
-                            icon="fa-globe"
-                            type="action"
-                            context="{'default_country_id': active_id, 'search_default_country_id': active_id}"
-                            string="Cities">
-
-                        </button>
                     </div>
                     <field name="image" widget="image" class="oe_avatar"/>
                     <group>
@@ -39,7 +31,6 @@
                         </group>
                         <group>
                             <field name="phone_code"/>
-                            <field name="enforce_cities"/>
                         </group>
                         <group string="Advanced Address Formatting" groups="base.group_no_one" >
                             <field name="address_format" placeholder="Address format..."/>

--- a/odoo/addons/base/res/res_partner.py
+++ b/odoo/addons/base/res/res_partner.py
@@ -39,18 +39,27 @@ def _tz_get(self):
     return [(tz, tz) for tz in sorted(pytz.all_timezones, key=lambda tz: tz if not tz.startswith('Etc/') else '_')]
 
 
-class FormatAddress(object):
+class FormatAddressMixin(models.AbstractModel):
+    _name = "format.address.mixin"
 
-    @api.model
-    def fields_view_get_address(self, arch):
-        #consider the country of the user, not the country of the partner we want to display
+    def _fields_view_get_address(self, arch):
+        # consider the country of the user, not the country of the partner we want to display
         address_view_id = self.env.user.company_id.country_id.address_view_id
         if address_view_id and not self._context.get('no_address_format'):
             #render the partner address accordingly to address_view_id
             doc = etree.fromstring(arch)
             for address_node in doc.xpath("//div[@class='o_address_format']"):
-                sub_view = self.env['res.partner'].with_context(no_address_format=True).fields_view_get(view_id=address_view_id.id, view_type='form', toolbar=False, submenu=False)
+                Partner = self.env['res.partner'].with_context(no_address_format=True)
+                sub_view = Partner.fields_view_get(
+                    view_id=address_view_id.id, view_type='form', toolbar=False, submenu=False)
                 sub_view_node = etree.fromstring(sub_view['arch'])
+                #if the model is different than res.partner, there are chances that the view won't work
+                #(e.g fields not present on the model). In that case we just return arch
+                if self._name != 'res.partner':
+                    try:
+                        self.env['ir.ui.view'].postprocess_and_fields(self._name, sub_view_node, None)
+                    except ValueError:
+                        return arch
                 address_node.getparent().replace(address_node, sub_view_node)
             arch = etree.tostring(doc)
         return arch
@@ -117,8 +126,9 @@ class PartnerTitle(models.Model):
 
     _sql_constraints = [('name_uniq', 'unique (name)', "Title name already exists !")]
 
-class Partner(models.Model, FormatAddress):
+class Partner(models.Model):
     _description = 'Partner'
+    _inherit = ['format.address.mixin']
     _name = "res.partner"
     _order = "display_name"
 
@@ -297,12 +307,12 @@ class Partner(models.Model, FormatAddress):
         return tools.image_resize_image_big(image.encode('base64'))
 
     @api.model
-    def fields_view_get(self, view_id=None, view_type='form', toolbar=False, submenu=False):
+    def _fields_view_get(self, view_id=None, view_type='form', toolbar=False, submenu=False):
         if (not view_id) and (view_type == 'form') and self._context.get('force_email'):
             view_id = self.env.ref('base.view_partner_simple_form').id
-        res = super(Partner, self).fields_view_get(view_id=view_id, view_type=view_type, toolbar=toolbar, submenu=submenu)
+        res = super(Partner, self)._fields_view_get(view_id=view_id, view_type=view_type, toolbar=toolbar, submenu=submenu)
         if view_type == 'form':
-            res['arch'] = self.fields_view_get_address(res['arch'])
+            res['arch'] = self._fields_view_get_address(res['arch'])
         return res
 
     @api.constrains('parent_id')

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -1337,23 +1337,8 @@ class BaseModel(object):
         return result
 
     @api.model
-    def fields_view_get(self, view_id=None, view_type='form', toolbar=False, submenu=False):
-        """ fields_view_get([view_id | view_type='form'])
-
-        Get the detailed composition of the requested view like fields, model, view architecture
-
-        :param view_id: id of the view or None
-        :param view_type: type of the view to return if view_id is None ('form', 'tree', ...)
-        :param toolbar: true to include contextual actions
-        :param submenu: deprecated
-        :return: dictionary describing the composition of the requested view (including inherited views and extensions)
-        :raise AttributeError:
-                            * if the inherited view has unknown position to work with other than 'before', 'after', 'inside', 'replace'
-                            * if some tag other than 'position' is found in parent view
-        :raise Invalid ArchitectureError: if there is view type other than form, tree, calendar, search etc defined on the structure
-        """
+    def _fields_view_get(self, view_id=None, view_type='form', toolbar=False, submenu=False):
         View = self.env['ir.ui.view']
-
         result = {
             'model': self._name,
             'field_parent': False,
@@ -1381,7 +1366,6 @@ class BaseModel(object):
                 # otherwise try to find the lowest priority matching ir.ui.view
                 view_id = View.default_view(self._name, view_type)
 
-        # context for post-processing might be overriden
         if view_id:
             # read the view with inherited views applied
             root_view = View.browse(view_id).read_combined(['id', 'name', 'field_parent', 'type', 'model', 'arch'])
@@ -1390,9 +1374,7 @@ class BaseModel(object):
             result['type'] = root_view['type']
             result['view_id'] = root_view['id']
             result['field_parent'] = root_view['field_parent']
-            # override context from postprocessing
-            if root_view['model'] != self._name:
-                View = View.with_context(base_model_name=root_view['model'])
+            result['base_model'] = root_view['model']
         else:
             # fallback on default views methods if no ir.ui.view could be found
             try:
@@ -1402,6 +1384,32 @@ class BaseModel(object):
                 result['name'] = 'default'
             except AttributeError:
                 raise UserError(_("No default view of type '%s' could be found !") % view_type)
+        return result
+
+    @api.model
+    def fields_view_get(self, view_id=None, view_type='form', toolbar=False, submenu=False):
+        """ fields_view_get([view_id | view_type='form'])
+
+        Get the detailed composition of the requested view like fields, model, view architecture
+
+        :param view_id: id of the view or None
+        :param view_type: type of the view to return if view_id is None ('form', 'tree', ...)
+        :param toolbar: true to include contextual actions
+        :param submenu: deprecated
+        :return: dictionary describing the composition of the requested view (including inherited views and extensions)
+        :raise AttributeError:
+                            * if the inherited view has unknown position to work with other than 'before', 'after', 'inside', 'replace'
+                            * if some tag other than 'position' is found in parent view
+        :raise Invalid ArchitectureError: if there is view type other than form, tree, calendar, search etc defined on the structure
+        """
+        View = self.env['ir.ui.view']
+
+        # Get the view arch and all other attributes describing the composition of the view
+        result = self._fields_view_get(view_id=view_id, view_type=view_type, toolbar=toolbar, submenu=submenu)
+
+        # Override context for postprocessing
+        if view_id and result.get('base_model', self._name) != self._name:
+            View = View.with_context(base_model_name=result['base_model'])
 
         # Apply post processing, groups and modifiers etc...
         xarch, xfields = View.postprocess_and_fields(self._name, etree.fromstring(result['arch']), view_id)


### PR DESCRIPTION
TODO
---------
- [x] ~~rebase from odoo/odoo v10 until commit https://github.com/odoo/odoo/commit/347494c06bac6e53f42f2494638133645c94cabc~~
- [x] cherry-pick from odoo/odoo master those commits: https://github.com/odoo/odoo/commit/4dd27bb, https://github.com/odoo/odoo/commit/0dc4e13 and https://github.com/odoo/odoo/commit/a14d6bb
- [x] fix divergence at file [crm lead](https://github.com/Vauxoo/odoo/blob/10.0/addons/crm/models/crm_lead.py):

![captura de pantalla de 2016-12-28 13-45-22](https://cloud.githubusercontent.com/assets/5335402/21530111/0facbfde-cd04-11e6-8df2-4eedb281d55c.png)

- [mail.activity.mixin](https://github.com/odoo/odoo/blob/master/addons/mail/models/mail_activity.py) is only available in master.


```python
class Lead(models.Model):

    _name = "crm.lead"
    _description = "Lead/Opportunity"
    _order = "priority desc,date_action,id desc"
    _inherit = ['mail.thread', 'ir.needaction_mixin', 'utm.mixin', 'format.address.mixin']
    _mail_mass_mailing = _('Leads / Opportunities')

```