### PR TITLE
[FIX] sale: blocking message

### DIFF
--- a/addons/sale/models/sale.py
+++ b/addons/sale/models/sale.py
@@ -1073,6 +1073,17 @@ class SaleOrderLine(models.Model):
 
         result = {'domain': domain}
 
+        name = product.name_get()[0][1]
+        if product.description_sale:
+            name += '\n' + product.description_sale
+        vals['name'] = name
+
+        self._compute_tax_id()
+
+        if self.order_id.pricelist_id and self.order_id.partner_id:
+            vals['price_unit'] = self.env['account.tax']._fix_tax_included_price_company(self._get_display_price(product), product.taxes_id, self.tax_id, self.company_id)
+        self.update(vals)
+
         title = False
         message = False
         warning = {}
@@ -1084,18 +1095,6 @@ class SaleOrderLine(models.Model):
             result = {'warning': warning}
             if product.sale_line_warn == 'block':
                 self.product_id = False
-                return result
-
-        name = product.name_get()[0][1]
-        if product.description_sale:
-            name += '\n' + product.description_sale
-        vals['name'] = name
-
-        self._compute_tax_id()
-
-        if self.order_id.pricelist_id and self.order_id.partner_id:
-            vals['price_unit'] = self.env['account.tax']._fix_tax_included_price_company(self._get_display_price(product), product.taxes_id, self.tax_id, self.company_id)
-        self.update(vals)
 
         return result
 


### PR DESCRIPTION
Backport of odoo/odoo#31456

When a blocking message is configured on a product, we force the removal
of the `product_id` on the SO line. This causes a problem in the method
`_get_display_price`. When the price list is configured with
`discount_policy != with_discount`, `get_product_price_rule` is called
with an empty `self.product_id`.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
