### PR TITLE
[FIX] hr_expense: Correct states are used in the payment_mode field

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -65,7 +65,7 @@ class HrExpense(models.Model):
     payment_mode = fields.Selection([
         ("own_account", "Employee (to reimburse)"),
         ("company_account", "Company")
-    ], default='own_account', states={'done': [('readonly', True)], 'post': [('readonly', True)], 'submitted': [('readonly', True)]}, string="Paid By")
+    ], default='own_account', states={'done': [('readonly', True)], 'approved': [('readonly', True)], 'reported': [('readonly', True)]}, string="Paid By")
     attachment_number = fields.Integer('Number of Attachments', compute='_compute_attachment_number')
     state = fields.Selection([
         ('draft', 'To Submit'),


### PR DESCRIPTION
The [states](https://github.com/odoo/odoo/blob/12.0/addons/hr_expense/models/hr_expense.py#L70) in the expense are:
- draft
- reported
- approved
- done
- refused

Then, in the `payment_mode` field must be used that options.

Without this change, use states that are not in the expenses.





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
