### PR TITLE
[IMP] Taking away company_id mandatory field on Analytic Accounts

### DIFF
--- a/addons/analytic/models/analytic_account.py
+++ b/addons/analytic/models/analytic_account.py
@@ -52,7 +52,7 @@ class AccountAnalyticAccount(models.Model):
     tag_ids = fields.Many2many('account.analytic.tag', 'account_analytic_account_tag_rel', 'account_id', 'tag_id', string='Tags', copy=True)
     line_ids = fields.One2many('account.analytic.line', 'account_id', string="Analytic Lines")
 
-    company_id = fields.Many2one('res.company', string='Company', required=True, default=lambda self: self.env.user.company_id)
+    company_id = fields.Many2one('res.company', string='Company', required=False, default=lambda self: self.env['res.company'])
 
     # use auto_join to speed up name_search call
     partner_id = fields.Many2one('res.partner', string='Customer', auto_join=True, track_visibility='onchange')


### PR DESCRIPTION
This PR takes away the mandatory field in the company_id for the analytic account 
https://github.com/odoo/odoo/blob/11.0/addons/analytic/models/analytic_account.py#L55


to make similar to that of the v12 where that restriction no longer exists
https://github.com/odoo/odoo/blob/12.0/addons/analytic/models/analytic_account.py#L132

So far this will be used as `dirty-patch` in patches.txt in deployed projects.

Why?

If this dirty patch is not applied the field company_id is repopulated again when doing -u all -d DB.
with the company_id of the user doing the full update, admin's company this is not advisable.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
