### PR TITLE
[IMP] l10n_pe, base_vat: improve interaction with l10n_latam*

### DIFF
--- a/addons/base_vat/models/res_partner.py
+++ b/addons/base_vat/models/res_partner.py
@@ -326,37 +326,30 @@ class ResPartner(models.Model):
     # Peruvian VAT validation, contributed by Vauxoo
     def check_vat_pe(self, vat):
 
-        vat_type, vat = vat and len(vat) >= 2 and (vat[0], vat[1:]) or (False, False)
-
-        if vat_type and vat_type.upper() == 'D':
-            # DNI
+        if len(vat) != 11:
+            # DNI or any other document in Peru
             return True
-        elif vat_type and vat_type.upper() == 'R':
-            # verify RUC
-            factor = '5432765432'
-            sum = 0
-            dig_check = False
-            if len(vat) != 11:
-                return False
-            try:
-                int(vat)
-            except ValueError:
-                return False
-
-            for f in range(0, 10):
-                sum += int(factor[f]) * int(vat[f])
-
-            subtraction = 11 - (sum % 11)
-            if subtraction == 10:
-                dig_check = 0
-            elif subtraction == 11:
-                dig_check = 1
-            else:
-                dig_check = subtraction
-
-            return int(vat[10]) == dig_check
-        else:
+        # verify RUC
+        factor = '5432765432'
+        sum = 0
+        dig_check = False
+        try:
+            int(vat)
+        except ValueError:
             return False
+
+        for f in range(0, 10):
+            sum += int(factor[f]) * int(vat[f])
+
+        subtraction = 11 - (sum % 11)
+        if subtraction == 10:
+            dig_check = 0
+        elif subtraction == 11:
+            dig_check = 1
+        else:
+            dig_check = subtraction
+
+        return int(vat[10]) == dig_check
 
     # VAT validation in Turkey, contributed by # Levent Karakas @ Eska Yazilim A.S.
     def check_vat_tr(self, vat):

--- a/addons/base_vat/tests/__init__.py
+++ b/addons/base_vat/tests/__init__.py
@@ -1,0 +1,2 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from . import test_validate_ruc

--- a/addons/base_vat/tests/test_validate_ruc.py
+++ b/addons/base_vat/tests/test_validate_ruc.py
@@ -1,0 +1,16 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo.tests import common
+from odoo.exceptions import ValidationError
+
+
+class TestRUCStructure(common.TransactionCase):
+
+    def test_peru_ruc_format(self):
+        """Only values that has the length of 11 will be checked as RUC, that's what we are proving. The second part
+        will check for a valid ruc and there will be no problem at all.
+        """
+        partner = self.env['res.partner'].create({'name': "Dummy partner", 'country_id': self.env.ref('base.pe').id})
+
+        with self.assertRaises(ValidationError):
+            partner.vat = '11111111111'
+        partner.vat = '20507822470'

--- a/addons/l10n_latam_invoice_document/models/account_move.py
+++ b/addons/l10n_latam_invoice_document/models/account_move.py
@@ -153,7 +153,8 @@ class AccountMove(models.Model):
                 lambda x: x.internal_type == internal_type) or document_types
 
             rec.l10n_latam_available_document_type_ids = document_types
-            rec.l10n_latam_document_type_id = document_type and document_type[0]
+            if not rec.l10n_latam_document_type_id:
+                rec.l10n_latam_document_type_id = document_type and document_type[0]
         remaining = self - recs_with_journal_partner
         remaining.l10n_latam_available_document_type_ids = []
         remaining.l10n_latam_document_type_id = False

--- a/addons/l10n_pe/__manifest__.py
+++ b/addons/l10n_pe/__manifest__.py
@@ -11,6 +11,7 @@
         'base_address_extended',
         'base_address_city',
         'l10n_latam_base',
+        'l10n_latam_invoice_document',
     ],
     'data': [
         'security/ir.model.access.csv',

--- a/addons/l10n_pe/data/account_tax_data.xml
+++ b/addons/l10n_pe/data/account_tax_data.xml
@@ -121,7 +121,7 @@
         <field name="name">0% Exonerated</field>
         <field name="description">EXO</field>
         <field name="l10n_pe_edi_tax_code">9997</field>
-        <field name="l10n_pe_edi_unece_category">E</field>
+        <field name="l10n_pe_edi_unece_category">S</field>
         <field name="amount">0.0</field>
         <field name="type_tax_use">sale</field>
         <field name="sequence">1</field>

--- a/addons/l10n_pe/data/account_tax_data.xml
+++ b/addons/l10n_pe/data/account_tax_data.xml
@@ -121,7 +121,7 @@
         <field name="name">0% Exonerated</field>
         <field name="description">EXO</field>
         <field name="l10n_pe_edi_tax_code">9997</field>
-        <field name="l10n_pe_edi_unece_category">S</field>
+        <field name="l10n_pe_edi_unece_category">E</field>
         <field name="amount">0.0</field>
         <field name="type_tax_use">sale</field>
         <field name="sequence">1</field>

--- a/addons/l10n_pe/models/__init__.py
+++ b/addons/l10n_pe/models/__init__.py
@@ -1,8 +1,9 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from . import account_tax
 from . import account_move
+from . import account_journal
+from . import account_chart_template
 from . import l10n_latam_identification_type
 from . import res_partner
 from . import res_city_district
 from . import res_city
-

--- a/addons/l10n_pe/models/__init__.py
+++ b/addons/l10n_pe/models/__init__.py
@@ -7,3 +7,4 @@ from . import l10n_latam_identification_type
 from . import res_partner
 from . import res_city_district
 from . import res_city
+from . import res_company

--- a/addons/l10n_pe/models/account_chart_template.py
+++ b/addons/l10n_pe/models/account_chart_template.py
@@ -1,0 +1,15 @@
+from odoo import models
+
+
+class AccountChartTemplate(models.Model):
+
+    _inherit = 'account.chart.template'
+
+    def _prepare_all_journals(self, acc_template_ref, company, journals_dict=None):
+        """ If Peruvian chart, we don't create sales journal as we need more data to create it properly """
+        journals = super()._prepare_all_journals(acc_template_ref, company, journals_dict=journals_dict)
+        if company.country_id == self.env.ref('base.pe'):
+            for journal in journals:
+                if journal['type'] == 'sale':
+                    journal.update({'l10n_latam_use_documents': True})
+        return journals

--- a/addons/l10n_pe/models/account_chart_template.py
+++ b/addons/l10n_pe/models/account_chart_template.py
@@ -11,5 +11,7 @@ class AccountChartTemplate(models.Model):
         if company.country_id == self.env.ref('base.pe'):
             for journal in journals:
                 if journal['type'] == 'sale':
-                    journal.update({'l10n_latam_use_documents': True})
+                    journal.update({'l10n_latam_use_documents': True,
+                                    'default_debit_account_id': self.env.ref('l10n_pe.chart1213').id,
+                                    'default_credit_account_id': self.env.ref('l10n_pe.chart1213').id})
         return journals

--- a/addons/l10n_pe/models/account_journal.py
+++ b/addons/l10n_pe/models/account_journal.py
@@ -1,0 +1,16 @@
+from odoo import models, api
+
+
+class AccountJournal(models.Model):
+    _inherit = "account.journal"
+
+    @api.model
+    def _get_sequence_prefix(self, code, refund=False):
+        """For peruvian companies we can not use sequences with **/** due to the edi generation which need in the
+        sequence a plain text ended by a *-* and the length of this prefix"""
+        if self.env.company.country_id != self.env.ref('base.pe'):
+            return super()._get_sequence_prefix(code, refund=refund)
+        prefix = code.upper()
+        if refund:
+            prefix = 'R' + prefix[:-1]
+        return prefix + '-'

--- a/addons/l10n_pe/models/account_tax.py
+++ b/addons/l10n_pe/models/account_tax.py
@@ -46,7 +46,9 @@ class AccountTaxTemplate(models.Model):
         ('G', 'Free export item, tax not charged'),
         ('O', 'Services outside scope of tax'),
         ('S', 'Standard rate'),
-        ('Z', 'Zero rated goods')], 'EDI UNECE code',
+        ('Z', 'Zero rated goods'),
+        ('VAT', 'General Sales Tax'),
+    ], 'EDI UNECE code',
         help="Follow the UN/ECE 5305 standard from the United Nations Economic Commission for Europe for more "
              "information  http://www.unece.org/trade/untdid/d08a/tred/tred5305.htm"
     )

--- a/addons/l10n_pe/models/res_company.py
+++ b/addons/l10n_pe/models/res_company.py
@@ -1,0 +1,13 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo import models, api
+
+
+class ResCompany(models.Model):
+
+    _inherit = "res.company"
+
+    @api.onchange('country_id')
+    def onchange_country(self):
+        """In Peru, the rounding method it's calculated as global"""
+        for rec in self.filtered(lambda x: x.country_id == self.env.ref('base.pe')):
+            rec.tax_calculation_rounding_method = 'round_globally'


### PR DESCRIPTION
Description of the issue/feature this PR addresses:


First, l10n_pe does not need to have base_vat, we are adding the
dependency l10n_latam_base, there is the dependency of base_vat.

Second, base_vat does not need to check the structure and letters of the
VAT because we are already adding a field for the type of document in
l10n_latam_base(l10n_latam_identification_type_id), this field does what
the logic in the module did before.

Now, all the future developments should only use the VAT and
l10n_latam_identification_type_id and not split_vat, that method is no
longer useful is we use the latam modules.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
