### PR TITLE
[FIX] odoo: Temporal patch to`support` spanish Latin America (es_419) lang

### DIFF
--- a/addons/im_livechat/controllers/main.py
+++ b/addons/im_livechat/controllers/main.py
@@ -75,7 +75,7 @@ class LivechatController(http.Controller):
         # if the user is identifiy (eg: portal user on the frontend), don't use the anonymous name. The user will be added to session.
         if request.session.uid:
             anonymous_name = request.env.user.name
-        return request.env["im_livechat.channel"].with_context(lang=False).get_mail_channel(channel_id, anonymous_name)
+        return request.env["im_livechat.channel"].get_mail_channel(channel_id, anonymous_name)
 
     @http.route('/im_livechat/feedback', type='json', auth='public')
     def feedback(self, uuid, rate, reason=None, **kwargs):

--- a/odoo/addons/base/ir/ir_translation.py
+++ b/odoo/addons/base/ir/ir_translation.py
@@ -350,6 +350,12 @@ class IrTranslation(models.Model):
 
         # create missing translations
         for res_id in set(ids) - set(existing_ids):
+            # TODO: Remove this ugly fix, needed because es_419 lang is not
+            # supported by odoo yet.
+            # Remove this section after issue
+            # https://github.com/odoo/odoo/issues/18363 be solved.
+            if lang == 'es_419':
+                lang = self.env.user.company_id.partner_id.lang or 'en_US'
             self.create({
                 'lang': lang,
                 'type': tt,


### PR DESCRIPTION
It was decided to do this patch when talking to @moylop260

FIX https://github.com/odoo/odoo/issues/18363

- [  ] TODO- Remove this ugly fix after issue
  https://github.com/odoo/odoo/issues/19920 be solved

  Odoo Ticket 775568

  Also reverted commit [FIX] im_livechat: unsupported locale
  https://github.com/odoo/odoo/commit/6879409723184ed360043b7a2da11fcd725e5c4f


DUMMY PR https://github.com/Vauxoo/abastotal/pull/416