### PR TITLE
[IMP] product: change string of search field pricelists

### DIFF
--- a/addons/product/i18n/es.po
+++ b/addons/product/i18n/es.po
@@ -2405,8 +2405,8 @@ msgstr "Elementos de las tarifas de productos"
 
 #. module: product
 #: view:product.pricelist:product.product_pricelist_view_search
-msgid "Products Price"
-msgstr "Precio de los productos"
+msgid "Products Price List Name"
+msgstr "Nombre de tarifa de productos"
 
 #. module: product
 #: view:product.pricelist:product.product_pricelist_view

--- a/addons/product/pricelist_view.xml
+++ b/addons/product/pricelist_view.xml
@@ -128,7 +128,7 @@
             <field name="model">product.pricelist</field>
             <field name="arch" type="xml">
                 <search string="Products Price Search">
-                    <field name="name" string="Products Price"/>
+                    <field name="name" string="Products Price List Name"/>
                     <field name="type"/>
                     <field name="active" />
                     <field name="currency_id" groups="base.group_multi_currency"/>


### PR DESCRIPTION
The base string "Products Price" was changed to "Products Price List Name" with its respective traduction "Precio de los productos" to "Nombre de tarifa de productos". 

This change is because it's confusing for the customers introduce a name when with the original string, "Products Price", looks like you need to introduce a price.

Issue https://github.com/odoo/odoo/issues/19076

**screen shots**
![image](https://user-images.githubusercontent.com/19410285/29832009-d4097eb0-8cb4-11e7-9aa9-bf4ffc68fa3c.png)

![image](https://user-images.githubusercontent.com/19410285/29831660-d1a13b96-8cb3-11e7-87ab-b1a45db5402b.png)

