### PR TITLE
[IMP] point_of_sale: improve vat validation

### DIFF
--- a/addons/base_vat/models/res_partner.py
+++ b/addons/base_vat/models/res_partner.py
@@ -66,7 +66,7 @@ class ResPartner(models.Model):
     _inherit = 'res.partner'
 
     def _split_vat(self, vat):
-        vat_country, vat_number = vat[:2].lower(), vat[2:].replace(' ', '')
+        vat_country, vat_number = vat[:2].lower(), vat[2:]
         return vat_country, vat_number
 
     @api.model


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
In pos if you put a space between the Type of VAT and the VAT code we can let the vat with the space to be validated, that's an error, we should let know the user that this VAT is wrong and display the help traceback

**Current behavior before PR:**
If you sabe a VAT **PER 20300166611** it will allow us, but the space between is wrong

**Desired behavior after PR is merged:**
Not allow spaces between the VAT

[![IMAGE DESCRIPTION](http://img.youtube.com/vi/xyvRKSxbAXk/maxresdefault.jpg)](https://youtu.be/xyvRKSxbAXk "Video description")


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
