### PR TITLE
[IMP] base: avoid hard-code the rate precision

### DIFF
--- a/odoo/addons/base/data/res_currency_data.xml
+++ b/odoo/addons/base/data/res_currency_data.xml
@@ -1545,6 +1545,11 @@
             <field name="currency_unit_label">Quetzal</field>
             <field name="currency_subunit_label">Centavo</field>
         </record>
+	
+	<record id="rate_precision" model="decimal.precision">
+            <field name="name">Rate Precision</field>
+            <field name="digits">6</field>
+        </record>
 
     </data>
 </odoo>

--- a/odoo/addons/base/models/res_currency.py
+++ b/odoo/addons/base/models/res_currency.py
@@ -8,6 +8,7 @@ import time
 import traceback
 
 from odoo import api, fields, models, tools, _
+from odoo.addons import decimal_precision as dp
 
 _logger = logging.getLogger(__name__)
 
@@ -246,7 +247,7 @@ class CurrencyRate(models.Model):
 
     name = fields.Date(string='Date', required=True, index=True,
                            default=lambda self: fields.Date.today())
-    rate = fields.Float(digits=(12, 6), default=1.0, help='The rate of the currency to the currency of rate 1')
+    rate = fields.Float(digits=dp.get_precision('Rate Precision'), default=1.0, help='The rate of the currency to the currency of rate 1')
     currency_id = fields.Many2one('res.currency', string='Currency', readonly=True)
     company_id = fields.Many2one('res.company', string='Company',
                                  default=lambda self: self.env.user.company_id)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
This change allows us to inherit the precision of the rate in a more cleaner way in the future.

Current behaviour before PR:
Using the banxico rate value of 20.4108, when dividing 1/20.4108 we get 0.048993.

Desired behaviour after PR is merged:
The expected value must be  0.048993670017

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
