### PR TITLE
[ADD]l10n_mx: add new changes on COA according with the SAT

### DIFF
--- a/addons/l10n_mx/data/account_tag_data.xml
+++ b/addons/l10n_mx/data/account_tag_data.xml
@@ -2077,212 +2077,230 @@
                 <field name='applicability'>accounts</field>
                 <field name='nature'>A</field>
             </record>
+            <record id='account_tag_401_04_new' model='account.account.tag'>
+                <field name='name'>401.04 Ventas y/o servicios gravados realizados en zona fronteriza norte</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+                <field name='nature'>A</field>
+            </record>
+            <record id='account_tag_401_05_new' model='account.account.tag'>
+                <field name='name'>401.05 Ventas y/o servicios gravados realizados en zona fronteriza norte de contado</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+                <field name='nature'>A</field>
+            </record>
+            <record id='account_tag_401_06_new' model='account.account.tag'>
+                <field name='name'>401.06 Ventas y/o servicios gravados realizados en zona fronteriza norte a crédito</field>
+                <field name='color'>4</field>
+                <field name='applicability'>accounts</field>
+                <field name='nature'>A</field>
+            </record>
             <record id='account_tag_401_04' model='account.account.tag'>
-                <field name='name'>401.04 Ventas y/o servicios gravados al 0%</field>
+                <field name='name'>401.07 Ventas y/o servicios gravados al 0%</field>
                 <field name='color'>4</field>
                 <field name='applicability'>accounts</field>
                 <field name='nature'>A</field>
             </record>
             <record id='account_tag_401_05' model='account.account.tag'>
-                <field name='name'>401.05 Ventas y/o servicios gravados al 0% de contado</field>
+                <field name='name'>401.08 Ventas y/o servicios gravados al 0% de contado</field>
                 <field name='color'>4</field>
                 <field name='applicability'>accounts</field>
                 <field name='nature'>A</field>
             </record>
             <record id='account_tag_401_06' model='account.account.tag'>
-                <field name='name'>401.06 Ventas y/o servicios gravados al 0% a crédito</field>
+                <field name='name'>401.09 Ventas y/o servicios gravados al 0% a crédito</field>
                 <field name='color'>4</field>
                 <field name='applicability'>accounts</field>
                 <field name='nature'>A</field>
             </record>
             <record id='account_tag_401_07' model='account.account.tag'>
-                <field name='name'>401.07 Ventas y/o servicios exentos</field>
+                <field name='name'>401.10 Ventas y/o servicios exentos</field>
                 <field name='color'>4</field>
                 <field name='applicability'>accounts</field>
                 <field name='nature'>A</field>
             </record>
             <record id='account_tag_401_08' model='account.account.tag'>
-                <field name='name'>401.08 Ventas y/o servicios exentos de contado</field>
+                <field name='name'>401.11 Ventas y/o servicios exentos de contado</field>
                 <field name='color'>4</field>
                 <field name='applicability'>accounts</field>
                 <field name='nature'>A</field>
             </record>
             <record id='account_tag_401_09' model='account.account.tag'>
-                <field name='name'>401.09 Ventas y/o servicios exentos a crédito</field>
+                <field name='name'>401.12 Ventas y/o servicios exentos a crédito</field>
                 <field name='color'>4</field>
                 <field name='applicability'>accounts</field>
                 <field name='nature'>A</field>
             </record>
             <record id='account_tag_401_10' model='account.account.tag'>
-                <field name='name'>401.10 Ventas y/o servicios gravados a la tasa general nacionales partes relacionadas</field>
+                <field name='name'>401.13 Ventas y/o servicios gravados a la tasa general nacionales partes relacionadas</field>
                 <field name='color'>4</field>
                 <field name='applicability'>accounts</field>
                 <field name='nature'>A</field>
             </record>
             <record id='account_tag_401_11' model='account.account.tag'>
-                <field name='name'>401.11 Ventas y/o servicios gravados a la tasa general extranjeros partes relacionadas</field>
+                <field name='name'>401.14 Ventas y/o servicios gravados a la tasa general extranjeros partes relacionadas</field>
                 <field name='color'>4</field>
                 <field name='applicability'>accounts</field>
                 <field name='nature'>A</field>
             </record>
             <record id='account_tag_401_12' model='account.account.tag'>
-                <field name='name'>401.12 Ventas y/o servicios gravados al 0% nacionales partes relacionadas</field>
+                <field name='name'>401.15 Ventas y/o servicios gravados al 0% nacionales partes relacionadas</field>
                 <field name='color'>4</field>
                 <field name='applicability'>accounts</field>
                 <field name='nature'>A</field>
             </record>
             <record id='account_tag_401_13' model='account.account.tag'>
-                <field name='name'>401.13 Ventas y/o servicios gravados al 0% extranjeros partes relacionadas</field>
+                <field name='name'>401.16 Ventas y/o servicios gravados al 0% extranjeros partes relacionadas</field>
                 <field name='color'>4</field>
                 <field name='applicability'>accounts</field>
                 <field name='nature'>A</field>
             </record>
             <record id='account_tag_401_14' model='account.account.tag'>
-                <field name='name'>401.14 Ventas y/o servicios exentos nacionales partes relacionadas</field>
+                <field name='name'>401.17 Ventas y/o servicios exentos nacionales partes relacionadas</field>
                 <field name='color'>4</field>
                 <field name='applicability'>accounts</field>
                 <field name='nature'>A</field>
             </record>
             <record id='account_tag_401_15' model='account.account.tag'>
-                <field name='name'>401.15 Ventas y/o servicios exentos extranjeros partes relacionadas</field>
+                <field name='name'>401.18 Ventas y/o servicios exentos extranjeros partes relacionadas</field>
                 <field name='color'>4</field>
                 <field name='applicability'>accounts</field>
                 <field name='nature'>A</field>
             </record>
             <record id='account_tag_401_16' model='account.account.tag'>
-                <field name='name'>401.16 Ingresos por servicios administrativos</field>
+                <field name='name'>401.19 Ingresos por servicios administrativos</field>
                 <field name='color'>4</field>
                 <field name='applicability'>accounts</field>
                 <field name='nature'>A</field>
             </record>
             <record id='account_tag_401_17' model='account.account.tag'>
-                <field name='name'>401.17 Ingresos por servicios administrativos nacionales partes relacionadas</field>
+                <field name='name'>401.20 Ingresos por servicios administrativos nacionales partes relacionadas</field>
                 <field name='color'>4</field>
                 <field name='applicability'>accounts</field>
                 <field name='nature'>A</field>
             </record>
             <record id='account_tag_401_18' model='account.account.tag'>
-                <field name='name'>401.18 Ingresos por servicios administrativos extranjeros partes relacionadas</field>
+                <field name='name'>401.21 Ingresos por servicios administrativos extranjeros partes relacionadas</field>
                 <field name='color'>4</field>
                 <field name='applicability'>accounts</field>
                 <field name='nature'>A</field>
             </record>
             <record id='account_tag_401_19' model='account.account.tag'>
-                <field name='name'>401.19 Ingresos por servicios profesionales</field>
+                <field name='name'>401.22 Ingresos por servicios profesionales</field>
                 <field name='color'>4</field>
                 <field name='applicability'>accounts</field>
                 <field name='nature'>A</field>
             </record>
             <record id='account_tag_401_20' model='account.account.tag'>
-                <field name='name'>401.20 Ingresos por servicios profesionales nacionales partes relacionadas</field>
+                <field name='name'>401.23 Ingresos por servicios profesionales nacionales partes relacionadas</field>
                 <field name='color'>4</field>
                 <field name='applicability'>accounts</field>
                 <field name='nature'>A</field>
             </record>
             <record id='account_tag_401_21' model='account.account.tag'>
-                <field name='name'>401.21 Ingresos por servicios profesionales extranjeros partes relacionadas</field>
+                <field name='name'>401.24 Ingresos por servicios profesionales extranjeros partes relacionadas</field>
                 <field name='color'>4</field>
                 <field name='applicability'>accounts</field>
                 <field name='nature'>A</field>
             </record>
             <record id='account_tag_401_22' model='account.account.tag'>
-                <field name='name'>401.22 Ingresos por arrendamiento</field>
+                <field name='name'>401.25 Ingresos por arrendamiento</field>
                 <field name='color'>4</field>
                 <field name='applicability'>accounts</field>
                 <field name='nature'>A</field>
             </record>
             <record id='account_tag_401_23' model='account.account.tag'>
-                <field name='name'>401.23 Ingresos por arrendamiento nacionales partes relacionadas</field>
+                <field name='name'>401.26 Ingresos por arrendamiento nacionales partes relacionadas</field>
                 <field name='color'>4</field>
                 <field name='applicability'>accounts</field>
                 <field name='nature'>A</field>
             </record>
             <record id='account_tag_401_24' model='account.account.tag'>
-                <field name='name'>401.24 Ingresos por arrendamiento extranjeros partes relacionadas</field>
+                <field name='name'>401.27 Ingresos por arrendamiento extranjeros partes relacionadas</field>
                 <field name='color'>4</field>
                 <field name='applicability'>accounts</field>
                 <field name='nature'>A</field>
             </record>
             <record id='account_tag_401_25' model='account.account.tag'>
-                <field name='name'>401.25 Ingresos por exportación</field>
+                <field name='name'>401.28 Ingresos por exportación</field>
                 <field name='color'>4</field>
                 <field name='applicability'>accounts</field>
                 <field name='nature'>A</field>
             </record>
             <record id='account_tag_401_26' model='account.account.tag'>
-                <field name='name'>401.26 Ingresos por comisiones</field>
+                <field name='name'>401.29 Ingresos por comisiones</field>
                 <field name='color'>4</field>
                 <field name='applicability'>accounts</field>
                 <field name='nature'>A</field>
             </record>
             <record id='account_tag_401_27' model='account.account.tag'>
-                <field name='name'>401.27 Ingresos por maquila</field>
+                <field name='name'>401.30 Ingresos por maquila</field>
                 <field name='color'>4</field>
                 <field name='applicability'>accounts</field>
                 <field name='nature'>A</field>
             </record>
             <record id='account_tag_401_28' model='account.account.tag'>
-                <field name='name'>401.28 Ingresos por coordinados</field>
+                <field name='name'>401.31 Ingresos por coordinados</field>
                 <field name='color'>4</field>
                 <field name='applicability'>accounts</field>
                 <field name='nature'>A</field>
             </record>
             <record id='account_tag_401_29' model='account.account.tag'>
-                <field name='name'>401.29 Ingresos por regalías</field>
+                <field name='name'>401.32 Ingresos por regalías</field>
                 <field name='color'>4</field>
                 <field name='applicability'>accounts</field>
                 <field name='nature'>A</field>
             </record>
             <record id='account_tag_401_30' model='account.account.tag'>
-                <field name='name'>401.30 Ingresos por asistencia técnica</field>
+                <field name='name'>401.33 Ingresos por asistencia técnica</field>
                 <field name='color'>4</field>
                 <field name='applicability'>accounts</field>
                 <field name='nature'>A</field>
             </record>
             <record id='account_tag_401_31' model='account.account.tag'>
-                <field name='name'>401.31 Ingresos por donativos</field>
+                <field name='name'>401.34 Ingresos por donativos</field>
                 <field name='color'>4</field>
                 <field name='applicability'>accounts</field>
                 <field name='nature'>A</field>
             </record>
             <record id='account_tag_401_32' model='account.account.tag'>
-                <field name='name'>401.32 Ingresos por intereses (actividad propia)</field>
+                <field name='name'>401.35 Ingresos por intereses (actividad propia)</field>
                 <field name='color'>4</field>
                 <field name='applicability'>accounts</field>
                 <field name='nature'>A</field>
             </record>
             <record id='account_tag_401_33' model='account.account.tag'>
-                <field name='name'>401.33 Ingresos de copropiedad</field>
+                <field name='name'>401.36 Ingresos de copropiedad</field>
                 <field name='color'>4</field>
                 <field name='applicability'>accounts</field>
                 <field name='nature'>A</field>
             </record>
             <record id='account_tag_401_34' model='account.account.tag'>
-                <field name='name'>401.34 Ingresos por fideicomisos</field>
+                <field name='name'>401.37 Ingresos por fideicomisos</field>
                 <field name='color'>4</field>
                 <field name='applicability'>accounts</field>
                 <field name='nature'>A</field>
             </record>
             <record id='account_tag_401_35' model='account.account.tag'>
-                <field name='name'>401.35 Ingresos por factoraje financiero</field>
+                <field name='name'>401.38 Ingresos por factoraje financiero</field>
                 <field name='color'>4</field>
                 <field name='applicability'>accounts</field>
                 <field name='nature'>A</field>
             </record>
             <record id='account_tag_401_36' model='account.account.tag'>
-                <field name='name'>401.36 Ingresos por arrendamiento financiero</field>
+                <field name='name'>401.39 Ingresos por arrendamiento financiero</field>
                 <field name='color'>4</field>
                 <field name='applicability'>accounts</field>
                 <field name='nature'>A</field>
             </record>
             <record id='account_tag_401_37' model='account.account.tag'>
-                <field name='name'>401.37 Ingresos de extranjeros con establecimiento en el país</field>
+                <field name='name'>401.40 Ingresos de extranjeros con establecimiento en el país</field>
                 <field name='color'>4</field>
                 <field name='applicability'>accounts</field>
                 <field name='nature'>A</field>
             </record>
             <record id='account_tag_401_38' model='account.account.tag'>
-                <field name='name'>401.38 Otros ingresos propios</field>
+                <field name='name'>401.41 Otros ingresos propios</field>
                 <field name='color'>4</field>
                 <field name='applicability'>accounts</field>
                 <field name='nature'>A</field>


### PR DESCRIPTION
New account tags were added to use with the incoming of the northern border
zone of Mexico

These changes were announced in the new [Annex 24 RFM 2019](https://www.sat.gob.mx/cs/Satellite?blobcol=urldata&blobkey=id&blobtable=MungoBlobs&blobwhere=1461173688346&ssbinary=true) and define the new accounts for the northern border zone. This change affects a part of the CoA because these accounts are added in the middle instead of at the end of the group.

**Before:**
![Screenshot(1)](https://user-images.githubusercontent.com/19410285/58216980-98318480-7cce-11e9-9c18-40ff8e04407a.png)

**After:**
![Screenshot](https://user-images.githubusercontent.com/19410285/58216981-99fb4800-7cce-11e9-9be6-5327dcb4ccb0.png)

