### PR TITLE
12.0 - [IMP] website: perf - add cache for website frequent fields - Backport of 6d6b5055 v14.0

### DIFF
--- a/addons/website/models/ir_http.py
+++ b/addons/website/models/ir_http.py
@@ -82,8 +82,7 @@ class Http(models.AbstractModel):
         if not request.session.uid:
             env = api.Environment(request.cr, SUPERUSER_ID, request.context)
             website = env['website'].get_current_website()
-            if website and website.user_id:
-                request.uid = website.user_id.id
+            request.uid = website and website._get_cached('user_id')
         if not request.uid:
             super(Http, cls)._auth_method_public()
 
@@ -131,7 +130,7 @@ class Http(models.AbstractModel):
     @classmethod
     def _get_default_lang(cls):
         if getattr(request, 'website', False):
-            return request.website.default_lang_id
+            return request.env['res.lang'].browse(request.website._get_cached('default_lang_id'))
         return super(Http, cls)._get_default_lang()
 
     @classmethod

--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -277,6 +277,18 @@ class Website(models.Model):
     def guess_mimetype(self):
         return _guess_mimetype()
 
+    @tools.ormcache('self.id')
+    def _get_cached_values(self):
+        self.ensure_one()
+        return {
+            'user_id': self.user_id.id,
+            'company_id': self.company_id.id,
+            'default_lang_id': self.default_lang_id.id,
+        }
+
+    def _get_cached(self, field):
+        return self._get_cached_values()[field]
+
     def get_unique_path(self, page_url):
         """ Given an url, return that url suffixed by counter if it already exists
             :param page_url : the url to be checked for uniqueness


### PR DESCRIPTION
https://github.com/odoo/odoo/commit/6d6b505598413b0d766a8394c7131351ade64266

Original commit message:
```txt
 [IMP] website: perf - add cache for website frequent fields

The dispatching layer of Odoo (common to any call) can avoid a query on website
if those 3 values are cached.
Note that for complex business flows, there won't be any gain since website
infos will have to be fetched at some point.

About user_id:
In most cases, for a website page you will need to browse the website btw so
we don't remove this request previously. But in case of a simple image, the
controller /web/content need the public user just to set the request.uid in
auth_public but no other info from website.

With this commit, we don't do the 'select * from website where id in()'
request on each controller declared in auth='public' but use the user_id
from the cache. (Invalidated by the write on website_id)

task-2211013

Co-authored-by: Jérémy Kersten <jke@odoo.com>
Co-authored-by: Romain Derie <rde@odoo.com>
```

It will be open in order to use as patch in our `patches.txt` way since that Odoo refused applied to stable here:
 - https://github.com/odoo/odoo/pull/49690

and PR closed doesn't update patch diff even if you push changes to branch.