### PR TITLE
[FIX] sale,account: do not reference to not declared yet group

### DIFF
--- a/addons/account/views/account_invoice_view.xml
+++ b/addons/account/views/account_invoice_view.xml
@@ -46,7 +46,7 @@
                     <field name="quantity"/>
                     <field name="uom_id" groups="product.group_uom"/>
                     <field name="price_unit"/>
-                    <field name="discount" groups="sale.group_discount_per_so_line"/>
+                    <field name="discount" groups="base.group_no_one"/>
                     <field name="price_subtotal"/>
                     <field name="currency_id" invisible="1"/>
                 </tree>
@@ -68,7 +68,7 @@
                                 <field name="uom_id" class="oe_inline" groups="product.group_uom"/>
                             </div>
                             <field name="price_unit"/>
-                            <field name="discount" groups="sale.group_discount_per_so_line"/>
+                            <field name="discount" groups="base.group_no_one"/>
                             <field name="currency_id" invisible="1"/>
                         </group>
                         <group>
@@ -272,7 +272,7 @@
                                     <field name="quantity"/>
                                     <field name="uom_id" groups="product.group_uom"/>
                                     <field name="price_unit"/>
-                                    <field name="discount" groups="sale.group_discount_per_so_line"/>
+                                    <field name="discount" groups="base.group_no_one"/>
                                     <field name="invoice_line_tax_ids" widget="many2many_tags" context="{'type':parent.type}"
                                         domain="[('type_tax_use','=','purchase'),('company_id', '=', parent.company_id)]" options="{'no_create': True}"/>
                                     <field name="price_subtotal"/>
@@ -410,7 +410,7 @@
                                     <field name="quantity"/>
                                     <field name="uom_id" groups="product.group_uom"/>
                                     <field name="price_unit"/>
-                                    <field name="discount" groups="sale.group_discount_per_so_line"/>
+                                    <field name="discount" groups="base.group_no_one"/>
                                     <field name="invoice_line_tax_ids" widget="many2many_tags" context="{'type':parent.type}"
                                         domain="[('type_tax_use','=','sale'),('company_id', '=', parent.company_id)]" options="{'no_create': True}"/>
                                     <field name="price_subtotal"/>

--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -61,7 +61,7 @@
                         <th class="hidden">Source Document</th>
                         <th class="text-right">Quantity</th>
                         <th class="text-right">Unit Price</th>
-                        <th t-if="display_discount" class="text-right" groups="sale.group_discount_per_so_line">Disc.(%)</th>
+                        <th t-if="display_discount" class="text-right">Disc.(%)</th>
                         <th class="text-right">Taxes</th>
                         <th class="text-right">Tax Excluded Price</th>
                     </tr>
@@ -77,7 +77,7 @@
                         <td class="text-right">
                             <span t-field="l.price_unit"/>
                         </td>
-                        <td t-if="display_discount" class="text-right" groups="sale.group_discount_per_so_line">
+                        <td t-if="display_discount" class="text-right">
                             <span t-field="l.discount"/>
                         </td>
                         <td class="text-right">

--- a/addons/sale/views/sale_views.xml
+++ b/addons/sale/views/sale_views.xml
@@ -668,6 +668,19 @@
             </field>
         </record>
 
+        <record model="ir.ui.view" id="account_invoice_line_tree">
+            <field name="name">account.invoice.line.tree</field>
+            <field name="model">account.invoice.line</field>
+            <field name="inherit_id" ref="account.view_invoice_line_tree"/>
+            <field name="arch" type="xml">
+                <data>
+                    <xpath expr="//field[@name='discount']" position="attributes">
+                        <attribute name="groups">sale.group_discount_per_so_line</attribute>
+                    </xpath>
+                </data>
+            </field>
+        </record>
+
         <record model="ir.ui.view" id="account_invoice_line_form">
             <field name="name">account.invoice.line.form</field>
             <field name="model">account.invoice.line</field>
@@ -676,6 +689,22 @@
                 <data>
                     <xpath expr="//group/group/field[@name='product_id']" position="after">
                         <field name="layout_category_id" groups="sale.group_sale_layout"/>
+                    </xpath>
+                    <xpath expr="//field[@name='discount']" position="attributes">
+                        <attribute name="groups">sale.group_discount_per_so_line</attribute>
+                    </xpath>
+                </data>
+            </field>
+        </record>
+
+        <record model="ir.ui.view" id="account_invoice_supplier_form">
+            <field name="name">account.invoice.supplier.form</field>
+            <field name="model">account.invoice</field>
+            <field name="inherit_id" ref="account.invoice_supplier_form"/>
+            <field name="arch" type="xml">
+                <data>
+                    <xpath expr="//field[@name='discount']" position="attributes">
+                        <attribute name="groups">sale.group_discount_per_so_line</attribute>
                     </xpath>
                 </data>
             </field>


### PR DESCRIPTION
The group sale.group_discount_per_so_line is used in account but declared in
sale. As the has_group method ignores unexistant fields, this field was never
displayed until somebody install sale.

In account, replace the discount group with debug mode.
Remove it from the report as it was only displayed when at least one discount
was set (not possible if the discount field is not displayed).

In sale, makes xpath to use the correct group.

Fixes 15094

Cherry-pick from [Odoo](https://github.com/odoo/odoo/commit/c278ebf2feae649de3bfc51ec3ad0e5378816a88) 