### PR TITLE
[FIX] purchase: Only use purchase UOM on vendor bill

### DIFF
--- a/addons/account/models/account_invoice.py
+++ b/addons/account/models/account_invoice.py
@@ -1314,9 +1314,6 @@ class AccountInvoiceLine(models.Model):
                 self.price_unit = 0.0
             domain['uom_id'] = []
         else:
-            # Use the purchase uom by default
-            self.uom_id = self.product_id.uom_po_id
-
             if part.lang:
                 product = self.product_id.with_context(lang=part.lang)
             else:

--- a/addons/purchase/models/account_invoice.py
+++ b/addons/purchase/models/account_invoice.py
@@ -59,6 +59,13 @@ class AccountInvoice(models.Model):
             data['account_id'] = account.id
         return data
 
+    def _onchange_product_id(self):
+        domain = super(AccountInvoice, self)._onchange_product_id()
+        if self.purchase_id:
+            # Use the purchase uom by default
+            self.uom_id = self.product_id.uom_po_id
+        return domain
+
     # Load all unsold PO lines
     @api.onchange('purchase_id')
     def purchase_order_change(self):


### PR DESCRIPTION
It was the purpose of this commit fea667a2433dfc2387daa7051989e840d30e18e0
However it uses purchase uom in any cases and not
only vendor bill.

This commit correct it by using it only if a purchase
order is linked to the invoice.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
