### PR TITLE
[ADD] l10n_pe: Adding perception's data

### DIFF
--- a/addons/l10n_pe/data/account_tax_data.xml
+++ b/addons/l10n_pe/data/account_tax_data.xml
@@ -53,4 +53,35 @@
       <field name="tag_ids" eval="[(6,0,[ref('tax_tag_purchase_02')])]"/>
       <field name="tax_group_id" ref="tax_group_2"/>
     </record>
+
+    <record id="tax_group_perceptions" model="account.tax.group">
+        <field name="name">Percepciones</field>
+    </record>
+
+    <record id="sale_tax_intern_sale_perception" model="account.tax">
+      <field name="name">Percepción Venta Interna (Porcentaje 2%)</field>
+      <field name="description">Percepción Venta Interna (Porcentaje 2%)</field>
+      <field name="amount">2</field>
+      <field name="amount_type">percent</field>
+      <field name="type_tax_use">sale</field>
+      <field name="tax_group_id" ref="tax_group_perceptions"/>
+    </record>
+
+    <record id="sale_tax_perception_fuel" model="account.tax">
+      <field name="name">Percepción a la adquisición de combustible (Porcentaje 1%)</field>
+      <field name="description">Percepción a la adquisición de combustible (Porcentaje 1%)</field>
+      <field name="amount">1</field>
+      <field name="amount_type">percent</field>
+      <field name="type_tax_use">sale</field>
+      <field name="tax_group_id" ref="tax_group_perceptions"/>
+    </record>
+
+    <record id="sale_tax_perception_agent" model="account.tax">
+      <field name="name">Percepción realizada al agente de percepción con tasa especial (Porcentaje 0.5%)</field>
+      <field name="description">Percepción realizada al agente de percepción con tasa especial (Porcentaje 0.5%)</field>
+      <field name="amount">0.5</field>
+      <field name="amount_type">percent</field>
+      <field name="type_tax_use">sale</field>
+      <field name="tax_group_id" ref="tax_group_perceptions"/>
+    </record>
 </odoo>


### PR DESCRIPTION
Description of this PR:
Adding perception's data as taxes, this data is part of the catalogs 22 and 53 from SUNAT, so we can have this information to add the support for Perceptions

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr