### PR TITLE
[FIX] web: Make top bar's menu items navigable when using the keyboard

### DIFF
--- a/addons/web/static/src/xml/base.xml
+++ b/addons/web/static/src/xml/base.xml
@@ -331,7 +331,7 @@
                 <t t-esc="section.label"/> <span class="caret"/>
             </button>
             <t t-if="section.name == 'buttons'" t-foreach="widget.items[section.name]" t-as="item" t-att-class="item.classname">
-                <a t-att-title="item.title or None" t-att-data-section="section.name" t-att-data-index="item_index" t-att-href="item.url" target="_blank">
+                <a t-att-title="item.title or None" t-att-data-section="section.name" t-att-data-index="item_index" t-att-href="item.url or '#'" target="_blank">
                     <t t-raw="item.label"/>
                 </a>
             </t>
@@ -353,7 +353,7 @@
                             <t t-raw="item.write_uid[1]"/>  <t t-esc="item.write_date_string"/>
                         </t>
                     </t>
-                    <a t-att-title="item.title or None" t-att-data-section="section.name" t-att-data-index="item_index" t-att-href="item.url">
+                    <a t-att-title="item.title or None" t-att-data-section="section.name" t-att-data-index="item_index" t-att-href="item.url or '#'">
                         <t t-raw="item.label"/>
                         <span t-if="section.name == 'files' and widget.options.editable and !item.callback" class="fa fa-trash-o o_sidebar_delete_attachment" t-att-data-id="item.id" title="Delete this attachment"/>
                     </a>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Sidebar's menu items are not currently reachable when using the
keyboard. 

Current behavior before PR:
Items are missing the attribute `href`, thus are not
indexed for tabbing navigation.

Desired behavior after PR is merged:
This change causes that attribute to be included, so the menu items are
reachable and navigable when using the keyboard.

Video showing the behavior before and after this patch:
https://youtu.be/G_IA3oczNog



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
