### PR TITLE
[IMP] account: Unlinking Journal Entries & ItemsSpeedUp

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -375,28 +375,26 @@ class AccountMove(models.Model):
 
     @api.multi
     def unlink(self):
-        for move in self:
-            #check the lock date + check if some entries are reconciled
-            move.line_ids._update_check()
-            move.line_ids.unlink()
+        self.mapped('line_ids').unlink()
         return super(AccountMove, self).unlink()
 
     @api.multi
     def _post_validate(self):
-        for move in self:
-            if move.line_ids:
-                if not all([x.company_id.id == move.company_id.id for x in move.line_ids]):
-                    raise UserError(_("Cannot create moves for different companies."))
+        for move in self.filtered(lambda x: x.line_ids):
+            if not all([x.company_id.id == move.company_id.id for x in move.line_ids]):
+                raise UserError(_("Cannot create moves for different companies."))
         self.assert_balanced()
         return self._check_lock_date()
 
     @api.multi
     def _check_lock_date(self):
-        for move in self:
-            lock_date = max(move.company_id.period_lock_date or date.min, move.company_id.fiscalyear_lock_date or date.min)
+        for company_id in self.mapped('company_id'):
+            lock_date = max(company_id.period_lock_date or date.min, company_id.fiscalyear_lock_date or date.min)
             if self.user_has_groups('account.group_account_manager'):
-                lock_date = move.company_id.fiscalyear_lock_date
-            if move.date <= (lock_date or date.min):
+                lock_date = company_id.fiscalyear_lock_date or date.min
+            # /!\ NOTE: For this company_id let us fetch only company's JE and let us find out which is one is the most
+            # critical JE, i.e., the minimum date
+            if min(self.filtered(lambda x: x.company_id == company_id).mapped('date')) <= (lock_date or date.min):
                 if self.user_has_groups('account.group_account_manager'):
                     message = _("You cannot add/modify entries prior to and inclusive of the lock date %s") % (lock_date)
                 else:
@@ -1245,13 +1243,10 @@ class AccountMoveLine(models.Model):
     @api.multi
     def unlink(self):
         self._update_check()
-        move_ids = set()
-        for line in self:
-            if line.move_id.id not in move_ids:
-                move_ids.add(line.move_id.id)
+        move_ids = self.mapped('move_id').ids
         result = super(AccountMoveLine, self).unlink()
         if self._context.get('check_move_validity', True) and move_ids:
-            self.env['account.move'].browse(list(move_ids))._post_validate()
+            self.env['account.move'].browse(move_ids)._post_validate()
         return result
 
     @api.multi
@@ -1290,16 +1285,16 @@ class AccountMoveLine(models.Model):
     @api.multi
     def _update_check(self):
         """ Raise Warning to cause rollback if the move is posted, some entries are reconciled or the move is older than the lock date"""
-        move_ids = set()
-        for line in self:
-            err_msg = _('Move name (id): %s (%s)') % (line.move_id.name, str(line.move_id.id))
-            if line.move_id.state != 'draft':
-                raise UserError(_('You cannot do this modification on a posted journal entry, you can just change some non legal fields. You must revert the journal entry to cancel it.\n%s.') % err_msg)
-            if line.reconciled and not (line.debit == 0 and line.credit == 0):
-                raise UserError(_('You cannot do this modification on a reconciled entry. You can just change some non legal fields or you must unreconcile first.\n%s.') % err_msg)
-            if line.move_id.id not in move_ids:
-                move_ids.add(line.move_id.id)
-        self.env['account.move'].browse(list(move_ids))._check_lock_date()
+        err_msg = _('Move name (id): %s (%s)')
+        line = self.search([('id', 'in', self.ids), ('move_id.state', '!=', 'draft'),], limit=1)
+        if line:
+            err_msg = err_msg % (line.move_id.name, str(line.move_id.id))
+            raise UserError(_('You cannot do this modification on a posted journal entry, you can just change some non legal fields. You must revert the journal entry to cancel it.\n%s.') % err_msg)
+        line = self.search(['&', '&', ('id', 'in', self.ids), ('reconciled', '=', True), '!', '&', ('debit', '=', 0), ('credit', '=', 0),], limit=1)
+        if line:
+            err_msg = err_msg % (line.move_id.name, str(line.move_id.id))
+            raise UserError(_('You cannot do this modification on a reconciled entry. You can just change some non legal fields or you must unreconcile first.\n%s.') % err_msg)
+        self.env['account.move'].browse(self.mapped('move_id').ids)._check_lock_date()
         return True
 
     ####################################################


### PR DESCRIPTION
while unlinking Journal Entries & Journal Items several
checks are made all over the records. Some of the checks were O(2) Other
were quite repetitive and could be achieved without for loops.

This change was profiled with a method where the amount of Journal Entries to unlink was huge

Profiling Before Change
-

```txt
Wrote profile results to odoo-bin.lprof
Timer unit: 1e-06 s

Total time: 442.567 s
File: /home/odoo/instance/extra_addons/mexico/l10n_mx_avoid_reversal_entry/models/account_move.py
Function: unlink at line 24

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
    24                                               @profile
    25                                               def unlink(self):
    26                                                   """ When removing a partial reconciliation, also unlink its full
    27                                                   reconciliation if it exists.
    28                                                   This Method will un-post and delete the journal entry from the Tax Cash
    29                                                   Basis
    30                                                   """
    31         1          3.0      3.0      0.0          mxn_moves = self.filtered(
    32         1     196591.0 196591.0      0.0              lambda r: r.company_id.country_id == self.env.ref('base.mx'))
    33         1        204.0    204.0      0.0          res = super(AccountPartialReconcile, self - mxn_moves).unlink()
    34         1          2.0      2.0      0.0          if not mxn_moves:
    35                                                       return res
    36         1          0.0      0.0      0.0          partial_to_unlink = mxn_moves
    37         1       4003.0   4003.0      0.0          full_to_unlink = mxn_moves.mapped('full_reconcile_id')
    38                                                   # delete the tax basis move created at the reconciliation time
    39         1          8.0      8.0      0.0          move_ids = self.env['account.move'].search(
    40         1     105200.0 105200.0      0.0              [('tax_cash_basis_rec_id', 'in', partial_to_unlink.ids)])
    41                                                   # Journal entries from tax cash might include reconciliations
    42         1    1238383.0 1238383.0      0.3          full_to_unlink |= move_ids.mapped('line_ids.full_reconcile_id')
    43                                                   # include deletion of exchange rate journal entries
    44         1      20218.0  20218.0      0.0          move_ids |= full_to_unlink.mapped('exchange_move_id')
    45         1     116628.0 116628.0      0.0          partial_to_unlink |= move_ids.mapped('line_ids.matched_debit_ids')
    46         1     105482.0 105482.0      0.0          partial_to_unlink |= move_ids.mapped('line_ids.matched_credit_ids')
    47         1  103877598.0 103877598.0     23.5          full_to_unlink.unlink()
    48         1  124704173.0 124704173.0     28.2          res = super(models.Model, partial_to_unlink).unlink()
    49         1     367724.0 367724.0      0.1          move_ids.button_cancel()
    50         1  211830586.0 211830586.0     47.9          move_ids.unlink()
    51         1          2.0      2.0      0.0          return res
```

Profiling After Change
-


```text
Total time: 296.742 s
File: /home/odoo/instance/extra_addons/mexico/l10n_mx_avoid_reversal_entry/models/account_move.py
Function: unlink at line 24

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
    24                                               @profile
    25                                               def unlink(self):
    26                                                   """ When removing a partial reconciliation, also unlink its full
    27                                                   reconciliation if it exists.
    28                                                   This Method will un-post and delete the journal entry from the Tax Cash
    29                                                   Basis
    30                                                   """
    31         1          3.0      3.0      0.0          mxn_moves = self.filtered(
    32         1     219655.0 219655.0      0.1              lambda r: r.company_id.country_id == self.env.ref('base.mx'))
    33         1        244.0    244.0      0.0          res = super(AccountPartialReconcile, self - mxn_moves).unlink()
    34         1          2.0      2.0      0.0          if not mxn_moves:
    35                                                       return res
    36         1          1.0      1.0      0.0          partial_to_unlink = mxn_moves
    37         1       4889.0   4889.0      0.0          full_to_unlink = mxn_moves.mapped('full_reconcile_id')
    38                                                   # delete the tax basis move created at the reconciliation time
    39         1          9.0      9.0      0.0          move_ids = self.env['account.move'].search(
    40         1     109466.0 109466.0      0.0              [('tax_cash_basis_rec_id', 'in', partial_to_unlink.ids)])
    41                                                   # Journal entries from tax cash might include reconciliations
    42         1    1233309.0 1233309.0      0.4          full_to_unlink |= move_ids.mapped('line_ids.full_reconcile_id')
    43                                                   # include deletion of exchange rate journal entries
    44         1      20228.0  20228.0      0.0          move_ids |= full_to_unlink.mapped('exchange_move_id')
    45         1     117773.0 117773.0      0.0          partial_to_unlink |= move_ids.mapped('line_ids.matched_debit_ids')
    46         1     104843.0 104843.0      0.0          partial_to_unlink |= move_ids.mapped('line_ids.matched_credit_ids')
    47         1  104409680.0 104409680.0     35.2          full_to_unlink.unlink()
    48         1  125515446.0 125515446.0     42.3          res = super(models.Model, partial_to_unlink).unlink()
    49         1     334507.0 334507.0      0.1          move_ids.button_cancel()
    50         1   64672246.0 64672246.0     21.8          move_ids.unlink()
    51         1          2.0      2.0      0.0          return res
```

Results
-

||Before|After|
|-|-:|-:|
|Total time|442.567 s|296.742 s|

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
