### PR TITLE
[FIX] /web/login restore request.uid from authenticate function instead of controller  case of authentication failure

### DIFF
--- a/addons/web/controllers/main.py
+++ b/addons/web/controllers/main.py
@@ -463,14 +463,12 @@ class Home(http.Controller):
             values['databases'] = None
 
         if request.httprequest.method == 'POST':
-            old_uid = request.uid
             uid = request.session.authenticate(request.session.db, request.params['login'], request.params['password'])
             if uid is not False:
                 request.params['login_success'] = True
                 if not redirect:
                     redirect = '/web'
                 return http.redirect_with_hash(redirect)
-            request.uid = old_uid
             values['error'] = _("Wrong login/password")
         return request.render('web.login', values)
 

--- a/odoo/http.py
+++ b/odoo/http.py
@@ -290,7 +290,7 @@ class WebRequest(object):
     def _handle_exception(self, exception):
         """Called within an except block to allow converting exceptions
            to abitrary responses. Anything returned (except None) will
-           be used as response.""" 
+           be used as response."""
         self._failed = exception # prevent tx commit
         if not isinstance(exception, NO_POSTMORTEM) \
                 and not isinstance(exception, werkzeug.exceptions.HTTPException):
@@ -573,7 +573,7 @@ class JsonRequest(WebRequest):
         self.jsonp = jsonp
         request = None
         request_id = args.get('id')
-        
+
         if jsonp and self.httprequest.method == 'POST':
             # jsonp 2 steps step1 POST: save call
             def handler():
@@ -1025,6 +1025,7 @@ class OpenERPSession(werkzeug.contrib.sessions.Session):
                     to authenticate the user.
         """
 
+        old_uid = request.uid
         if uid is None:
             wsgienv = request.httprequest.environ
             env = dict(
@@ -1039,7 +1040,7 @@ class OpenERPSession(werkzeug.contrib.sessions.Session):
         self.uid = uid
         self.login = login
         self.password = password
-        request.uid = uid
+        request.uid = uid or old_uid
         request.disable_db = False
 
         if uid: self.get_context()


### PR DESCRIPTION
In case of authentication failure, request.uid was setted with False causing a internal server error
https://github.com/Vauxoo/imeqmo/issues/122

odoo apply the next fix in order to avoid the error explained above
https://github.com/odoo/odoo/commit/679d278d253e314e94da6e33c96a4f149f12fb6b

Currentlly in Vauxoo/server-tools the module [passwor_security](https://github.com/Vauxoo/server-tools/blob/10.0/password_security/controllers/main.py#L36-L54) mande an inherit of `web_login` method but its open to fail in case of authentication failure since never is restore request.uid,
Here was applied a ugly [fix](https://github.com/Vauxoo/server-tools/commit/d409c85dda6eb46209e04e8e5f10615737a299e0) that I think is not correct solution, 

In order to fix these issues, I think is most better made the restore of request.uid is from `authentication` method, so please review the proposed changes and give us your point of view.

