### PR TITLE
[FIX] account: Better Wording at button_cancel() method

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -359,7 +359,8 @@ class AccountMove(models.Model):
     def button_cancel(self):
         for move in self:
             if not move.journal_id.update_posted:
-                raise UserError(_('You cannot modify a posted entry of this journal.\nFirst you should set the journal to allow cancelling entries.'))
+                err_msg = _('Journal name (id): %s (%s)') % (move.journal_id.name, str(move.journal_id.id))
+                raise UserError(_('You cannot modify a posted entry of this journal.\nFirst you should set the journal to allow cancelling entries.\n%s.') % err_msg)
             # We remove all the analytics entries for this journal
             move.mapped('line_ids.analytic_line_ids').unlink()
         if self.ids:


### PR DESCRIPTION
When Unposting several Journal Entries with button_cancel() method there
could be some JE that cannot be unposted but information provide gives
no clue on which journal entry the UserError arises.

# Note.
This is for patches.txt usage only

Odoo Patch
-

https://github.com/odoo/odoo/pull/43515 (closed)

No master PR has been made because master method was cleaned/refactored no raises were left.

new method button_draft() is the one standing.

A new proposal is to be made

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
