### PR TITLE
[IMP] base_vat: allow to re-use the 'vat' field of res.partner for lo…

### DIFF
--- a/addons/base_vat/models/res_partner.py
+++ b/addons/base_vat/models/res_partner.py
@@ -42,7 +42,7 @@ _ref_vat = {
     'lu': 'LU12345613',
     'lv': 'LV41234567891',
     'mt': 'MT12345634',
-    'mx': 'MXABC123456T1B',
+    'mx': 'ABC123456T1B',
     'nl': 'NL123456782B90',
     'no': 'NO123456785',
     'pe': 'PER10254824220 or PED10254824220',
@@ -96,7 +96,7 @@ class ResPartner(models.Model):
             # country code or empty VAT number), so we fall back to the simple check.
             return self.simple_vat_check(country_code, vat_number)
 
-    @api.constrains("vat")
+    @api.constrains('vat', 'country_id', 'commercial_partner_id.country_id')
     def check_vat(self):
         if self.env.user.company_id.vat_check_vies:
             # force full VIES online check
@@ -107,27 +107,24 @@ class ResPartner(models.Model):
         for partner in self:
             if not partner.vat:
                 continue
+            #check with country code as prefix of the TIN
             vat_country, vat_number = self._split_vat(partner.vat)
             if not check_func(vat_country, vat_number):
-                _logger.info("Importing VAT Number [%s] is not valid !" % vat_number)
-                msg = partner._construct_constraint_msg()
-                raise ValidationError(msg)
+                #if fails, check with country code from country
+                country_code = partner.commercial_partner_id.country_id.code
+                if country_code:
+                    if not check_func(country_code.lower(), partner.vat):
+                        msg = self._construct_constraint_msg(country_code.lower())
+                        raise ValidationError(msg)
 
-    def _construct_constraint_msg(self):
+    def _construct_constraint_msg(self, country_code):
         self.ensure_one()
-
-        def default_vat_check(cn, vn):
-            # by default, a VAT number is valid if:
-            #  it starts with 2 letters
-            #  has more than 3 characters
-            return len(cn) == 2 and cn[0] in string.ascii_lowercase and cn[1] in string.ascii_lowercase
 
         vat_country, vat_number = self._split_vat(self.vat)
         vat_no = "'CC##' (CC=Country Code, ##=VAT Number)"
-        if default_vat_check(vat_country, vat_number):
-            vat_no = _ref_vat[vat_country] if vat_country in _ref_vat else vat_no
-            if self.env.user.company_id.vat_check_vies:
-                return '\n' + _('The VAT number [%s] for partner [%s] either failed the VIES VAT validation check or did not respect the expected format %s.') % (self.vat, self.name, vat_no)
+        vat_no = _ref_vat.get(country_code) or vat_no
+        if self.env.user.company_id.vat_check_vies:
+            return '\n' + _('The VAT number [%s] for partner [%s] either failed the VIES VAT validation check or did not respect the expected format %s.') % (self.vat, self.name, vat_no)
         return '\n' + _('The VAT number [%s] for partner [%s] does not seem to be valid. \nNote: the expected format is %s') % (self.vat, self.name, vat_no)
 
     __check_vat_ch_re1 = re.compile(r'(MWST|TVA|IVA)[0-9]{6}$')

--- a/addons/base_vat/models/res_partner.py
+++ b/addons/base_vat/models/res_partner.py
@@ -96,7 +96,7 @@ class ResPartner(models.Model):
             # country code or empty VAT number), so we fall back to the simple check.
             return self.simple_vat_check(country_code, vat_number)
 
-    @api.constrains('vat', 'country_id', 'commercial_partner_id.country_id')
+    @api.constrains('vat', 'country_id', 'commercial_partner_id')
     def check_vat(self):
         if self.env.user.company_id.vat_check_vies:
             # force full VIES online check


### PR DESCRIPTION
…calized TIN number algorithm without forcing to prefix that number with the country code (which is weird for people).