### PR TITLE
[IMP] base: Constraint to not create bank accounts duplicated improved

### DIFF
--- a/odoo/addons/base/models/res_bank.py
+++ b/odoo/addons/base/models/res_bank.py
@@ -82,7 +82,7 @@ class ResPartnerBank(models.Model):
     qr_code_valid = fields.Boolean(string="Has all required arguments", compute="_validate_qr_code_arguments")
 
     _sql_constraints = [
-        ('unique_number', 'unique(sanitized_acc_number, company_id)', 'Account Number must be unique'),
+        ('unique_number', 'unique(sanitized_acc_number, partner_id, bank_id, company_id)', 'Account Number must be unique'),
     ]
 
     @api.depends('acc_number')


### PR DESCRIPTION
The restriction to do not allow create bank accounts duplicated
was improved, to allow have 2 bank accounts with the same account, but
to a different bank and partner.

With this improve now could be created the next structure:

Account | Bank | Partner | Company
-- | -- | -- | --
1234 | Bank of Mexico | Deco | Your Company
1234 | Bank of Mexico | Vauxoo | Your Company

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
