### PR TITLE
[FIX] website_sale_options: reallow "quick cart add" on product grid

### DIFF
--- a/addons/website_sale_options/static/src/js/website_sale.js
+++ b/addons/website_sale_options/static/src/js/website_sale.js
@@ -6,10 +6,6 @@ var website = require('website.website');
 var base = require('web_editor.base');
 require('website_sale.website_sale');
 
-if(!$('.js_add_cart_variants[data-attribute_value_ids]').length) {
-    return $.Deferred().reject("DOM doesn't contain '.js_add_cart_variants[data-attribute_value_ids]'");
-}
-
 $('.oe_website_sale #add_to_cart, .oe_website_sale #products_grid .a-submit')
     .off('click')
     .removeClass('a-submit')
@@ -28,9 +24,14 @@ $('.oe_website_sale #add_to_cart, .oe_website_sale #products_grid .a-submit')
 
                 $modal.find('img:first').attr("src", "/web/image/product.product/" + product_id + "/image_medium");
 
+                // disable opacity on the <form> if currently active (in case the product is
+                // not published), as it interferes with bs modals
+                $form.addClass('css_options');
+
                 $modal.appendTo($form)
                     .modal()
                     .on('hidden.bs.modal', function () {
+                        $form.removeClass('css_options'); // possibly reactivate opacity (see above)
                         $(this).remove();
                     });
 


### PR DESCRIPTION
Rev 0ff26cf7cdb29bc525462b281d2253889a65b1f4 disabled this option
because it was causing JS errors, which is not the case anymore.

We now get the expected result:
 - if product has no variants, open quick add modal dialog
 - if the product has variants, open the product page to let
   the user choose a variant

Also fix the bootstrap modal bug that happens when the quick add
modal is opened on a product that is not published (modal appeared
partially transparent and unusable)

Dummy pr
https://github.com/Vauxoo/abastotal/pull/216