### PR TITLE
[FIX] Reverting  website_sale: Updating price on Optional Products TA#7904, Issue#4282

### DIFF
--- a/addons/website_sale/static/src/js/website_sale.js
+++ b/addons/website_sale/static/src/js/website_sale.js
@@ -295,10 +295,8 @@ odoo.define('website_sale.website_sale', function (require) {
             var $ul = $(ev.target).closest('.js_add_cart_variants');
             var $parent = $ul.closest('.js_product');
             var $product_id = $parent.find('input.product_id').first();
-            var $price = $parent.find(".oe_price:first .oe_currency_value")
-                .add($('#product_confirmation').find(".oe_price"));
-            var $default_price = $parent.find(".oe_default_price:first .oe_currency_value")
-                .add($('#product_confirmation').find(".oe_default_price:first .oe_currency_value"));
+            var $price = $parent.find(".oe_price:first .oe_currency_value");
+            var $default_price = $parent.find(".oe_default_price:first .oe_currency_value");
             var $optional_price = $parent.find(".oe_optional:first .oe_currency_value");
             var variant_ids = $ul.data("attribute_value_ids");
             var values = [];


### PR DESCRIPTION
Temporal Patch

Reverting
https://github.com/odoo/odoo/commit/c8a434306f110bfb5e5ce71609e8e096a850d309

Because the prices is not showed correctly when the product has optional
products configured

Revert this change when fixed following reported issue
https://github.com/odoo/odoo/issues/17342