### PR TITLE
[FIX] website_sale_digital: no more 'digital' product

### DIFF
--- a/addons/website_sale_digital/controllers/main.py
+++ b/addons/website_sale_digital/controllers/main.py
@@ -38,16 +38,13 @@ class WebsiteSaleDigital(website_account):
         purchased_products_attachments = {}
         for il in invoiced_lines:
             product = il.product_id
-            # Ignore products that do not have digital content
-            if not product.product_tmpl_id.type == 'digital':
-                continue
 
             # Search for product attachments
             Attachment = request.env['ir.attachment']
             product_id = product.id
             template = product.product_tmpl_id
             att = Attachment.search_read(
-                domain=['|', '&', ('res_model', '=', product._name), ('res_id', '=', product_id), '&', ('res_model', '=', template._name), ('res_id', '=', template.id)],
+                domain=['|', '&', ('res_model', '=', product._name), ('res_id', '=', product_id), '&', ('res_model', '=', template._name), '&', ('res_id', '=', template.id), ('product_downloadable', '=', True)],
                 fields=['name', 'write_date'],
                 order='write_date desc',
             )

--- a/addons/website_sale_digital/models/account_invoice.py
+++ b/addons/website_sale_digital/models/account_invoice.py
@@ -13,7 +13,7 @@ class AccountInvoiceLine(models.Model):
 
         # Get paid invoices
         purchases = self.sudo().search_read(
-            domain=[('invoice_id.state', '=', 'paid'), ('invoice_id.partner_id', '=', partner.id), ('product_id.product_tmpl_id.type', '=', 'digital')],
+            domain=[('invoice_id.state', '=', 'paid'), ('invoice_id.partner_id', '=', partner.id)],
             fields=['product_id'],
         )
 


### PR DESCRIPTION
Summary
-------------

Following commit 1a1efe3fce12c, the module has some troubles to work correctly. For example, it's impossible to get the download link in the frontend of an attachment when the product was bought and paid.

Not really a big deal, but just in case the client wants to download what he bought, we add back the link in the eCommerce.

A more complete fix will land later in master branch.