### PR TITLE
[IMP] base_address_city: Improved way as append the city_id

### DIFF
--- a/addons/base_address_city/__manifest__.py
+++ b/addons/base_address_city/__manifest__.py
@@ -16,6 +16,7 @@ This module allows to enforce users to choose the city of a partner inside a giv
         'security/ir.model.access.csv',
         'views/res_city_view.xml',
         'views/res_country_view.xml',
+        'views/res_partner_view.xml',
     ],
     'depends': ['base'],
 }

--- a/addons/base_address_city/models/res_partner.py
+++ b/addons/base_address_city/models/res_partner.py
@@ -25,13 +25,11 @@ class Partner(models.Model):
         # render the partner address accordingly to address_view_id
         doc = etree.fromstring(arch)
         for city_node in doc.xpath("//field[@name='city']"):
-            replacement_xml = """
-            <div>
-                <field name="country_enforce_cities" invisible="1"/>
-                <field name='city' attrs="{'invisible': [('country_enforce_cities', '=', True), ('city_id', '!=', False)], 'readonly': [('type', '=', 'contact'), ('parent_id', '!=', False)]}"/>
-                <field name='city_id' attrs="{'invisible': [('country_enforce_cities', '=', False)], 'readonly': [('type', '=', 'contact'), ('parent_id', '!=', False)]}" context="{'default_country_id': country_id}" domain="[('country_id', '=', country_id)]"/>
-            </div>
-            """
+            view = self.env.ref(
+                'base_address_city.view_partner_city_address_form')
+            arch = view._read_template(view.id)
+            replacement_xml = etree.tostring(
+                etree.fromstring(arch).xpath("//div")[0])
             city_id_node = etree.fromstring(replacement_xml)
             city_node.getparent().replace(city_node, city_id_node)
 

--- a/addons/base_address_city/views/res_partner_view.xml
+++ b/addons/base_address_city/views/res_partner_view.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_partner_city_address_form" model="ir.ui.view">
+        <field name="name">res.partner.city.address.form</field>
+        <field name="model">res.partner</field>
+        <field name="arch" type="xml">
+            <form>
+                <div>
+                    <field name="country_enforce_cities" invisible="1"/>
+                    <field name='city_id' placeholder="City..." class="o_address_city" attrs="{'invisible': [('country_enforce_cities', '=', False)], 'readonly': [('type', '=', 'contact'), ('parent_id', '!=', False)]}" context="{'default_country_id': country_id}" domain="[('country_id', '=', country_id)]"/>
+                    <field name='city' placeholder="City..." class="o_address_city" attrs="{'invisible': [('country_enforce_cities', '=', True), ('city_id', '!=', False)], 'readonly': [('type', '=', 'contact'), ('parent_id', '!=', False)]}"/>
+                </div>
+            </form>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Like the address_format could be changed by each country, this method
is required to append the field city_id in the views, to all country
address formats.

But if We need inherit the view to add a parameter in city or city_id,
WE need overwrite this method. Now, with this change, We only inherit
the view, and not all the method.