### PR TITLE
[IMP] Adding a new tag to allow the reporting of importation taxes

### DIFF
--- a/addons/l10n_mx/data/account_tax_data.xml
+++ b/addons/l10n_mx/data/account_tax_data.xml
@@ -18,6 +18,10 @@
         <field name="name">DIOT: 16%</field>
         <field name="applicability">taxes</field>
     </record>
+    <record id="tag_diot_16_imp" model="account.account.tag">
+        <field name="name">DIOT: 16% IMP</field>
+        <field name="applicability">taxes</field>
+    </record>
     <record id="tag_diot_0" model="account.account.tag">
         <field name="name">DIOT: 0%</field>
         <field name="applicability">taxes</field>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
As of today it is not possible to properly report importation taxes in the DIOT


Current behavior before PR:

Desired behavior after PR is merged:
Be able to allow the use the importation Tags for Importation Taxes

This PR is now addressed to odoo project @ https://github.com/odoo/odoo/pull/22405

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
