### PR TITLE
[FIX] website_sale_stock: product cart_qty without request

### DIFF
--- a/addons/website_sale_stock/models/product_product.py
+++ b/addons/website_sale_stock/models/product_product.py
@@ -11,7 +11,7 @@ class ProductProduct(models.Model):
     cart_qty = fields.Integer(compute='_compute_cart_qty')
 
     def _compute_cart_qty(self):
-        website = getattr(request, 'website', None)
+        website = request and getattr(request, 'website', None)
         if not website:
             return
         cart = website.sale_get_order()

--- a/doc/cla/corporate/vauxoo.md
+++ b/doc/cla/corporate/vauxoo.md
@@ -41,3 +41,4 @@ Mariano Fernandez mariano@vauxoo.com https://github.com/Batuto
 Edgar Rivero edgar@vauxoo.com https://github.com/egrivero
 Alexander Olivares alexander@vauxoo.com https://github.com/alxolivares
 Jose Manuel Robles josemanuel@vauxoo.com https://github.com/keylor2906
+Erick Birbe erick@vauxoo.com https://github.com/ebirbe


### PR DESCRIPTION
Reading product's `cart_qty` computed field directly with the XMLRPC API
failed because, in such case, the request is unbound.

Fixes #21530

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
