### PR TITLE
[IMP] base_address_city: Added field to assign the city code

### DIFF
--- a/addons/base_address_city/models/res_city.py
+++ b/addons/base_address_city/models/res_city.py
@@ -10,6 +10,7 @@ class City(models.Model):
     _order = 'name'
 
     name = fields.Char("Name", required=True, translate=True)
+    code = fields.Char()
     zipcode = fields.Char("Zip")
     country_id = fields.Many2one('res.country', string='Country', required=True)
     state_id = fields.Many2one(

--- a/addons/base_address_city/views/res_city_view.xml
+++ b/addons/base_address_city/views/res_city_view.xml
@@ -6,6 +6,7 @@
             <field name="arch" type="xml">
                 <tree string="City" editable="top">
                     <field name="name"/>
+                    <field name="code"/>
                     <field name="zipcode"/>
                     <field name="country_id"/>
                     <field name="state_id"/>


### PR DESCRIPTION
As in state and country is added the field to save the code that
have each city.

Example where is required:

In Mexico we generate the CFDI document by invoice, that is a XML that
is generated with the invoice data.

The CFDI have some Complements, example:

External trade, that gave the attribute "Municipio" that is equal to
city, and in this attribute must be assigned the city code,

> Atributo opcional que sirve para precisar la clave del municipio o
> delegación en donde se encuentra ubicado el domicilio del emisor del
> comprobante, conforme con el catálogo c_Municipio publicado en el portal
> del SAT en internet.

The catalog is found here:
https://goo.gl/vmLtRT

By this reason We need this new field