### PR TITLE
[FIX] base_address_*: enforce_cities feature now working properly

### DIFF
--- a/addons/base_address_city/models/res_partner.py
+++ b/addons/base_address_city/models/res_partner.py
@@ -5,30 +5,6 @@ from lxml import etree
 
 from odoo import api, models, fields
 
-class FormatAddressMixin(models.AbstractModel):
-    _inherit = "format.address.mixin"
-
-    @api.model
-    def _fields_view_get_address(self, arch):
-        arch = super(FormatAddressMixin, self)._fields_view_get_address(arch)
-        if self._name == 'res.partner':
-            #render the partner address accordingly to address_view_id
-            doc = etree.fromstring(arch)
-            for city_node in doc.xpath("//field[@name='city']"):
-                replacement_xml = """
-                <div>
-                    <field name="country_enforce_cities" invisible="1"/>
-                    <field name='city' attrs="{'invisible': [('country_enforce_cities', '=', True), ('city_id', '!=', False)]}"/>
-                    <field name='city_id' attrs="{'invisible': [('country_enforce_cities', '=', False)]}"/>
-                </div>
-                """
-                city_id_node = etree.fromstring(replacement_xml)
-                city_node.getparent().replace(city_node, city_id_node)
-
-            arch = etree.tostring(doc)
-        return arch
-
-
 class Partner(models.Model):
     _inherit = 'res.partner'
 
@@ -40,3 +16,22 @@ class Partner(models.Model):
         self.city = self.city_id.name
         self.zip = self.city_id.zipcode
         self.state_id = self.city_id.state_id
+
+    @api.model
+    def _fields_view_get_address(self, arch):
+        arch = super(Partner, self)._fields_view_get_address(arch)
+        # render the partner address accordingly to address_view_id
+        doc = etree.fromstring(arch)
+        for city_node in doc.xpath("//field[@name='city']"):
+            replacement_xml = """
+            <div>
+                <field name="country_enforce_cities" invisible="1"/>
+                <field name='city' attrs="{'invisible': [('country_enforce_cities', '=', True), ('city_id', '!=', False)]}"/>
+                <field name='city_id' attrs="{'invisible': [('country_enforce_cities', '=', False)]}"/>
+            </div>
+            """
+            city_id_node = etree.fromstring(replacement_xml)
+            city_node.getparent().replace(city_node, city_id_node)
+
+        arch = etree.tostring(doc)
+        return arch

--- a/addons/base_address_city/models/res_partner.py
+++ b/addons/base_address_city/models/res_partner.py
@@ -11,20 +11,21 @@ class FormatAddressMixin(models.AbstractModel):
     @api.model
     def _fields_view_get_address(self, arch):
         arch = super(FormatAddressMixin, self)._fields_view_get_address(arch)
-        #render the partner address accordingly to address_view_id
-        doc = etree.fromstring(arch)
-        for city_node in doc.xpath("//field[@name='city']"):
-            replacement_xml = """
-            <div>
-                <field name="country_enforce_cities" invisible="1"/>
-                <field name='city' attrs="{'invisible': [('country_enforce_cities', '=', True), ('city_id', '!=', False)]}"/>
-                <field name='city_id' attrs="{'invisible': [('country_enforce_cities', '=', False)]}"/>
-            </div>
-            """
-            city_id_node = etree.fromstring(replacement_xml)
-            city_node.getparent().replace(city_node, city_id_node)
+        if self._name == 'res.partner':
+            #render the partner address accordingly to address_view_id
+            doc = etree.fromstring(arch)
+            for city_node in doc.xpath("//field[@name='city']"):
+                replacement_xml = """
+                <div>
+                    <field name="country_enforce_cities" invisible="1"/>
+                    <field name='city' attrs="{'invisible': [('country_enforce_cities', '=', True), ('city_id', '!=', False)]}"/>
+                    <field name='city_id' attrs="{'invisible': [('country_enforce_cities', '=', False)]}"/>
+                </div>
+                """
+                city_id_node = etree.fromstring(replacement_xml)
+                city_node.getparent().replace(city_node, city_id_node)
 
-        arch = etree.tostring(doc)
+            arch = etree.tostring(doc)
         return arch
 
 

--- a/addons/base_address_city/models/res_partner.py
+++ b/addons/base_address_city/models/res_partner.py
@@ -9,18 +9,16 @@ class FormatAddressMixin(models.AbstractModel):
     _inherit = "format.address.mixin"
 
     @api.model
-    def fields_view_get_address(self, arch):
-        arch = super(FormatAddressMixin, self).fields_view_get_address(arch)
+    def _fields_view_get_address(self, arch):
+        arch = super(FormatAddressMixin, self)._fields_view_get_address(arch)
         #render the partner address accordingly to address_view_id
         doc = etree.fromstring(arch)
         for city_node in doc.xpath("//field[@name='city']"):
             replacement_xml = """
             <div>
-            <field name="country_enforce_cities" invisible="1"/>
-            <div attrs="{'invisible': [('country_enforce_cities', '=', False)]}">
-                <field name='city' attrs="{'invisible': ['|', ('city_id', '!=', False), ('city', '=', False)]}"/>
-                <field name='city_id'/>
-            </div>
+                <field name="country_enforce_cities" invisible="1"/>
+                <field name='city' attrs="{'invisible': [('country_enforce_cities', '=', True), ('city_id', '!=', False)]}"/>
+                <field name='city_id' attrs="{'invisible': [('country_enforce_cities', '=', False)]}"/>
             </div>
             """
             city_id_node = etree.fromstring(replacement_xml)

--- a/addons/base_address_extended/models/base_address_extended.py
+++ b/addons/base_address_extended/models/base_address_extended.py
@@ -90,9 +90,8 @@ class Partner(models.Model):
         street_fields = self.get_street_fields()
         for partner in self:
             if not partner.street:
-                partner.street_name = ''
-                partner.street_number = ''
-                partner.street_number2 = ''
+                for field in street_fields:
+                    partner[field] = ''
                 continue
 
             street_format = (partner.country_id.street_format or


### PR DESCRIPTION
Summary
-------------

Was made the following cherry-picks from master:
a877299
ca2d63d
274e38e
04a87bf

Previously was requested this fix in this PR https://github.com/odoo/odoo/pull/14878, but not was merged because the porposal suggest a change of all res.partners view where has `city` field. This proposal was a better looking solution in design terms, but required a lot more work.

