### PR TITLE
[FIX] l10n_cr: Fix partners title

### DIFF
--- a/addons/l10n_cr/data/l10n_cr_state_data.xml
+++ b/addons/l10n_cr/data/l10n_cr_state_data.xml
@@ -43,21 +43,13 @@
         Resource: res.partner.title
         Update partner titles
         -->
-        <record id="base.res_partner_title_pvt_ltd" model="res.partner.title">
+        <record id="res_partner_title_pvt_ltd" model="res.partner.title">
             <field name="name">Corporation</field>
             <field name="shortcut">Corp.</field>
         </record>
-        <record id="base.res_partner_title_ltd" model="res.partner.title">
+        <record id="res_partner_title_ltd" model="res.partner.title">
             <field name="name">Limited Company</field>
             <field name="shortcut">Ltd.</field>
-        </record>
-        <record id="base.res_partner_title_miss" model="res.partner.title">
-            <field name="name">Miss</field>
-            <field name="shortcut">Mss.</field>
-        </record>
-        <record id="base.res_partner_title_madam" model="res.partner.title">
-            <field name="name">Madam</field>
-            <field name="shortcut">Ms.</field>
         </record>
         <record id="res_partner_title_sal" model="res.partner.title">
             <field name="name">Sociedad An&#243;nima Laboral</field>
@@ -75,35 +67,31 @@
             <field name="name">Educational Institution</field>
             <field name="shortcut">Edu.</field>
         </record>
-        <record id="base.res_partner_title_prof" model="res.partner.title">
-            <field name="name">Professor</field>
-            <field name="shortcut">Prof.</field>
-        </record>
         <record id="res_partner_title_indprof" model="res.partner.title">
             <field name="name">Independant Professional</field>
             <field name="shortcut">Ind. Prof.</field>
         </record>
-        <record id="base.res_partner_title_dra" model="res.partner.title">
+        <record id="res_partner_title_dra" model="res.partner.title">
             <field name="name">Doctora</field>
             <field name="shortcut">Dra.</field>
         </record>
-        <record id="base.res_partner_title_msc" model="res.partner.title">
+        <record id="res_partner_title_msc" model="res.partner.title">
             <field name="name">Msc.</field>
             <field name="shortcut">Msc.</field>
         </record>
-        <record id="base.res_partner_title_mba" model="res.partner.title">
+        <record id="res_partner_title_mba" model="res.partner.title">
             <field name="name">MBA</field>
             <field name="shortcut">MBA</field>
         </record>
-        <record id="base.res_partner_title_lic" model="res.partner.title">
+        <record id="res_partner_title_lic" model="res.partner.title">
             <field name="name">Licenciado</field>
             <field name="shortcut">Lic.</field>
         </record>
-        <record id="base.res_partner_title_licda" model="res.partner.title">
+        <record id="res_partner_title_licda" model="res.partner.title">
             <field name="name">Licenciada</field>
             <field name="shortcut">Licda.</field>
         </record>
-        <record id="base.res_partner_title_ing" model="res.partner.title">
+        <record id="res_partner_title_ing" model="res.partner.title">
             <field name="name">Ingeniero/a</field>
             <field name="shortcut">Ing.</field>
         </record>


### PR DESCRIPTION
Summary:
--------------

To Fix:
```
2017-02-14 04:09:20,530 177 WARNING openerp_template odoo.addons.base.ir.ir_model: Creating the ir.model.data res_partner_title_pvt_ltd in module base instead of l10n_cr.
2017-02-14 04:09:20,533 177 WARNING openerp_template odoo.addons.base.ir.ir_model: Creating the ir.model.data res_partner_title_ltd in module base instead of l10n_cr.
2017-02-14 04:09:20,550 177 WARNING openerp_template odoo.addons.base.ir.ir_model: Creating the ir.model.data res_partner_title_dra in module base instead of l10n_cr.
2017-02-14 04:09:20,552 177 WARNING openerp_template odoo.addons.base.ir.ir_model: Creating the ir.model.data res_partner_title_msc in module base instead of l10n_cr.
2017-02-14 04:09:20,555 177 WARNING openerp_template odoo.addons.base.ir.ir_model: Creating the ir.model.data res_partner_title_mba in module base instead of l10n_cr.
2017-02-14 04:09:20,557 177 WARNING openerp_template odoo.addons.base.ir.ir_model: Creating the ir.model.data res_partner_title_lic in module base instead of l10n_cr.
2017-02-14 04:09:20,559 177 WARNING openerp_template odoo.addons.base.ir.ir_model: Creating the ir.model.data res_partner_title_licda in module base instead of l10n_cr.
2017-02-14 04:09:20,562 177 WARNING openerp_template odoo.addons.base.ir.ir_model: Creating the ir.model.data res_partner_title_ing in module base instead of l10n_cr.
```