### PR TITLE
[ADD] l10n_pe: adding missing taxes

### DIFF
--- a/addons/l10n_pe/data/account_tax_data.xml
+++ b/addons/l10n_pe/data/account_tax_data.xml
@@ -15,6 +15,41 @@
         <field name="applicability">taxes</field>
     </record>
 
+    <record id="tax_tag_sale_ivap" model="account.account.tag">
+        <field name="name">IVAP Venta</field>
+        <field name="applicability">taxes</field>
+    </record>
+
+    <record id="tax_tag_sale_isc" model="account.account.tag">
+        <field name="name">ISC Venta</field>
+        <field name="applicability">taxes</field>
+    </record>
+
+    <record id="tax_tag_sale_exportation" model="account.account.tag">
+        <field name="name">EXPORTACIÓN Venta</field>
+        <field name="applicability">taxes</field>
+    </record>
+
+    <record id="tax_tag_sale_free" model="account.account.tag">
+        <field name="name">GRATUITO Venta</field>
+        <field name="applicability">taxes</field>
+    </record>
+
+    <record id="tax_tag_sale_exonerated" model="account.account.tag">
+        <field name="name">EXONERADO Venta</field>
+        <field name="applicability">taxes</field>
+    </record>
+
+    <record id="tax_tag_sale_inafected" model="account.account.tag">
+        <field name="name">INAFECTO Venta</field>
+        <field name="applicability">taxes</field>
+    </record>
+
+    <record id="tax_tag_sale_others" model="account.account.tag">
+        <field name="name">OTROS Venta</field>
+        <field name="applicability">taxes</field>
+    </record>
+
     <record id="ITAX_18" model="account.tax.template">
       <field name="chart_template_id" ref="pe_chart_template"/>
       <field name="name">IGV 18% Venta</field>
@@ -53,4 +88,90 @@
       <field name="tag_ids" eval="[(6,0,[ref('tax_tag_purchase_02')])]"/>
       <field name="tax_group_id" ref="tax_group_2"/>
     </record>
+
+    <record id="sale_tax_ivap_4" model="account.tax.template">
+        <field name="chart_template_id" ref="pe_chart_template"/>
+        <field name="name">IVAP 4% Venta</field>
+        <field name="description">IVAP 4%</field>
+        <field name="amount">4</field>
+        <field name="amount_type">percent</field>
+        <field name="type_tax_use">sale</field>
+        <field name="account_id" ref="401110"/>
+        <field name="refund_account_id" ref="401110"/>
+        <field name="tag_ids" eval="[(6,0,[ref('tax_tag_sale_ivap')])]"/>
+    </record>
+
+    <record id="sale_tax_isc_50" model="account.tax.template">
+        <field name="chart_template_id" ref="pe_chart_template"/>
+        <field name="name">ISC 50% Venta</field>
+        <field name="description">ISC 50%</field>
+        <field name="amount">50</field>
+        <field name="amount_type">percent</field>
+        <field name="price_include">False</field>
+        <field name="type_tax_use">sale</field>
+        <field name="tag_ids" eval="[(6,0,[ref('tax_tag_sale_isc')])]"/>
+        <field name="account_id" ref="401110"/>
+        <field name="refund_account_id" ref="401110"/>
+    </record>
+
+    <record id="sale_tax_exportation_17" model="account.tax.template">
+        <field name="chart_template_id" ref="pe_chart_template"/>
+        <field name="name">EXPORTACIÓN 17% Venta</field>
+        <field name="description">EXPORTACIÓN 17%</field>
+        <field name="amount">17</field>
+        <field name="amount_type">percent</field>
+        <field name="type_tax_use">sale</field>
+        <field name="account_id" ref="401110"/>
+        <field name="refund_account_id" ref="401110"/>
+        <field name="tag_ids" eval="[(6,0,[ref('tax_tag_sale_exportation')])]"/>
+    </record>
+
+    <record id="sale_tax_free_0" model="account.tax.template">
+        <field name="chart_template_id" ref="pe_chart_template"/>
+        <field name="name">FREE 0% Venta</field>
+        <field name="description">FREE 0%</field>
+        <field name="amount">0</field>
+        <field name="amount_type">percent</field>
+        <field name="type_tax_use">sale</field>
+        <field name="account_id" ref="401110"/>
+        <field name="refund_account_id" ref="401110"/>
+        <field name="tag_ids" eval="[(6,0,[ref('tax_tag_sale_free')])]"/>
+    </record>
+
+    <record id="sale_tax_exonerate_0" model="account.tax.template">
+        <field name="chart_template_id" ref="pe_chart_template"/>
+        <field name="name">EXONERADO 0% Venta</field>
+        <field name="description">EXONERADO 0%</field>
+        <field name="amount">0</field>
+        <field name="amount_type">percent</field>
+        <field name="type_tax_use">sale</field>
+        <field name="account_id" ref="401110"/>
+        <field name="refund_account_id" ref="401110"/>
+        <field name="tag_ids" eval="[(6,0,[ref('tax_tag_sale_exonerated')])]"/>
+    </record>
+
+    <record id="sale_tax_inafected_0" model="account.tax.template">
+        <field name="chart_template_id" ref="pe_chart_template"/>
+        <field name="name">INAFECTO 0% Venta</field>
+        <field name="description">INAFECTO 0%</field>
+        <field name="amount">0</field>
+        <field name="amount_type">percent</field>
+        <field name="type_tax_use">sale</field>
+        <field name="account_id" ref="401110"/>
+        <field name="refund_account_id" ref="401110"/>
+        <field name="tag_ids" eval="[(6,0,[ref('tax_tag_sale_inafected')])]"/>
+    </record>
+
+    <record id="sale_tax_others_30" model="account.tax.template">
+        <field name="chart_template_id" ref="pe_chart_template"/>
+        <field name="name">OTROS 30% Venta</field>
+        <field name="description">OTROS 30%</field>
+        <field name="amount">30</field>
+        <field name="amount_type">percent</field>
+        <field name="type_tax_use">sale</field>
+        <field name="account_id" ref="401110"/>
+        <field name="refund_account_id" ref="401110"/>
+        <field name="tag_ids" eval="[(6,0,[ref('tax_tag_sale_others')])]"/>
+    </record>
+
 </odoo>


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

Adding a new set of taxes to cover the cases that we are missing, and
adding the codes to identify the taxes.

Based on the information we find in http://cpe.sunat.gob.pe/sites/default/files/inline-files/AjustesValidacionesCPEv20180726.zip
We are adding the next data to create the taxes.

Catalog 5 Says that we must refer to the taxes in certain way with a
table:
Identifier code | UN/ECE 5153 | UN/ECE 5305
We are adding this values as a dictionary with just adding the tax code,
and the rest of the information can be stored with a compute



Current behavior before PR:
We don't have the taxes for special cases


Desired behavior after PR is merged:
We will have the taxes for special cases



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
