### PR TITLE
[IMP] l10n_mx: Order data files to assign the fiscal positions

### DIFF
--- a/addons/l10n_mx/__manifest__.py
+++ b/addons/l10n_mx/__manifest__.py
@@ -40,7 +40,7 @@ With this module you will have:
         "data/l10n_mx_chart_data.xml",
         "data/account_data.xml",
         "data/account_tax_data.xml",
-        "data/account_chart_template_data.yml",
         "data/fiscal_position_data.xml",
+        "data/account_chart_template_data.yml",
     ],
 }


### PR DESCRIPTION
Fiscal positions must be generated before to assign the chart template to generate the files