### PR TITLE
[IMP] account: Added in payment invoice related

### DIFF
--- a/addons/account/models/account_bank_statement.py
+++ b/addons/account/models/account_bank_statement.py
@@ -870,6 +870,7 @@ class AccountBankStatementLine(models.Model):
         company_currency = self.journal_id.company_id.currency_id
         statement_currency = self.journal_id.currency_id or company_currency
         st_line_currency = self.currency_id or statement_currency
+        invoice_ids = []
 
         counterpart_moves = self.env['account.move']
 
@@ -877,6 +878,8 @@ class AccountBankStatementLine(models.Model):
         if any(rec.statement_id for rec in payment_aml_rec):
             raise UserError(_('A selected move line was already reconciled.'))
         for aml_dict in counterpart_aml_dicts:
+            if aml_dict['move_line'].invoice_id:
+                invoice_ids.append(aml_dict['move_line'].invoice_id.id)
             if aml_dict['move_line'].reconciled:
                 raise UserError(_('A selected move line was already reconciled.'))
             if isinstance(aml_dict['move_line'], (int, long)):
@@ -933,6 +936,7 @@ class AccountBankStatementLine(models.Model):
                     'amount': abs(total),
                     'communication': self._get_communication(payment_methods[0] if payment_methods else False),
                     'name': self.statement_id.name,
+                    'invoice_ids': [(6, 0, invoice_ids)],
                 })
 
             # Complete dicts to create both counterpart move lines and write-offs


### PR DESCRIPTION
When I generate a payment directly from the invoice, this generate a
payment, and relate the invoice that is paid in that record, the same
when I use the option to pay many invoice from the invoice list view.

But when I generate the payment from the bank.statement, the payment
that is created with that process, do not assign the invoices that are
paid whit the statement.

Why I need the invoices related in all cases?

To the customer payments, is generated a CFDI document where are
indicated the invoices that are related with the payment, but when thw
process comes from bank.statement, this are not found.

The process to assign the invoices in the payment, do not affect Odoo
process, then We could have this records related.

Related with this Odoo PR https://github.com/odoo/odoo/pull/21532