### PR TITLE
[FIX] payment, account: Consistent onchange on groups

### DIFF
--- a/addons/account/models/account.py
+++ b/addons/account/models/account.py
@@ -769,6 +769,7 @@ class AccountJournal(models.Model):
                 company = self.env['res.company'].browse(company_id)
                 account_vals = self._prepare_liquidity_account(vals.get('name'), company, vals.get('currency_id'), vals.get('type'))
                 default_account = self.env['account.account'].create(account_vals)
+                default_account.onchange_code()
                 vals['default_debit_account_id'] = default_account.id
                 vals['default_credit_account_id'] = default_account.id
 

--- a/addons/payment/models/payment_acquirer.py
+++ b/addons/payment/models/payment_acquirer.py
@@ -232,6 +232,7 @@ class PaymentAcquirer(models.Model):
         self.ensure_one()
         account_vals = self.company_id.chart_template_id._prepare_transfer_account_for_direct_creation(self.name, self.company_id)
         account = self.env['account.account'].create(account_vals)
+        account.onchange_code()
         inbound_payment_method_ids = []
         if self.token_implemented and self.payment_flow == 's2s':
             inbound_payment_method_ids.append((4, self.env.ref('payment.account_payment_method_electronic_in').id))


### PR DESCRIPTION
In order to be consistent, the onchange of the code should be triggered when an account is automatically created from a localization module, this save the job of sign by data such groups.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
