### PR TITLE
[FIX] Compute fields total/expected margin in product margin report

### DIFF
--- a/addons/product_margin/models/product_product.py
+++ b/addons/product_margin/models/product_product.py
@@ -76,21 +76,17 @@ class ProductProduct(models.Model):
                         re[l] = res_val[key][l]
         return res
 
-    def _compute_product_margin_fields_values(self, field_names=None):
+    @api.depends()
+    def _compute_product_margin_fields_values(self):
         res = {}
-        if field_names is None:
-            field_names = []
         for val in self:
             res[val.id] = {}
             date_from = self.env.context.get('date_from', time.strftime('%Y-01-01'))
             date_to = self.env.context.get('date_to', time.strftime('%Y-12-31'))
             invoice_state = self.env.context.get('invoice_state', 'open_paid')
-            if 'date_from' in field_names:
-                res[val.id]['date_from'] = date_from
-            if 'date_to' in field_names:
-                res[val.id]['date_to'] = date_to
-            if 'invoice_state' in field_names:
-                res[val.id]['invoice_state'] = invoice_state
+            res[val.id]['date_from'] = date_from
+            res[val.id]['date_to'] = date_to
+            res[val.id]['invoice_state'] = invoice_state
             invoice_types = ()
             states = ()
             if invoice_state == 'paid':
@@ -136,14 +132,10 @@ class ProductProduct(models.Model):
             res[val.id]['normal_cost'] = val.standard_price * res[val.id]['purchase_num_invoiced']
             res[val.id]['purchase_gap'] = res[val.id]['normal_cost'] - res[val.id]['total_cost']
 
-            if 'total_margin' in field_names:
-                res[val.id]['total_margin'] = res[val.id]['turnover'] - res[val.id]['total_cost']
-            if 'expected_margin' in field_names:
-                res[val.id]['expected_margin'] = res[val.id]['sale_expected'] - res[val.id]['normal_cost']
-            if 'total_margin_rate' in field_names:
-                res[val.id]['total_margin_rate'] = res[val.id]['turnover'] and res[val.id]['total_margin'] * 100 / res[val.id]['turnover'] or 0.0
-            if 'expected_margin_rate' in field_names:
-                res[val.id]['expected_margin_rate'] = res[val.id]['sale_expected'] and res[val.id]['expected_margin'] * 100 / res[val.id]['sale_expected'] or 0.0
+            res[val.id]['total_margin'] = res[val.id]['turnover'] - res[val.id]['total_cost']
+            res[val.id]['expected_margin'] = res[val.id]['sale_expected'] - res[val.id]['normal_cost']
+            res[val.id]['total_margin_rate'] = res[val.id]['turnover'] and res[val.id]['total_margin'] * 100 / res[val.id]['turnover'] or 0.0
+            res[val.id]['expected_margin_rate'] = res[val.id]['sale_expected'] and res[val.id]['expected_margin'] * 100 / res[val.id]['sale_expected'] or 0.0
+
             for k, v in res[val.id].items():
                 setattr(val, k, v)
-        return res


### PR DESCRIPTION
The Odoo PR of this change
https://github.com/odoo/odoo/pull/15604

---

This compute fields were moved to new api but appears that they were not
tested. The next fields were set to 0 and were not computed as supposed to:

- date_from
- date_to
- invoice_state
- total_margin
- expected_margin
- total_margin_rate
- expected_margin_rate

In order to fix this I just update the compute method to work with
api.depends decorator and remove field_names argument and the inside if
that make references to field_names. Now all the fields are computed.

Also remove the return res because compute methods API 10.0 do not need to
return a dictionary with the compute values, only need to set them.
