### PR TITLE
[12.0] account: don't set a journal_id if it has one already

### DIFF
--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -210,11 +210,12 @@ class account_abstract_payment(models.AbstractModel):
     def _onchange_currency(self):
         self.amount = abs(self._compute_payment_amount())
 
-        # Set by default the first liquidity journal having this currency if exists.
-        journal = self.env['account.journal'].search(
-            [('type', 'in', ('bank', 'cash')), ('currency_id', '=', self.currency_id.id)], limit=1)
-        if journal:
-            return {'value': {'journal_id': journal.id}}
+        if not self.journal_id:
+            # Set by default the first liquidity journal having this currency if exists.
+            journal = self.env['account.journal'].search(
+                [('type', 'in', ('bank', 'cash')), ('currency_id', '=', self.currency_id.id)], limit=1)
+            if journal:
+                return {'value': {'journal_id': journal.id}}
 
     @api.multi
     def _compute_payment_amount(self, invoices=None, currency=None):


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
If you have a journal linked to the account.payment for that view, then there is no need to change it.

**Current behavior before PR:**
If you set the currency_id with a domain to update the view and that journal is set a currency_id already, it will set another journal as default in the view

**Desired behavior after PR is merged:**
If there is a journal  already linked to that view, it will leave it like it is, otherwise, it will set a journal from a search related to the currency_id you are setting.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
