### PR TITLE
[FIX] stock_quant: fix method quants_reserve, when quant is None

### DIFF
--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -143,10 +143,10 @@ class Quant(models.Model):
         reserved_availability = move.reserved_availability
         # split quants if needed
         for quant, qty in quants:
-            if qty <= 0.0 or (quant and quant.qty <= 0.0):
-                raise UserError(_('You can not reserve a negative quantity or a negative quant.'))
             if not quant:
                 continue
+            if qty <= 0.0 or (quant and quant.qty <= 0.0):
+                raise UserError(_('You can not reserve a negative quantity or a negative quant.'))
             quant._quant_split(qty)
             quants_to_reserve_sudo |= quant
             reserved_availability += quant.qty


### PR DESCRIPTION
- When qty of product is 0.0 in move_stock, then the quants is (None,0.0) and return a raise,
that's why picking is not done. The conditions of the quants_reserve method
were exchanged,  to that it is validated first if there is a quant.

- This is done to get the same behavior as in v9.0

Value quants in v10.0 [(None, 0.0)]
![quants10 0](https://user-images.githubusercontent.com/17258001/27982620-86a2c1d6-6374-11e7-856c-035f3a443e5d.png)
Value quants in 9.0 [ ] 
Dummy https://github.com/Vauxoo/abastotal/pull/321