### PR TITLE
[FIX] Multi-currency reconciliation could fetch values from different records

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -910,7 +910,7 @@ class AccountMoveLine(models.Model):
                     # temp_amount_residual_currency back to local currency.
                     def virtual_conversion(virtual_residual_currency, temp_residual, amount_residual, currency_id):
                         res = amount_residual * temp_residual / virtual_residual_currency
-                        res = amount_residual if float_compare(amount_residual, res, precision_rounding=currency_id.rounding) == 1 else currency_id.round(res)
+                        res = amount_residual if float_compare(amount_residual, res, precision_rounding=currency_id.rounding) == 0 else currency_id.round(res)
                         return res
                     currency = debit_move.currency_id or credit_move.currency_id
                     if not debit_move.currency_id and not float_is_zero(debit_move.amount_residual, precision_rounding=currency.rounding):

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -939,7 +939,9 @@ class AccountMoveLine(models.Model):
                 # in that secondary currency in the partial reconciliation. That allows the exchange difference entry
                 # to be created, in case it is needed. It also allows to compute the amount residual in foreign currency.
                 currency = debit_move.currency_id or credit_move.currency_id
-                currency_date = debit_move.currency_id and credit_move.date or debit_move.date
+                # /!\ NOTE: We need to be consistent with value that is computed at the APR record.
+                # Hence, so far currency_date is to be equal to max_date in APR.
+                currency_date = max(credit_move.date, debit_move.date)
                 amount_reconcile_currency = company_currency._convert(amount_reconcile, currency, debit_move.company_id, currency_date)
                 currency = currency.id
 

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -891,6 +891,7 @@ class AccountMoveLine(models.Model):
         cash_basis_percentage_before_rec = {}
         dc_vals ={}
         while (debit_moves and credit_moves):
+            debit_to_remove = credit_to_remove = self.env['account.move.line']
             debit_move = debit_moves[0]
             credit_move = credit_moves[0]
             company_currency = debit_move.company_id.currency_id
@@ -913,6 +914,7 @@ class AccountMoveLine(models.Model):
                         return res
                     currency = debit_move.currency_id or credit_move.currency_id
                     if not debit_move.currency_id and not float_is_zero(debit_move.amount_residual, precision_rounding=currency.rounding):
+                        debit_to_remove = debit_move
                         virtual_residual_currency = company_currency._convert(debit_move.amount_residual, currency, debit_move.company_id, debit_move.date)
                         temp_amount_residual_currency = min(virtual_residual_currency, -credit_move.amount_residual_currency)
                         temp_amount_residual = virtual_conversion(virtual_residual_currency, temp_amount_residual_currency, debit_move.amount_residual, currency)
@@ -922,6 +924,7 @@ class AccountMoveLine(models.Model):
                             (temp_amount_residual_currency, debit_move.amount_residual),
                             (-credit_move.amount_residual_currency, -credit_move.amount_residual))
                     elif not credit_move.currency_id and not float_is_zero(credit_move.amount_residual, precision_rounding=currency.rounding):
+                        credit_to_remove = credit_move
                         virtual_residual_currency = company_currency._convert(-credit_move.amount_residual, currency, credit_move.company_id, credit_move.date)
                         temp_amount_residual_currency = min(debit_move.amount_residual_currency, virtual_residual_currency)
                         temp_amount_residual = virtual_conversion(virtual_residual_currency, temp_amount_residual_currency, -credit_move.amount_residual, currency)
@@ -947,12 +950,16 @@ class AccountMoveLine(models.Model):
             else:
                 debit_moves[0].amount_residual -= temp_amount_residual
                 debit_moves[0].amount_residual_currency -= temp_amount_residual_currency
+                debit_moves -= debit_to_remove
 
             if amount_reconcile == -credit_move[field]:
                 credit_moves -= credit_move
             else:
                 credit_moves[0].amount_residual += temp_amount_residual
                 credit_moves[0].amount_residual_currency += temp_amount_residual_currency
+                credit_moves -= credit_to_remove
+
+            # /!\ NOTE: This code section can be moved upwards in a later time to avoid redundancy of code.
             #Check for the currency and amount_currency we can set
             currency = False
             amount_reconcile_currency = 0

--- a/addons/account/tests/test_reconciliation.py
+++ b/addons/account/tests/test_reconciliation.py
@@ -2032,9 +2032,10 @@ class TestReconciliationExec(TestReconciliation):
         tax_waiting_line = invoice.move_id.line_ids.filtered(lambda l: l.account_id == self.tax_waiting_account)
         self.assertFalse(tax_waiting_line.reconciled)
 
-        move_caba0 = tax_waiting_line.matched_debit_ids.debit_move_id.move_id
+        # /!\ NOTE: There could be two account.partial.reconcile records
+        # `matched_debit_ids` one for the CABA entry and one for the FX entry.
+        move_caba0 = tax_waiting_line.mapped('matched_debit_ids.debit_move_id.move_id').filtered(lambda x: x.journal_id == self.env.user.company_id.tax_cash_basis_journal_id)
         self.assertTrue(move_caba0.exists())
-        self.assertEqual(move_caba0.journal_id, self.env.user.company_id.tax_cash_basis_journal_id)
 
         pay_receivable_line0 = payment0.move_line_ids.filtered(lambda l: l.account_id == self.account_rcv)
         self.assertTrue(pay_receivable_line0.reconciled)

--- a/addons/account/tests/test_reconciliation.py
+++ b/addons/account/tests/test_reconciliation.py
@@ -2466,7 +2466,7 @@ class TestReconciliationExec(TestReconciliation):
         self.assertEquals(inv1_receivable.full_reconcile_id, payment_receivable.full_reconcile_id)
 
         exchange_rcv = inv1_receivable.full_reconcile_id.exchange_move_id.line_ids.filtered(lambda l: l.account_id.internal_type == 'receivable')
-        self.assertEqual(exchange_rcv.amount_currency, 0.01)
+        self.assertEqual(exchange_rcv.amount_currency, 0.00)
 
         self.assertTrue(inv1.reconciled)
         self.assertTrue(inv2.reconciled)
@@ -2670,7 +2670,7 @@ class TestReconciliationExec(TestReconciliation):
         self.assertEqual(move_balance_receiv.full_reconcile_id, inv1_receivable.full_reconcile_id)
 
         exchange_rcv = inv1_receivable.full_reconcile_id.exchange_move_id.line_ids.filtered(lambda l: l.account_id.internal_type == 'receivable')
-        self.assertEqual(exchange_rcv.amount_currency, 0.01)
+        self.assertEqual(exchange_rcv.amount_currency, 0.00)
 
         self.assertTrue(inv1.reconciled)
 


### PR DESCRIPTION
Before
-

Before this commit when reconciling multi-currency Journal Items
with different rates and the amount_residual goes down and the
amount_currency_residual goes up as in this example:

Line:   | amount_residual_currency | amount_residual | currency | rate| reconciled
-|-|-|-|-|-
Debit:                 |  1,000.00      |  20,000.00     |  USD | 20.00     |  False
Credit:                |   -900.00     |  -22,500.00      | USD | 25.00      | False

Led to fetch the values as:
    - temp_amount_residual_currency = 900.00
    - temp_amount_residual = 20,000.00

And in doing so it was fetching values from two different records. In
the case of the payment (Credit) though fully consumed was not being
marked as reconciled as depicted here:

Line:   | amount_residual_currency | amount_residual | currency | rate| reconciled
-|-|-|-|-|-
Debit:                   | 100.00            | 0.00      | USD | 20.00      | False
Credit:                   |   0.00       | -2,500.00     |  USD |  25.00     |  False

This has the effect of leaving both of the lines marked as not reconciled.
And account.payment record is kept showing the "smart button".

After
-
After this commit when reconciling multi-currency Journal Items
with different rates and the amount_residual goes down and the
amount_currency_residual goes up as in this example:

Line:   | amount_residual_currency | amount_residual | currency | rate| reconciled
-|-|-|-|-|-
Debit:                  | 1,000.00       | 20,000.00     |  USD |  20.00     |  False
Credit:                  | -900.00      | -22,500.00     |  USD | 25.00     |  False

The fetched values for the following variables will be like:
    - temp_amount_residual_currency = 900.00
    - temp_amount_residual = 22,500.00

As both values are fetched from the same record. In
the case of the payment (Credit), it is fully consumed in both fields
and it is marked as reconciled as depicted here:

Line:   | amount_residual_currency | amount_residual | currency | rate| reconciled
-|-|-|-|-|-
Debit:                   |  100.00      |  -2,500.00      | USD | 20.00     |  False
Credit:                  |    0.00           |  0.00      | USD|  25.00       | True

This has the effect of leaving the account.payment record marked as reconciled

Another good side effect is that the carrying exchange difference is
transferred to the outstanding value that could later be reconciled as
the payment won't be included in the reconciliation any longer.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr