### PR TITLE
[FIX] l10n_mx: add new tag for tax of 8 %

### DIFF
--- a/addons/l10n_mx/data/account_data.xml
+++ b/addons/l10n_mx/data/account_data.xml
@@ -11,6 +11,10 @@
             <field name="name">IVA 16% </field>
         </record>
 
+        <record id="tax_group_iva_8" model="account.tax.group">
+            <field name="name">IVA 8%</field>
+        </record>
+
         <record id="tax_group_iva_ret_4" model="account.tax.group">
             <field name="name">IVA Retencion 4%</field>
         </record>

--- a/addons/l10n_mx/data/account_tax_data.xml
+++ b/addons/l10n_mx/data/account_tax_data.xml
@@ -194,5 +194,21 @@
         <field name="cash_basis_account_id" ref="cuenta118_01"/>
         <field name="tag_ids" eval="[(6,0,[ref('tag_diot_16')])]"/>
     </record>
+
+    <record id="tax16" model="account.tax.template">
+        <field name="chart_template_id" ref="mx_coa"/>
+        <field name="name">IVA(8%) COMPRAS</field>
+        <field name="description">IVA(8%)</field>
+        <field name="amount">8</field>
+        <field name="amount_type">percent</field>
+        <field name="type_tax_use">purchase</field>
+        <field name="account_id" ref="cuenta119_01"/>
+        <field name="refund_account_id" ref="cuenta119_01"/>
+        <field name="tax_group_id" ref="tax_group_iva_8"/>
+        <field name="tax_exigibility">on_payment</field>
+        <field name="cash_basis_base_account_id" ref="cuenta801_01_99"/>
+        <field name="cash_basis_account_id" ref="cuenta118_01"/>
+        <field name="tag_ids" eval="[(6,0,[ref('tag_diot_8')])]"/>
+    </record>
   </data>
 </odoo>

--- a/addons/l10n_mx/data/account_tax_data.xml
+++ b/addons/l10n_mx/data/account_tax_data.xml
@@ -30,6 +30,10 @@
         <field name="name">DIOT: 0%</field>
         <field name="applicability">taxes</field>
     </record>
+    <record id="tag_diot_8" model="account.account.tag">
+        <field name="name">DIOT: 8%</field>
+        <field name="applicability">taxes</field>
+    </record>
     <record id="tag_diot_ret" model="account.account.tag">
         <field name="name">DIOT: Retención</field>
         <field name="applicability">taxes</field>


### PR DESCRIPTION
Add a new tag of 8 % to be used in the new Mexican tax for the northern border zone, and in the DIOT report.

Related to https://github.com/Vauxoo/enterprise/pull/495

---------------------------------------------------------------------------------------------------------------------
The new tax reform of Mexico allows invoicing with a tax of 8 % in the northern border zone.

This reform consists in a reduction of 50% of the general rate (8% VAT), which will take effect on January 1, 2019.
Those who can enjoy the stimulus are the following:

* Taxpayers with fiscal residence in the northern border area of the country who carry out commercial operations within said strip with products authorized for the stimulus.
