### PR TITLE
[IMP] account: allow to register payments for several partners, from …

### DIFF
--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -12,9 +12,9 @@ MAP_INVOICE_TYPE_PARTNER_TYPE = {
 # Since invoice amounts are unsigned, this is how we know if money comes in or goes out
 MAP_INVOICE_TYPE_PAYMENT_SIGN = {
     'out_invoice': 1,
-    'in_refund': 1,
+    'in_refund': -1,
     'in_invoice': -1,
-    'out_refund': -1,
+    'out_refund': 1,
 }
 
 class account_payment_method(models.Model):
@@ -54,14 +54,17 @@ class account_abstract_payment(models.AbstractModel):
         if not self.amount > 0.0:
             raise ValidationError(_('The payment amount must be strictly positive.'))
 
-    @api.one
+    @api.multi
     @api.depends('payment_type', 'journal_id')
     def _compute_hide_payment_method(self):
-        if not self.journal_id:
-            self.hide_payment_method = True
-            return
-        journal_payment_methods = self.payment_type == 'inbound' and self.journal_id.inbound_payment_method_ids or self.journal_id.outbound_payment_method_ids
-        self.hide_payment_method = len(journal_payment_methods) == 1 and journal_payment_methods[0].code == 'manual'
+        for payment in self:
+            if not payment.journal_id:
+                payment.hide_payment_method = True
+                continue
+            journal_payment_methods = payment.payment_type == 'inbound'\
+                and payment.journal_id.inbound_payment_method_ids\
+                or payment.journal_id.outbound_payment_method_ids
+            payment.hide_payment_method = len(journal_payment_methods) == 1 and journal_payment_methods[0].code == 'manual'
 
     @api.onchange('journal_id')
     def _onchange_journal(self):
@@ -75,24 +78,18 @@ class account_abstract_payment(models.AbstractModel):
             return {'domain': {'payment_method_id': [('payment_type', '=', payment_type), ('id', 'in', payment_methods.ids)]}}
         return {}
 
-    def _get_invoices(self):
-        """ Return the invoices of the payment. Must be overridden """
-        raise NotImplementedError
-
+    @api.model
     def _compute_total_invoices_amount(self):
         """ Compute the sum of the residual of invoices, expressed in the payment currency """
         payment_currency = self.currency_id or self.journal_id.currency_id or self.journal_id.company_id.currency_id or self.env.user.company_id.currency_id
-        invoices = self._get_invoices()
 
-        if all(inv.currency_id == payment_currency for inv in invoices):
-            total = sum(invoices.mapped('residual_signed'))
-        else:
-            total = 0
-            for inv in invoices:
-                if inv.company_currency_id != payment_currency:
-                    total += inv.company_currency_id.with_context(date=self.payment_date).compute(inv.residual_company_signed, payment_currency)
-                else:
-                    total += inv.residual_company_signed
+        total = 0
+        for inv in self.invoice_ids:
+            if inv.currency_id == payment_currency:
+                total += inv.residual_company_signed
+            else:
+                total += inv.company_currency_id.with_context(date=self.payment_date).compute(
+                    inv.residual_company_signed, payment_currency)
         return abs(total)
 
 
@@ -101,71 +98,137 @@ class account_register_payments(models.TransientModel):
     _inherit = 'account.abstract.payment'
     _description = "Register payments on multiple invoices"
 
+    invoice_ids = fields.Many2many('account.invoice', string='Invoices', copy=False)
+    multi = fields.Boolean(string='Multi', help='Technical field indicating if the user selected invoices from multiple partners or from different types.')
+
     @api.onchange('payment_type')
     def _onchange_payment_type(self):
         if self.payment_type:
             return {'domain': {'payment_method_id': [('payment_type', '=', self.payment_type)]}}
 
-    def _get_invoices(self):
-        return self.env['account.invoice'].browse(self._context.get('active_ids'))
+    @api.model
+    def _compute_payment_amount(self, invoice_ids):
+        payment_currency = self.currency_id or self.journal_id.currency_id or self.journal_id.company_id.currency_id
+
+        total = 0
+        for inv in invoice_ids:
+            if inv.currency_id == payment_currency:
+                total += MAP_INVOICE_TYPE_PAYMENT_SIGN[inv.type] * inv.residual_company_signed
+            else:
+                amount_residual = inv.company_currency_id.with_context(date=self.payment_date).compute(
+                    inv.residual_company_signed, payment_currency)
+                total += MAP_INVOICE_TYPE_PAYMENT_SIGN[inv.type] * amount_residual
+        return total
 
     @api.model
     def default_get(self, fields):
         rec = super(account_register_payments, self).default_get(fields)
-        context = dict(self._context or {})
-        active_model = context.get('active_model')
-        active_ids = context.get('active_ids')
+        active_ids = self._context.get('active_ids')
 
-        # Checks on context parameters
-        if not active_model or not active_ids:
-            raise UserError(_("Programmation error: wizard action executed without active_model or active_ids in context."))
-        if active_model != 'account.invoice':
-            raise UserError(_("Programmation error: the expected model for this action is 'account.invoice'. The provided one is '%d'.") % active_model)
+        # Check for selected invoices ids
+        if not active_ids:
+            raise UserError(_("Programmation error: wizard action executed without active_ids in context."))
 
-        # Checks on received invoice records
-        invoices = self.env[active_model].browse(active_ids)
+        invoices = self.env['account.invoice'].browse(active_ids)
+
+        # Check all invoices are open
         if any(invoice.state != 'open' for invoice in invoices):
             raise UserError(_("You can only register payments for open invoices"))
-        if any(inv.commercial_partner_id != invoices[0].commercial_partner_id for inv in invoices):
-            raise UserError(_("In order to pay multiple invoices at once, they must belong to the same commercial partner."))
-        if any(MAP_INVOICE_TYPE_PARTNER_TYPE[inv.type] != MAP_INVOICE_TYPE_PARTNER_TYPE[invoices[0].type] for inv in invoices):
-            raise UserError(_("You cannot mix customer invoices and vendor bills in a single payment."))
+        # Check all invoices have the same currency
         if any(inv.currency_id != invoices[0].currency_id for inv in invoices):
             raise UserError(_("In order to pay multiple invoices at once, they must use the same currency."))
 
-        total_amount = sum(inv.residual * MAP_INVOICE_TYPE_PAYMENT_SIGN[inv.type] for inv in invoices)
-        communication = ' '.join([ref for ref in invoices.mapped('reference') if ref])
+        # Look if we are mixin multiple commercial_partner or customer invoices with vendor bills
+        multi = any(inv.commercial_partner_id != invoices[0].commercial_partner_id
+            or MAP_INVOICE_TYPE_PARTNER_TYPE[inv.type] != MAP_INVOICE_TYPE_PARTNER_TYPE[invoices[0].type]
+            for inv in invoices)
+
+        total_amount = self._compute_payment_amount(invoices)
 
         rec.update({
             'amount': abs(total_amount),
             'currency_id': invoices[0].currency_id.id,
             'payment_type': total_amount > 0 and 'inbound' or 'outbound',
-            'partner_id': invoices[0].commercial_partner_id.id,
-            'partner_type': MAP_INVOICE_TYPE_PARTNER_TYPE[invoices[0].type],
-            'communication': communication,
+            'partner_id': False if multi else invoices[0].commercial_partner_id.id,
+            'partner_type': False if multi else MAP_INVOICE_TYPE_PARTNER_TYPE[invoices[0].type],
+            'communication': ' '.join([ref for ref in invoices.mapped('reference') if ref]),
+            'invoice_ids': [(6, 0, invoices.ids)],
+            'multi': multi,
         })
         return rec
 
-    def get_payment_vals(self):
-        """ Hook for extension """
+    @api.multi
+    def _groupby_invoices(self):
+        '''Split the invoices linked to the wizard according to their commercial partner and their type.
+
+        :return: a dictionary mapping (commercial_partner_id, type) => invoices recordset.
+        '''
+        results = {}
+        # Create a dict dispatching invoices according to their commercial_partner_id and type
+        for inv in self.invoice_ids:
+            key = (inv.commercial_partner_id.id, MAP_INVOICE_TYPE_PARTNER_TYPE[inv.type])
+            if not key in results:
+                results[key] = self.env['account.invoice']
+            results[key] += inv
+        return results
+
+    @api.multi
+    def _prepare_payment_vals(self, invoices):
+        '''Create the payment values.
+
+        :param invoices: The invoices that should have the same commercial partner and the same type.
+        :return: The payment values as a dictionary.
+        '''
+        amount = self._compute_payment_amount(invoices) if self.multi else self.amount
+        payment_type = ('inbound' if amount > 0 else 'outbound') if self.multi else self.payment_type
         return {
             'journal_id': self.journal_id.id,
             'payment_method_id': self.payment_method_id.id,
             'payment_date': self.payment_date,
             'communication': self.communication,
-            'invoice_ids': [(4, inv.id, None) for inv in self._get_invoices()],
-            'payment_type': self.payment_type,
-            'amount': self.amount,
+            'invoice_ids': [(6, 0, invoices.ids)],
+            'payment_type': payment_type,
+            'amount': abs(amount),
             'currency_id': self.currency_id.id,
-            'partner_id': self.partner_id.id,
-            'partner_type': self.partner_type,
+            'partner_id': invoices[0].commercial_partner_id.id,
+            'partner_type': MAP_INVOICE_TYPE_PARTNER_TYPE[invoices[0].type],
         }
 
     @api.multi
-    def create_payment(self):
-        payment = self.env['account.payment'].create(self.get_payment_vals())
-        payment.post()
-        return {'type': 'ir.actions.act_window_close'}
+    def get_payments_vals(self):
+        '''Compute the values for payments.
+
+        :return: a list of payment values (dictionary).
+        '''
+        if self.multi:
+            groups = self._groupby_invoices()
+            return [self._prepare_payment_vals(invoices) for invoices in groups.values()]
+        return [self._prepare_payment_vals(self.invoice_ids)]
+
+    @api.multi
+    def create_payments(self):
+        '''Create payments according to the invoices.
+        Having invoices with different commercial_partner_id or different type (Vendor bills with customer invoices)
+        leads to multiple payments.
+        In case of all the invoices are related to the same commercial_partner_id and have the same type,
+        only one payment will be created.
+
+        :return: The ir.actions.act_window to show created payments.
+        '''
+        Payment = self.env['account.payment']
+        payments = Payment
+        for payment_vals in self.get_payments_vals():
+            payments += Payment.create(payment_vals)
+        payments.post()
+        return {
+            'name': _('Payments'),
+            'domain': [('id', 'in', payments.ids), ('state', '=', 'posted')],
+            'view_type': 'form',
+            'view_mode': 'tree,form',
+            'res_model': 'account.payment',
+            'view_id': False,
+            'type': 'ir.actions.act_window',
+        }
 
 
 class account_payment(models.Model):
@@ -190,7 +253,6 @@ class account_payment(models.Model):
             self.payment_difference = self._compute_total_invoices_amount() - self.amount
 
     company_id = fields.Many2one(store=True)
-
     name = fields.Char(readonly=True, copy=False, default="Draft Payment") # The name is attributed upon post()
     state = fields.Selection([('draft', 'Draft'), ('posted', 'Posted'), ('sent', 'Sent'), ('reconciled', 'Reconciled'), ('cancel', 'Cancelled')], readonly=True, default='draft', copy=False, string="Status")
 
@@ -268,9 +330,6 @@ class account_payment(models.Model):
             rec['partner_id'] = invoice['partner_id'][0]
             rec['amount'] = invoice['residual']
         return rec
-
-    def _get_invoices(self):
-        return self.invoice_ids
 
     @api.multi
     def button_journal_entries(self):

--- a/addons/account/views/account_payment_view.xml
+++ b/addons/account/views/account_payment_view.xml
@@ -98,8 +98,8 @@
                         <group>
                             <group>
                                 <field name="payment_type" widget="radio" attrs="{'readonly': [('state', '!=', 'draft')]}"/>
-                                <field name="partner_type" nolabel="1" widget="selection" string="" attrs="{'required': [('payment_type', 'in', ('inbound', 'outbound'))], 'invisible': [('payment_type', 'not in', ('inbound', 'outbound'))], 'readonly': [('state', '!=', 'draft')]}"/>
-                                <field name="partner_id" nolabel="1" attrs="{'required': [('payment_type', 'in', ('inbound', 'outbound'))], 'invisible': [('payment_type', 'not in', ('inbound', 'outbound'))], 'readonly': [('state', '!=', 'draft')]}" context="{'default_is_company': True, 'default_supplier': payment_type == 'outbound', 'default_customer': payment_type == 'inbound'}"/>
+                                <field name="partner_type" widget="selection" attrs="{'required': [('payment_type', 'in', ('inbound', 'outbound'))], 'invisible': [('payment_type', 'not in', ('inbound', 'outbound'))], 'readonly': [('state', '!=', 'draft')]}"/>
+                                <field name="partner_id" attrs="{'required': [('payment_type', 'in', ('inbound', 'outbound'))], 'invisible': [('payment_type', 'not in', ('inbound', 'outbound'))], 'readonly': [('state', '!=', 'draft')]}" context="{'default_is_company': True, 'default_supplier': payment_type == 'outbound', 'default_customer': payment_type == 'inbound'}"/>
                                 <field name="journal_id" widget="selection" attrs="{'readonly': [('state', '!=', 'draft')]}"/>
                                 <field name="destination_journal_id" widget="selection" attrs="{'required': [('payment_type', '=', 'transfer')], 'invisible': [('payment_type', '!=', 'transfer')], 'readonly': [('state', '!=', 'draft')]}"/>
                                 <field name="hide_payment_method" invisible="1"/>
@@ -253,8 +253,9 @@
                             <field name="hide_payment_method" invisible="1"/>
                             <field name="payment_method_id" widget="radio" attrs="{'invisible': [('hide_payment_method', '=', True)]}"/>
                             <field name="payment_method_code" invisible="1"/>
-                            <field name="amount"/>
                             <field name="currency_id" invisible="1"/>
+                            <field name="multi" invisible="1"/>
+                            <field name="amount" attrs="{'readonly': [('multi', '=', True)]}"/>
                         </group>
                         <group>
                             <field name="payment_date"/>
@@ -262,7 +263,7 @@
                         </group>
                     </group>
                     <footer>
-                        <button string='Validate' name="create_payment" type="object" class="btn-primary"/>
+                        <button string='Validate' name="create_payments" type="object" class="btn-primary"/>
                         <button string="Cancel" class="btn-default" special="cancel"/>
                     </footer>
                </form>
@@ -279,6 +280,26 @@
             target="new"
             key2="client_action_multi"
         />
+
+        <!-- Action confirm_payments for multi -->
+        <record id="action_account_confirm_payments" model="ir.actions.server">
+            <field name="name">Confirm Payments</field>
+            <field name="type">ir.actions.server</field>
+            <field name="state">code</field>
+            <field name="model_id" ref="account.model_account_payment"/>
+            <field name="code">
+records.post()
+            </field>
+        </record>
+
+        <record id="account_confirm_payments" model="ir.values">
+            <field name="model_id" ref="account.model_account_payment"/>
+            <field name="name">Confirm Payments</field>
+            <field name="key2">client_action_multi</field>
+            <field name="value" eval="'ir.actions.server,' +str(ref('action_account_confirm_payments'))" />
+            <field name="key">action</field>
+            <field name="model">account.payment</field>
+        </record>
 
     </data>
 </odoo>

--- a/addons/account_check_printing/models/account_payment.py
+++ b/addons/account_check_printing/models/account_payment.py
@@ -31,8 +31,8 @@ class AccountRegisterPayments(models.TransientModel):
             super(AccountRegisterPayments, self)._onchange_amount()
         self.check_amount_in_words = self.env['account.payment']._get_check_amount_in_words(self.amount)
 
-    def get_payment_vals(self):
-        res = super(AccountRegisterPayments, self).get_payment_vals()
+    def _prepare_payment_vals(self, invoices):
+        res = super(AccountRegisterPayments, self)._prepare_payment_vals(invoices)
         if self.payment_method_id == self.env.ref('account_check_printing.account_payment_method_check'):
             res.update({
                 'check_amount_in_words': self.check_amount_in_words,

--- a/addons/hr_expense/wizard/hr_expense_register_payment.py
+++ b/addons/hr_expense/wizard/hr_expense_register_payment.py
@@ -53,7 +53,7 @@ class HrExpenseRegisterPaymentWizard(models.TransientModel):
             return {'domain': {'payment_method_id': [('payment_type', '=', 'outbound'), ('id', 'in', payment_methods.ids)]}}
         return {}
 
-    def get_payment_vals(self):
+    def _get_payment_vals(self):
         """ Hook for extension """
         return {
             'partner_type': 'supplier',
@@ -76,7 +76,7 @@ class HrExpenseRegisterPaymentWizard(models.TransientModel):
         expense_sheet = self.env['hr.expense.sheet'].browse(active_ids)
 
         # Create payment and post it
-        payment = self.env['account.payment'].create(self.get_payment_vals())
+        payment = self.env['account.payment'].create(self._get_payment_vals())
         payment.post()
 
         # Log the payment in the chatter

--- a/addons/hr_expense_check/models/payment.py
+++ b/addons/hr_expense_check/models/payment.py
@@ -29,8 +29,8 @@ class HrExpenseRegisterPaymentWizard(models.TransientModel):
             super(HrExpenseRegisterPaymentWizard, self)._onchange_amount()
         self.check_amount_in_words = self.env['account.payment']._get_check_amount_in_words(self.amount)
 
-    def get_payment_vals(self):
-        res = super(HrExpenseRegisterPaymentWizard, self).get_payment_vals()
+    def _get_payment_vals(self):
+        res = super(HrExpenseRegisterPaymentWizard, self)._get_payment_vals()
         if self.payment_method_id == self.env.ref('account_check_printing.account_payment_method_check'):
             res.update({
                 'check_amount_in_words': self.check_amount_in_words,


### PR DESCRIPTION
…invoices.

This patch allow to select several invoices/refunds or bills/bill refunds and launch the contextual action to register a payment for all of them.
Where, before, the system allowed that only if there was a single partner, it will now create and post a payment for each of them.

Was PR #https://github.com/odoo/odoo/pull/15228
Was task: 24014