### PR TITLE
[IMP] Compacting the creation of Journal Lines for CABA base lines.

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -1662,10 +1662,49 @@ class AccountPartialReconcile(models.Model):
             # probably already sent to the estate.
             newly_created_move.write({'date': move_date})
 
+    def _get_tax_cash_basis_hash(self, tax, move, line):
+        account_id = self._get_tax_cash_basis_base_account(line, tax)
+        return (move.id, account_id.id, tax.id, line.currency_id.id, line.partner_id.id)
+
+    def _get_tax_cash_basis_base_line(self, key, new_move):
+        move, account_id, tax, currency_id, partner_id = key
+        move = self.env['account.move'].browse(move)
+        return {
+            'name': move.name,
+            'account_id': account_id,
+            'tax_exigible': True,
+            'tax_ids': [(6, 0, [tax])],
+            'move_id': new_move.id,
+            'currency_id': currency_id,
+            'partner_id': partner_id,
+        }
+
+    def _create_tax_cash_basis_base_line(self, keys, amount_dict, amount_currency_dict, new_move):
+        for key in keys:
+            base_line = self._get_tax_cash_basis_base_line(key, new_move)
+            currency_id = base_line.get('currency_id', False)
+            rounded_amt = amount_dict[key]
+            amount_currency = amount_currency_dict[key] if currency_id else 0.0
+            aml_obj = self.env['account.move.line'].with_context(check_move_validity=False)
+            aml_obj.create(dict(
+                base_line,
+                debit=rounded_amt > 0 and rounded_amt or 0.0,
+                credit=rounded_amt < 0 and abs(rounded_amt) or 0.0,
+                amount_currency=amount_currency))
+            aml_obj.create(dict(
+                base_line,
+                credit=rounded_amt > 0 and rounded_amt or 0.0,
+                debit=rounded_amt < 0 and abs(rounded_amt) or 0.0,
+                amount_currency=-amount_currency,
+                tax_ids=[]))
+
     def create_tax_cash_basis_entry(self, percentage_before_rec):
         self.ensure_one()
         move_date = self.debit_move_id.date
         newly_created_move = self.env['account.move']
+        caba_amount_dict = {}
+        caba_amount_currency_dict = {}
+        caba_keys = set()
         with self.env.norecompute():
             # We use a set here in case the reconciled lines belong to the same move (it happens with POS)
             for move in {self.debit_move_id.move_id, self.credit_move_id.move_id}:
@@ -1723,34 +1762,20 @@ class AccountPartialReconcile(models.Model):
                                 to_clear_aml.reconcile()
 
                         if any([tax.tax_exigibility == 'on_payment' for tax in line.tax_ids]):
-                            if not newly_created_move:
-                                newly_created_move = self._create_tax_basis_move()
                             #create cash basis entry for the base
                             for tax in line.tax_ids.filtered(lambda t: t.tax_exigibility == 'on_payment'):
-                                account_id = self._get_tax_cash_basis_base_account(line, tax)
-                                self.env['account.move.line'].with_context(check_move_validity=False).create({
-                                    'name': line.name,
-                                    'debit': rounded_amt > 0 and rounded_amt or 0.0,
-                                    'credit': rounded_amt < 0 and abs(rounded_amt) or 0.0,
-                                    'account_id': account_id.id,
-                                    'tax_exigible': True,
-                                    'tax_ids': [(6, 0, [tax.id])],
-                                    'move_id': newly_created_move.id,
-                                    'currency_id': line.currency_id.id,
-                                    'amount_currency': self.amount_currency and line.currency_id.round(line.amount_currency * amount / line.balance) or 0.0,
-                                    'partner_id': line.partner_id.id,
-                                })
-                                self.env['account.move.line'].with_context(check_move_validity=False).create({
-                                    'name': line.name,
-                                    'credit': rounded_amt > 0 and rounded_amt or 0.0,
-                                    'debit': rounded_amt < 0 and abs(rounded_amt) or 0.0,
-                                    'account_id': account_id.id,
-                                    'tax_exigible': True,
-                                    'move_id': newly_created_move.id,
-                                    'currency_id': line.currency_id.id,
-                                    'amount_currency': self.amount_currency and line.currency_id.round(-line.amount_currency * amount / line.balance) or 0.0,
-                                    'partner_id': line.partner_id.id,
-                                })
+                                key = self._get_tax_cash_basis_hash(tax, move, line)
+                                caba_keys.add(key)
+                                caba_amount_dict.setdefault(key, 0)
+                                caba_amount_dict[key] += rounded_amt
+                                caba_amount_currency_dict.setdefault(key, 0)
+                                caba_amount_currency_dict[key] += line.currency_id.round(line.amount_currency * amount / line.balance) if line.currency_id and self.amount_currency else 0.0
+
+            if caba_keys:
+                if not newly_created_move:
+                    newly_created_move = self._create_tax_basis_move()
+                # create cash basis entry for the base
+                self._create_tax_cash_basis_base_line(caba_keys, caba_amount_dict, caba_amount_currency_dict, newly_created_move)
         self.recompute()
         if newly_created_move:
             self._set_tax_cash_basis_entry_date(move_date, newly_created_move)


### PR DESCRIPTION
Main
-
- Configure Tax base on payment.
- Have one invoice with one hundred lines
- Pay the invoice, be it partial or in full, it doesn't matter.
- Check the CABA entry created:
Chances are that the Journal Entry will end up having:
-- 1 Entry line per tax collected.
-- 1 Entry line per tax to be collected.
-- 200 Entry lines for the base.

Odoo does not economize on resources when creating CABA Entries.

This PR deals with the creation of a more Slimmed way of creating the CABA Entries.
After this PR you will end up with 

-- 1 Entry line per tax collected.
-- 1 Entry line per tax to be collected.
-- 2 Entry lines for the base, one debit, one credit.

chances are that this could be increased but the algorithm tries only to group by a set of keys.

Regards.

YouTube
-

https://youtu.be/njXJDJLOFWc

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
