### PR TITLE
[IMP] l10n_mx: Added tax group to TAX not creditable

### DIFF
--- a/addons/l10n_mx/data/account_data.xml
+++ b/addons/l10n_mx/data/account_data.xml
@@ -24,6 +24,9 @@
         <record id="tax_group_ietu" model="account.tax.group">
             <field name="name">IETU</field>
         </record>
+        <record id="tax_group_iva_no_acreditable" model="account.tax.group">
+            <field name="name">IVA NO ACREDITABLE</field>
+        </record>
 
     </data>
 </odoo>


### PR DESCRIPTION
The DIOT report have the column to `TAX not creditable`, to allow detect
the lines that must be added in that column was added a new tax group.

The logic to add the new column is added in the corresponding module
`l10n_mx_reports`

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
