### PR TITLE
[REF] point_of_sale: avoid relating order with not complete invoice

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -496,13 +496,13 @@ class PosOrder(models.Model):
             new_invoice = Invoice.with_context(local_context).sudo().create(inv)
             message = _("This invoice has been created from the point of sale session: <a href=# data-oe-model=pos.order data-oe-id=%d>%s</a>") % (order.id, order.name)
             new_invoice.message_post(body=message)
-            order.write({'invoice_id': new_invoice.id, 'state': 'invoiced'})
             Invoice += new_invoice
 
             for line in order.lines:
                 self.with_context(local_context)._action_create_invoice_line(line, new_invoice.id)
 
             new_invoice.with_context(local_context).sudo().compute_taxes()
+            order.write({'invoice_id': new_invoice.id, 'state': 'invoiced'})
             order.sudo().write({'state': 'invoiced'})
             # this workflow signal didn't exist on account.invoice -> should it have been 'invoice_open' ? (and now method .action_invoice_open())
             # shouldn't the created invoice be marked as paid, seing the customer paid in the POS?


### PR DESCRIPTION
Change invoice_id after create invoice lines and not before. This is
because it can produce an error when there are actions on update
pos.order and the invoice is not complete.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:

https://github.com/odoo/odoo/pull/21334
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
