### PR TITLE
[ADD] account: add charge notes

### DIFF
--- a/addons/account/tests/test_account_customer_invoice.py
+++ b/addons/account/tests/test_account_customer_invoice.py
@@ -338,3 +338,47 @@ class TestAccountCustomerInvoice(AccountTestUsers):
             dashboard_data = journal.get_journal_dashboard_datas()
             self.assertEquals(dashboard_data['number_late'], 2)
             self.assertIn('78.42', dashboard_data['sum_late'])
+
+    def test_charge_invoice(self):
+        """Create an invoice and then make an extra charge to that invoice"""
+        self.env.user.company_id.tax_calculation_rounding_method = 'round_globally'
+
+        payment_term = self.env.ref('account.account_payment_term_advance')
+        journalrec = self.env['account.journal'].search([('type', '=', 'sale')], limit=1)
+        partner3 = self.env.ref('base.res_partner_3')
+        account_id = self.env['account.account'].search([
+            ('user_type_id', '=', self.env.ref('account.data_account_type_revenue').id)], limit=1).id
+
+        invoice_line_data = [
+            (0, 0,
+                {
+                    'product_id': self.env.ref('product.product_product_1').id,
+                    'quantity': 40.0,
+                    'account_id': account_id,
+                    'name': 'product test 1',
+                    'price_unit': 2.27,
+                }
+             )
+        ]
+
+        invoice = self.env['account.invoice'].create({
+            'name': "Test Customer Invoice",
+            'payment_term_id': payment_term.id,
+            'journal_id': journalrec.id,
+            'partner_id': partner3.id,
+            'invoice_line_ids': invoice_line_data
+        })
+
+        invoice.action_invoice_open()
+        wizard = self.env['account.invoice.refund'].with_context(
+            {'active_ids': invoice.ids}).create({
+                'description': 'Charge for unfulfilled payment',
+                'date': datetime.date.today(),
+                'filter_refund': 'charge'
+            })
+        wizard.invoice_refund()
+        charge = self.env['account.invoice'].search([
+            ('origin', '=', invoice.move_name),
+            ('type', '=', 'out_invoice')
+        ])
+        self.assertTrue(charge, "There wasn't found a charge note.")

--- a/addons/account/views/account_invoice_view.xml
+++ b/addons/account/views/account_invoice_view.xml
@@ -264,7 +264,7 @@
                 <header>
                         <button name="action_invoice_open" type="object" states="draft" string="Validate" class="oe_highlight" groups="account.group_account_invoice"/>
                         <button name="%(action_account_invoice_payment)d" type="action" states="open" string="Register Payment" groups="account.group_account_invoice" class="oe_highlight"/>
-                        <button name="%(action_account_invoice_refund)d" type='action' string='Ask for a Credit Note' groups="account.group_account_invoice" attrs="{'invisible': ['|',('type', 'in', ['in_refund','out_refund']),('state','not in',('open','in_payment','paid'))]}"/>
+                        <button name="%(action_account_invoice_refund)d" type='action' string='Ask for a Credit Note' groups="account.group_account_invoice" attrs="{'invisible': ['|', '|',('type', 'in', ['in_refund','out_refund']),('state','not in',('open','in_payment','paid'))]}"/>
                         <button name="action_invoice_draft" states="cancel" string="Set to Draft" type="object" groups="account.group_account_invoice"/>
                     <field name="state" widget="statusbar" statusbar_visible="draft,open,paid" />
                 </header>
@@ -416,7 +416,7 @@
                             attrs="{'invisible': [('state', '!=', 'open')]}"
                             string="Register Payment" groups="account.group_account_invoice" class="oe_highlight"/>
                     <button name="action_invoice_open" type="object" states="draft" string="Validate" class="oe_highlight o_invoice_validate" groups="account.group_account_invoice"/>
-                    <button name="%(action_account_invoice_refund)d" type='action' string='Add Credit Note' groups="account.group_account_invoice" attrs="{'invisible': ['|',('type', '=', 'out_refund'), ('state', 'not in', ('open','in_payment','paid'))]}"/>
+                    <button name="%(action_account_invoice_refund)d" type='action' string='Add Credit Note' groups="account.group_account_invoice" attrs="{'invisible': ['|', '|', ('type', '=', 'out_refund'), ('state', 'not in', ('open','in_payment','paid'))]}"/>
                     <button name="preview_invoice" type="object" string="Preview"/>
                     <button name="action_invoice_draft" states="cancel" string="Reset to Draft" type="object" groups="account.group_account_invoice"/>
                     <field name="state" widget="statusbar" nolabel="1" statusbar_visible="draft,open,paid"/>

--- a/addons/account/wizard/account_invoice_refund_view.xml
+++ b/addons/account/wizard/account_invoice_refund_view.xml
@@ -30,6 +30,11 @@
                                 with the current invoice. A new draft invoice will be created
                                 so that you can edit it.
                              </div>
+                             <div attrs="{'invisible':['|',('refund_only','=',True),('filter_refund','!=','charge')]}" class="oe_grey" colspan="4">
+                                Use this options if you want to add another charge to an existing invoice.
+                                This charge can be due to extra costs after the previous agreement and you need
+                                to charge them to the customer.
+                             </div>
                          </group>
                          <group>
                              <field name="description"/>


### PR DESCRIPTION
### Description of the issue/feature this PR addresses:
A charge note is made when you need to add a charge to a transaction
after an agreement has been broken.

In Peru, we use charge notes in order to create an special charge for the other partner to pay for extra costs from a service/product sale. Usually, in other countries you create another invoice, but in peru it's recommended to create debit note when you need to charge extra to a user.

With this change we add this way, it's just an addition to the credit wizard.


### Examples

You give a discount to a customer and both agree that the payment is due
to the 15 of the following month.
The customer pays the 18 of the following month.
You can create a charge note for the amount in the discount.

The customer gives you a check.
One of your employees go to the bank to cash the check but the account
of the check has no money in it.
You can debit the amount of the total of the check plus a fee for the
expenses of the service.

You are selling big furniture, the client agrees that only will be
delivered to the doorstep.
Once you arrive the customer needs your crew to place the furniture
inside the house an that job takes several hours(or not but its extra
work).
You can charge this extra cost to the customer.

Note that most of this cases can be solved if we applied another invoice for
the cost, but in some countries of LATAM we can do this document or even
in some examples where the goods aren't billable we need to make this
document.



###  Current behavior before PR:
We don't have a charge note

### Desired behavior after PR is merged:
We will have a charge note







--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
