### PR TITLE
[FIX] purchase: taxes in price difference accounting entry

### DIFF
--- a/addons/purchase/invoice.py
+++ b/addons/purchase/invoice.py
@@ -165,10 +165,16 @@ class AccountInvoice(models.Model):
                                 and acc:
                             # price with discount and without tax included
                             price_unit = i_line.price_unit * (1 - (i_line.discount or 0.0) / 100.0)
+                            tax_ids = []
                             if line['tax_ids']:
                                 #line['tax_ids'] is like [(4, tax_id, None), (4, tax_id2, None)...]
                                 taxes = self.env['account.tax'].browse([x[1] for x in line['tax_ids']])
                                 price_unit = taxes.with_context(round=False).compute_all(price_unit, currency=inv.currency_id, quantity=1.0)['total_excluded']
+                                for tax in taxes:
+                                    tax_ids.append((4, tax.id, None))
+                                    for child in tax.children_tax_ids:
+                                        if child.type_tax_use != 'none':
+                                            tax_ids.append((4, child.id, None))
                             price_before = line.get('price', 0.0)
                             line.update({'price': round(valuation_price_unit * line['quantity'], account_prec)})
                             diff_res.append({
@@ -181,6 +187,7 @@ class AccountInvoice(models.Model):
                                 'product_id': line['product_id'],
                                 'uom_id': line['uom_id'],
                                 'account_analytic_id': line['account_analytic_id'],
+                                'tax_ids': tax_ids,
                                 })
                 return diff_res
         return []


### PR DESCRIPTION
Setting the taxes in the accounting move entries
is important for the taxes report.

When a price difference occures in a purchase
with a product set in a perpetual inventory valuation,
the taxes set on the price difference move line should be the same
than the move line from which this price difference
is computed. Otherwise, the taxes report
do not have the whole purchase amount

opw-710228