### PR TITLE
[FIX] base: Avoid error when keep_query is not used in an httprequest context

### DIFF
--- a/odoo/addons/base/ir/ir_ui_view.py
+++ b/odoo/addons/base/ir/ir_ui_view.py
@@ -71,7 +71,7 @@ def keep_query(*keep_params, **additional_params):
     if not keep_params and not additional_params:
         keep_params = ('*',)
     params = additional_params.copy()
-    qs_keys = list(request.httprequest.args)
+    qs_keys = list(request.httprequest.args) if request else []
     for keep_param in keep_params:
         for param in fnmatch.filter(qs_keys, keep_param):
             if param not in additional_params and param in qs_keys:


### PR DESCRIPTION
When the utility method `keep_query()` is used outside an httprequest
context (e.g. rendering a template from a unittest) the following
exception is throwng:
`RuntimeError: object unbound`

The above exception is caused by the method trying to retrieve
parameters from the HTTP request, even if the request object is unbownd.

This change ensures those parameters are retrieved only when exists,
making possible to use it outside the web client

Closes #18841

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
