### PR TITLE
[10.0][base_address_extended] FIX fields in address_format

### DIFF
--- a/addons/base_address_extended/models/base_address_extended.py
+++ b/addons/base_address_extended/models/base_address_extended.py
@@ -138,3 +138,9 @@ class Partner(models.Model):
             # /!\ Note that a write(vals) would cause a recursion since it would bypass the cache
             for k, v in vals.items():
                 partner[k] = v
+
+    @api.model
+    def _address_fields(self):
+        address_fields = super(Partner, self)._address_fields()
+        address_fields += ['street_name', 'street_number', 'street_number2']
+        return address_fields


### PR DESCRIPTION
This PR fix an issue when you try to use the new fields `'street_name', 'street_number' 'street_number2'`  in address_format from res.country you get error.