### PR TITLE
[FIX] base: strict=False when create new object PdfFileReader

### DIFF
--- a/addons/document/models/ir_attachment.py
+++ b/addons/document/models/ir_attachment.py
@@ -110,7 +110,7 @@ class IrAttachment(models.Model):
         if bin_data.startswith('%PDF-'):
             f = StringIO(bin_data)
             try:
-                pdf = PyPDF2.PdfFileReader(f, overwriteWarnings=False)
+                pdf = PyPDF2.PdfFileReader(f, overwriteWarnings=False, strict=False)
                 for page in pdf.pages:
                     buf += page.extractText()
             except Exception:

--- a/odoo/addons/base/ir/ir_actions_report.py
+++ b/odoo/addons/base/ir/ir_actions_report.py
@@ -85,7 +85,7 @@ def _merge_pdf(documents):
         for document in documents:
             pdfreport = open(document, 'rb')
             streams.append(pdfreport)
-            reader = PdfFileReader(pdfreport, overwriteWarnings=False)
+            reader = PdfFileReader(pdfreport, overwriteWarnings=False, strict=False)
             for page in range(0, reader.getNumPages()):
                 writer.addPage(reader.getPage(page))
 


### PR DESCRIPTION
**Current behavior before PR:**
Actually the branch saas-17 show the follow warning http://runbot.odoo.com/runbot/build/250255
```
2017-07-31 17:18:35,300 29183 WARNING 250255-saas-17-391a29-all py.warnings: /usr/local/lib/python2.7/dist-packages/PyPDF2/pdf.py:1736: PdfReadWarning: Xref table not zero-indexed. ID numbers for objects will be corrected.
  warnings.warn("Xref table not zero-indexed. ID numbers for objects will be corrected.", utils.PdfReadWarning)
```
I found some help about this `WARNING` https://github.com/mstamy2/PyPDF2/issues/36#issuecomment-28843088

**Desired behavior after PR is merged:**
No found `WARNING` in the odoo log


**What is the impact of that change ?**

Related with https://github.com/odoo/odoo/pull/18582