### PR TITLE
[REF] l10n_mx: changing account nature D > A, 802.02 Contra Cuenta CUFIN task#24558

### DIFF
--- a/addons/l10n_mx/data/account_tag_data.xml
+++ b/addons/l10n_mx/data/account_tag_data.xml
@@ -5399,7 +5399,7 @@
                 <field name='name'>802.02 Contra cuenta CUFIN</field>
                 <field name='color'>4</field>
                 <field name='applicability'>accounts</field>
-                <field name='nature'>D</field>
+                <field name='nature'>A</field>
             </record>
             <record id='account_tag_803_01' model='account.account.tag'>
                 <field name='name'>803.01 CUFIN de ejercicios anteriores</field>


### PR DESCRIPTION
The against CUFIN account (802.01 Contra Cuenta CUFIN) is showing in COA report as Debitable, it is expected to show as Creditable, as explained here:
 
![image](https://user-images.githubusercontent.com/5191766/39020418-c6db5ecc-43fa-11e8-9c5a-3bc4188bb67b.png)

To solve this:
- The file addons/l10n_mx/data/account_tag_data.xml was changed to make the account Creditable
![image](https://user-images.githubusercontent.com/5191766/39020488-0e0d9166-43fb-11e8-9610-6ec6141d13b7.png)
changing the nature code to 'A'


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
