### PR TITLE
[REF] l10n_mx: Use sequences without date prefix

### DIFF
--- a/addons/l10n_mx/models/account.py
+++ b/addons/l10n_mx/models/account.py
@@ -24,6 +24,24 @@ class AccountJournal(models.Model):
                 })
         return res
 
+    @api.model
+    def _get_sequence_prefix_mx(self, code, refund=False):
+        prefix = code.upper()
+        if refund:
+            prefix = 'R' + prefix
+        return prefix
+
+    @api.model
+    def _create_sequence(self, vals, refund=False):
+        seq = super(AccountJournal, self)._create_sequence(vals, refund)
+        # TODO: Create PR to split the original method _create_sequence
+        #       to get values and avoid a overwrite record here
+        if seq.company_id.country_id.id == self.env.ref('base.mx').id:
+            seq.use_date_range = False
+            seq.prefix = self._get_sequence_prefix_mx(vals['code'], refund)
+        return seq
+
+
 class AccountAccount(models.Model):
     _inherit = 'account.account'
 


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

The electronic invoice need to optional fields called "Folio and Serie", [our proposal will be to retrieve the Serie from the "prefix" part (represented by text) in the invoice number](https://github.com/Vauxoo/enterprise/pull/49), The most obvious behavior is that the number is cleanly the folio and the prefix represent the "Serie" (without the year on it to avoid the numeric unused part), this will save such technical configuration by user for the very first invoice because we are proposing a correct sequence configured and not the default wired one.

Why?

- The Folio is numeric by XSD definition, then we need to force that in the seqence on odoo.
- The Serie in our PoV is the prefix and is generally accepted pure text.
- It is the more common way to do things in MX.
- It is not normal reset per year the folio.

**Current behavior before PR:**

Once you create a journal the sequence is created like:

Prefix: CODE/2017/
use_date_range: True

Then the user will need to go to the sequence and clear this configuration in order to use:

Prefix: CODE
use_date_range: False

**Desired behavior after PR is merged:**

Prefix: CODE
use_date_range: False

**Some examples** of some companies in MX that use serie and folio to support why is not a good idea propose incorrectly the year in the sequence.

| Company                                        | Serie | Folio    |
|------------------------------------------------|-------|----------|
| COMERCIALIZADORA GURO 3H S.A. DE C.V. - COLIMA |       | 16384    |
| MARIBEL ZAMORA OSORIO                          |       | 2282     |
| MARIA EUGENIA MORALES ARVIZU                   | KI    | 463      |
| Oxxo Gas                                       | MRY   | 17728955 |
| ROBERTO ZENDEJAS MUÑOZ                         | E     | 1071     |
| AXTEL                                          | CB    | 23932098 |
| Amazon México                                  | CSale | 1506841  |
