### PR TITLE
[FIX] Time consuming Journal Item creation process can be avoided

### DIFF
--- a/addons/account/account_invoice.py
+++ b/addons/account/account_invoice.py
@@ -806,7 +806,8 @@ class account_invoice(models.Model):
             if inv.move_id:
                 continue
 
-            ctx = dict(self._context, lang=inv.partner_id.lang)
+            ctx = dict(self._context, lang=inv.partner_id.lang,
+                       novalidate=True)
 
             company_currency = inv.company_id.currency_id
             if not inv.date_invoice:


### PR DESCRIPTION
[FIX] This fix will add a new key into the context sending `novalidate=True`
in order to avoid validation at Entry Lines creation When this method is run at
invoice (action_move_create) it commission the creation of Journal Entry Lines
at https://github.com/odoo/odoo/blob/8.0/addons/account/account_invoice.py#L938
where each line created is validated at
https://github.com/odoo/odoo/blob/8.0/addons/account/account_move_line.py#L1481
after all lines are created and glued their Journal Entry is posted at
https://github.com/odoo/odoo/blob/8.0/addons/account/account_invoice.py#L949
which in turn does another validation on all the previous Journal Items at
https://github.com/odoo/odoo/blob/8.0/addons/account/account.py#L1316
Therefore, when creating the Journal Entry for an invoice it is enough to do
one validate when posting the Journal Entry and skip the other validations at
creation time.