### PR TITLE
[FIX] l10n_cr: wrong reference in partners titles

### DIFF
--- a/addons/l10n_cr/data/l10n_cr_state_data.xml
+++ b/addons/l10n_cr/data/l10n_cr_state_data.xml
@@ -43,21 +43,13 @@
         Resource: res.partner.title
         Update partner titles
         -->
-        <record id="base.res_partner_title_pvt_ltd" model="res.partner.title">
+        <record id="res_partner_title_pvt_ltd" model="res.partner.title">
             <field name="name">Corporation</field>
             <field name="shortcut">Corp.</field>
         </record>
-        <record id="base.res_partner_title_ltd" model="res.partner.title">
+        <record id="res_partner_title_ltd" model="res.partner.title">
             <field name="name">Limited Company</field>
             <field name="shortcut">Ltd.</field>
-        </record>
-        <record id="base.res_partner_title_miss" model="res.partner.title">
-            <field name="name">Miss</field>
-            <field name="shortcut">Mss.</field>
-        </record>
-        <record id="base.res_partner_title_madam" model="res.partner.title">
-            <field name="name">Madam</field>
-            <field name="shortcut">Ms.</field>
         </record>
         <record id="res_partner_title_sal" model="res.partner.title">
             <field name="name">Sociedad An&#243;nima Laboral</field>
@@ -75,35 +67,31 @@
             <field name="name">Educational Institution</field>
             <field name="shortcut">Edu.</field>
         </record>
-        <record id="base.res_partner_title_prof" model="res.partner.title">
-            <field name="name">Professor</field>
-            <field name="shortcut">Prof.</field>
-        </record>
         <record id="res_partner_title_indprof" model="res.partner.title">
             <field name="name">Independant Professional</field>
             <field name="shortcut">Ind. Prof.</field>
         </record>
-        <record id="base.res_partner_title_dra" model="res.partner.title">
+        <record id="res_partner_title_dra" model="res.partner.title">
             <field name="name">Doctora</field>
             <field name="shortcut">Dra.</field>
         </record>
-        <record id="base.res_partner_title_msc" model="res.partner.title">
+        <record id="res_partner_title_msc" model="res.partner.title">
             <field name="name">Msc.</field>
             <field name="shortcut">Msc.</field>
         </record>
-        <record id="base.res_partner_title_mba" model="res.partner.title">
+        <record id="res_partner_title_mba" model="res.partner.title">
             <field name="name">MBA</field>
             <field name="shortcut">MBA</field>
         </record>
-        <record id="base.res_partner_title_lic" model="res.partner.title">
+        <record id="res_partner_title_lic" model="res.partner.title">
             <field name="name">Licenciado</field>
             <field name="shortcut">Lic.</field>
         </record>
-        <record id="base.res_partner_title_licda" model="res.partner.title">
+        <record id="res_partner_title_licda" model="res.partner.title">
             <field name="name">Licenciada</field>
             <field name="shortcut">Licda.</field>
         </record>
-        <record id="base.res_partner_title_ing" model="res.partner.title">
+        <record id="res_partner_title_ing" model="res.partner.title">
             <field name="name">Ingeniero/a</field>
             <field name="shortcut">Ing.</field>
         </record>

--- a/doc/cla/corporate/vauxoo.md
+++ b/doc/cla/corporate/vauxoo.md
@@ -34,3 +34,4 @@ Osval Reyes osval@vauxoo.com https://github.com/osvalr
 Luis González lgonzalez@vauxoo.com https://github.com/luisg123v
 Oriana Maita oriana@vauxoo.com https://github.com/maitaoriana
 Gabriela Mogollon gmogollon@vauxoo.com https://github.com/GavyMG
+Jose Suniaga josemiguel@vauxoo.com https://github.com/suniagajose


### PR DESCRIPTION
Summary
-------------

When installing costa rican localization the partners titles has a wrong reference to base module that cause a warning message in server log. In total the localization had 8 partners titles that not exists in base which was removed the reference and another 2 that exists in base but not had any difference.

Courtesy of Vauxoo.


To fix:
-------

```
2017-05-26 22:14:31,647 137 INFO openerp_template odoo.modules.loading: loading l10n_cr/data/l10n_cr_state_data.xml
2017-05-26 22:14:31,721 137 WARNING openerp_template odoo.addons.base.ir.ir_model: Creating the ir.model.data res_partner_title_pvt_ltd in module base instead of l10n_cr.
2017-05-26 22:14:31,725 137 WARNING openerp_template odoo.addons.base.ir.ir_model: Creating the ir.model.data res_partner_title_ltd in module base instead of l10n_cr.
2017-05-26 22:14:32,101 137 WARNING openerp_template odoo.addons.base.ir.ir_model: Creating the ir.model.data res_partner_title_dra in module base instead of l10n_cr.
2017-05-26 22:14:32,105 137 WARNING openerp_template odoo.addons.base.ir.ir_model: Creating the ir.model.data res_partner_title_msc in module base instead of l10n_cr.
2017-05-26 22:14:32,109 137 WARNING openerp_template odoo.addons.base.ir.ir_model: Creating the ir.model.data res_partner_title_mba in module base instead of l10n_cr.
2017-05-26 22:14:32,113 137 WARNING openerp_template odoo.addons.base.ir.ir_model: Creating the ir.model.data res_partner_title_lic in module base instead of l10n_cr.
2017-05-26 22:14:32,117 137 WARNING openerp_template odoo.addons.base.ir.ir_model: Creating the ir.model.data res_partner_title_licda in module base instead of l10n_cr.
2017-05-26 22:14:32,121 137 WARNING openerp_template odoo.addons.base.ir.ir_model: Creating the ir.model.data res_partner_title_ing in module base instead of l10n_cr.
```