### PR TITLE
[FIX] account: Payment widget was using invoice date instead of payment date

### DIFF
--- a/addons/account/models/account_invoice.py
+++ b/addons/account/models/account_invoice.py
@@ -216,7 +216,7 @@ class AccountInvoice(models.Model):
                 amount_to_show = amount_currency
             else:
                 currency = payment.company_id.currency_id
-                amount_to_show = currency._convert(amount, self.currency_id, payment.company_id, self.date or fields.Date.today())
+                amount_to_show = currency._convert(amount, self.currency_id, payment.company_id, payment.date or fields.Date.today())
             if float_is_zero(amount_to_show, precision_rounding=self.currency_id.rounding):
                 continue
             payment_ref = payment.move_id.name


### PR DESCRIPTION
[FIX] account: Payment widget was using invoice date instead of payment date

It should be the same way as residual computes the payments.
- Checking Oustanding Widget
Prior reconciliation this is how the Outstanding widget looks like. In the widget outstanding payment is depicted as `USD 28.46` that is `546.52` divided by rate at `2019-06-12` (`19.2040`). This looks good.
![](https://user-images.githubusercontent.com/7598010/65439017-21c3a100-ddec-11e9-86cf-b78f3c09147e.png)
- Add Invoice F002 to F003. After payment is applied widget shows the payment as `USD 28.79`. Something weird has happened. `1,935.72 - 28.79 != 1,907.26`. Amount Due minus payment applied according to widget: `1,935.72 - 28.79 = 1,906.93`. Invoice residual is still computed according to Outstanding computation of payment: `1,935.72 - 1,907.26 = 28.46`.
![](https://user-images.githubusercontent.com/7598010/65439166-5b94a780-ddec-11e9-92c9-e8a4ad666230.png)
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
