### PR TITLE
[IMP] l10n_mx: Completed fiscal regime catalog

### DIFF
--- a/addons/l10n_mx/data/fiscal_position_data.xml
+++ b/addons/l10n_mx/data/fiscal_position_data.xml
@@ -1,28 +1,108 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <data noupdate="1">
-        <record id="account_fiscal_position_personasmoralesdelrgimengeneral0" model="account.fiscal.position.template">
-            <field name="name">Personas morales del régimen general</field>
+        <record id="account_fiscal_position_601_fr" model="account.fiscal.position.template">
+            <field name="name">601 - General de Ley Personas Morales</field>
             <field name="chart_template_id" ref="mx_coa"/>
         </record>
 
-        <record id="account_fiscal_position_personasmoralesconfinesnolucrativos0" model="account.fiscal.position.template">
-            <field name="name">Personas morales con fines no lucrativos</field>
+        <record id="account_fiscal_position_603_fr" model="account.fiscal.position.template">
+            <field name="name">603 - Personas Morales con Fines no Lucrativos</field>
             <field name="chart_template_id" ref="mx_coa"/>
         </record>
 
-        <record id="account_fiscal_position_asociacionesreligiosas0" model="account.fiscal.position.template">
-            <field name="name">Asociaciones Religiosas</field>
+        <record id="account_fiscal_position_605_fr" model="account.fiscal.position.template">
+            <field name="name">605 - Sueldos y Salarios e Ingresos Asimilados a Salarios</field>
             <field name="chart_template_id" ref="mx_coa"/>
         </record>
 
-        <record id="account_fiscal_position_personasmoralesdelrgimensimplificado0" model="account.fiscal.position.template">
-            <field name="name">Personas morales del régimen simplificado</field>
+        <record id="account_fiscal_position_606_fr" model="account.fiscal.position.template">
+            <field name="name">606 - Arrendamiento</field>
             <field name="chart_template_id" ref="mx_coa"/>
         </record>
 
-        <record id="account_fiscal_position_personafisicaconactividadempresarial0" model="account.fiscal.position.template">
-            <field name="name">Persona física con actividad empresarial</field>
+        <record id="account_fiscal_position_607_fr" model="account.fiscal.position.template">
+            <field name="name">607 - Régimen de Enajenación o Adquisición de Bienes</field>
+            <field name="chart_template_id" ref="mx_coa"/>
+        </record>
+
+        <record id="account_fiscal_position_608_fr" model="account.fiscal.position.template">
+            <field name="name">608 - Demás ingresos</field>
+            <field name="chart_template_id" ref="mx_coa"/>
+        </record>
+
+        <record id="account_fiscal_position_609_fr" model="account.fiscal.position.template">
+            <field name="name">609 - Consolidación</field>
+            <field name="chart_template_id" ref="mx_coa"/>
+        </record>
+
+        <record id="account_fiscal_position_610_fr" model="account.fiscal.position.template">
+            <field name="name">610 - Residentes en el Extranjero sin Establecimiento Permanente en México</field>
+            <field name="chart_template_id" ref="mx_coa"/>
+        </record>
+
+        <record id="account_fiscal_position_611_fr" model="account.fiscal.position.template">
+            <field name="name">611 - Ingresos por Dividendos (socios y accionistas)</field>
+            <field name="chart_template_id" ref="mx_coa"/>
+        </record>
+
+        <record id="account_fiscal_position_612_fr" model="account.fiscal.position.template">
+            <field name="name">612 - Personas Físicas con Actividades Empresariales y Profesionales</field>
+            <field name="chart_template_id" ref="mx_coa"/>
+        </record>
+
+        <record id="account_fiscal_position_614_fr" model="account.fiscal.position.template">
+            <field name="name">614 - Ingresos por intereses</field>
+            <field name="chart_template_id" ref="mx_coa"/>
+        </record>
+
+        <record id="account_fiscal_position_615_fr" model="account.fiscal.position.template">
+            <field name="name">615 - Régimen de los ingresos por obtención de premios</field>
+            <field name="chart_template_id" ref="mx_coa"/>
+        </record>
+
+        <record id="account_fiscal_position_616_fr" model="account.fiscal.position.template">
+            <field name="name">616 - Sin obligaciones fiscales</field>
+            <field name="chart_template_id" ref="mx_coa"/>
+        </record>
+
+        <record id="account_fiscal_position_620_fr" model="account.fiscal.position.template">
+            <field name="name">620 - Sociedades Cooperativas de Producción que optan por diferir sus ingresos</field>
+            <field name="chart_template_id" ref="mx_coa"/>
+        </record>
+
+        <record id="account_fiscal_position_621_fr" model="account.fiscal.position.template">
+            <field name="name">621 - Incorporación Fiscal</field>
+            <field name="chart_template_id" ref="mx_coa"/>
+        </record>
+
+        <record id="account_fiscal_position_622_fr" model="account.fiscal.position.template">
+            <field name="name">622 - Actividades Agrícolas, Ganaderas, Silvícolas y Pesqueras</field>
+            <field name="chart_template_id" ref="mx_coa"/>
+        </record>
+
+        <record id="account_fiscal_position_623_fr" model="account.fiscal.position.template">
+            <field name="name">623 - Opcional para Grupos de Sociedades</field>
+            <field name="chart_template_id" ref="mx_coa"/>
+        </record>
+
+        <record id="account_fiscal_position_624_fr" model="account.fiscal.position.template">
+            <field name="name">624 - Coordinados</field>
+            <field name="chart_template_id" ref="mx_coa"/>
+        </record>
+
+        <record id="account_fiscal_position_628_fr" model="account.fiscal.position.template">
+            <field name="name">628 - Hidrocarburos</field>
+            <field name="chart_template_id" ref="mx_coa"/>
+        </record>
+
+        <record id="account_fiscal_position_629_fr" model="account.fiscal.position.template">
+            <field name="name">629 - De los Regímenes Fiscales Preferentes y de las Empresas Multinacionales</field>
+            <field name="chart_template_id" ref="mx_coa"/>
+        </record>
+
+        <record id="account_fiscal_position_630_fr" model="account.fiscal.position.template">
+            <field name="name">630 - Enajenación de acciones en bolsa de valores</field>
             <field name="chart_template_id" ref="mx_coa"/>
         </record>
 


### PR DESCRIPTION
To CFDI 3.3 the SAT provide the [new catalog](http://www.sat.gob.mx/informacion_fiscal/factura_electronica/Documents/catCFDI.xls) that need be used in the node "RegimenFiscal", taked from the company that emit the documents.

Definition:

> Atributo requerido para incorporar la clave del régimen del
> contribuyente emisor al que aplicará el efecto fiscal de este
> comprobante.

And the attribute need the code from the catalog, and validate that it exist.

In CFDI 3.2 the attribute is required but free. Then the code also
could be used in CFDI 3.2.

As fiscal position have not field to save the code, is used the next
structure

`code - name`

And when is used this element in the XML generation take only the first
three characters.

`company_id.partner_id.property_account_position_id[:3]`