### PR TITLE
[FIX] res_currency: fix label of Peru currency label

### DIFF
--- a/odoo/addons/base/data/res_currency_data.xml
+++ b/odoo/addons/base/data/res_currency_data.xml
@@ -1470,7 +1470,7 @@
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="position">before</field>
-            <field name="currency_unit_label">Inti</field>
+            <field name="currency_unit_label">Sol</field>
             <field name="currency_subunit_label">Centimes</field>
         </record>
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
The inti, currency of peru has been depleted by the Peru SOL, or SOL, this PR is just to update that label

https://www.xe.com/currency/pen-peruvian-sol



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
