### PR TITLE
[IMP] l10n_mx: Added lost data to fiscal positions

### DIFF
--- a/addons/l10n_mx/data/fiscal_position_data.xml
+++ b/addons/l10n_mx/data/fiscal_position_data.xml
@@ -1,17 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
-<odoo>
-    <data noupdate="1">
-        <record id="account_fiscal_position0_purchase" model="account.fiscal.position.tax.template">
-            <field name="tax_src_id" ref="tax14"/>
-            <field name="tax_dest_id" ref="tax13"/>
-            <field name="position_id" ref="account_fiscal_position_foreign"/>
-        </record>
-
-        <record id="account_fiscal_position0_sale" model="account.fiscal.position.tax.template">
-            <field name="tax_src_id" ref="tax12"/>
-            <field name="tax_dest_id" ref="tax9"/>
-            <field name="position_id" ref="account_fiscal_position_foreign"/>
-        </record>
-
-    </data>
+<odoo noupdate="1">
+    <record id="account_fiscal_position_foreign" model="account.fiscal.position">
+        <field name="name">Foreign Customer</field>
+    </record>
+    <record id="account_fiscal_position0_purchase" model="account.fiscal.position.tax.template">
+        <field name="tax_src_id" ref="tax14"/>
+        <field name="tax_dest_id" ref="tax13"/>
+        <field name="position_id" ref="account_fiscal_position_foreign"/>
+    </record>
+    <record id="account_fiscal_position0_sale" model="account.fiscal.position.tax.template">
+        <field name="tax_src_id" ref="tax12"/>
+        <field name="tax_dest_id" ref="tax9"/>
+        <field name="position_id" ref="account_fiscal_position_foreign"/>
+    </record>
 </odoo>


### PR DESCRIPTION
Fixed error ```
"External ID not found in the system:
l10n_mx.account_fiscal_position_foreign" while parsing
/home/odoo/odoo-10.0/addons/l10n_mx/data/fiscal_position_data.xml:4
```
runbot.vauxoo.com/runbot/static/build/33575-277-89f985/logs/job_20_test_all.txt