### PR TITLE
account: [FIX] `account.register.payments` model doesn't has attribute `has_invoices`

### DIFF
--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -195,7 +195,7 @@ class account_abstract_payment(models.AbstractModel):
     def _compute_journal_domain_and_types(self):
         journal_type = ['bank', 'cash']
         domain = []
-        if self.currency_id.is_zero(self.amount) and self.has_invoices:
+        if self.currency_id.is_zero(self.amount) and hasattr(self, "has_invoices") and self.has_invoices:
             # In case of payment with 0 amount, allow to select a journal of type 'general' like
             # 'Miscellaneous Operations' and set this journal by default.
             journal_type = ['general']


### PR DESCRIPTION
As `_compute_journal_domain_and_types` method is defined in an
abstract model it could be called by other models which could not bear
`has_invoices` field.