### PR TITLE
[FIX] tools: colorize image with pillow 4.0

### DIFF
--- a/openerp/tools/image.py
+++ b/openerp/tools/image.py
@@ -183,7 +183,7 @@ def image_colorize(original, randomize=True, color=(255, 255, 255)):
     # generate the background color, past it as background
     if randomize:
         color = (randint(32, 224), randint(32, 224), randint(32, 224))
-    image.paste(color)
+    image.paste(color, box=(0, 0) + original.size)
     image.paste(original, mask=original)
     # return the new image
     buffer = StringIO.StringIO()


### PR DESCRIPTION
Introduced by python-pillow/Pillow@c3fe5d43 and integrated into pillow 4.0
The size of the image is ignored and must be set using an image or a mask.

This patch is retrocompatible with the previous versions as the changed code was
in the box size computation. With this patch a 4 points box size is given so the
modified code is not executed.

Fixes #14927