### PR TITLE
[FIX] sale: traceback when choosing a product with warning as order.line. vx#35058

### DIFF
--- a/addons/sale/models/sale.py
+++ b/addons/sale/models/sale.py
@@ -1073,6 +1073,18 @@ class SaleOrderLine(models.Model):
 
         result = {'domain': domain}
 
+        name = product.name_get()[0][1]
+        if product.description_sale:
+            name += '\n' + product.description_sale
+
+        vals['name'] = name
+
+        self._compute_tax_id()
+
+        if self.order_id.pricelist_id and self.order_id.partner_id:
+            vals['price_unit'] = self.env['account.tax']._fix_tax_included_price_company(self._get_display_price(product), product.taxes_id, self.tax_id, self.company_id)
+        self.update(vals)
+
         title = False
         message = False
         warning = {}
@@ -1084,18 +1096,6 @@ class SaleOrderLine(models.Model):
             result = {'warning': warning}
             if product.sale_line_warn == 'block':
                 self.product_id = False
-                return result
-
-        name = product.name_get()[0][1]
-        if product.description_sale:
-            name += '\n' + product.description_sale
-        vals['name'] = name
-
-        self._compute_tax_id()
-
-        if self.order_id.pricelist_id and self.order_id.partner_id:
-            vals['price_unit'] = self.env['account.tax']._fix_tax_included_price_company(self._get_display_price(product), product.taxes_id, self.tax_id, self.company_id)
-        self.update(vals)
 
         return result
 


### PR DESCRIPTION
If a user chooses a product that has a blocking error message, the product
is set to False. This is good, but we do not want the following to
happen:

When a blocking message is configured on a product, we force the removal
of the `product_id` on the SO line. This causes a problem in method
`name_get()` and name of the product with sudo fails to search for it.
Only work with admin user

We move the `product_id` removal at the end of the onchange.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
