### PR TITLE
[FIX] website: All menu translations on Website

### DIFF
--- a/addons/account/i18n/et.po
+++ b/addons/account/i18n/et.po
@@ -1279,7 +1279,7 @@ msgstr "Loo kreeditarve"
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice_send__add_sign
 msgid "Add Sign"
-msgstr ""
+msgstr "Lisa märk"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.onboarding_bank_account_step
@@ -4529,7 +4529,7 @@ msgstr "FRANKOSIHTSADAM"
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice_send__starred_partner_ids
 msgid "Favorited By"
-msgstr ""
+msgstr "Soositud"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_account_journal_search
@@ -4992,7 +4992,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:account.field_account_invoice_send__has_error
 #: model:ir.model.fields,help:account.field_account_invoice_send__has_error
 msgid "Has error"
-msgstr ""
+msgstr "On viga"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_abstract_payment__hide_payment_method
@@ -6781,12 +6781,12 @@ msgstr ""
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice_send__moderator_id
 msgid "Moderated By"
-msgstr ""
+msgstr "Modereerib"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice_send__moderation_status
 msgid "Moderation Status"
-msgstr ""
+msgstr "Modereerimise olek"
 
 #. module: account
 #. openerp-web
@@ -6912,7 +6912,7 @@ msgstr "Vajab tegevust"
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice_send__need_moderation
 msgid "Need moderation"
-msgstr ""
+msgstr "Vajab modereerimist"
 
 #. module: account
 #. openerp-web
@@ -7416,7 +7416,7 @@ msgstr "Väljuv"
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice_send__mail_server_id
 msgid "Outgoing mail server"
-msgstr ""
+msgstr "Väljuvate kirjade server"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_chart_template__property_stock_account_output_categ_id
@@ -7589,7 +7589,7 @@ msgstr "Partneri tüüp"
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice_send__needaction_partner_ids
 msgid "Partners with Need Action"
-msgstr ""
+msgstr "Partnerid, kellel on vaja tegutseda"
 
 #. module: account
 #: code:addons/account/models/account_journal_dashboard.py:95
@@ -8454,12 +8454,12 @@ msgstr "Normaalne"
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice_send__res_id
 msgid "Related Document ID"
-msgstr ""
+msgstr "Seotud dokumendi ID"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice_send__model
 msgid "Related Document Model"
-msgstr ""
+msgstr "Seotud dokumendi mudel"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice_send__rating_ids
@@ -10980,11 +10980,13 @@ msgid ""
 "Tracked values are stored in a separate model. This field allow to "
 "reconstruct the tracking and to generate statistics on the model."
 msgstr ""
+"Jälgitavad väärtused salvestatakse eraldi mudelis. See väli võimaldab "
+"taastada jälgimist ja  mudeli kohta statistikat genereerida."
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice_send__tracking_value_ids
 msgid "Tracking values"
-msgstr ""
+msgstr "Jälgimisväärtused"
 
 #. module: account
 #. openerp-web

--- a/addons/account/i18n/eu.po
+++ b/addons/account/i18n/eu.po
@@ -17,9 +17,9 @@
 # Naomi Hidalgo <naomihid96@gmail.com>, 2019
 # Iñaki Ibarrola <inakiibarrola@yahoo.es>, 2020
 # Maialen Rodriguez <maialenrodriguez98@gmail.com>, 2020
-# Miren Maiz <mirenmaizz@gmail.com>, 2020
-# Mikel Galarza <mikelgalarza99@gmail.com>, 2020
+# mgalarza005 <mikelgalarza99@gmail.com>, 2020
 # Unai Muñoz <unaimunoz9@gmail.com>, 2020
+# Miren Maiz <mirenmaizz@gmail.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -27,7 +27,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-11-14 07:33+0000\n"
 "PO-Revision-Date: 2018-08-24 09:14+0000\n"
-"Last-Translator: Unai Muñoz <unaimunoz9@gmail.com>, 2020\n"
+"Last-Translator: Miren Maiz <mirenmaizz@gmail.com>, 2020\n"
 "Language-Team: Basque (https://www.transifex.com/odoo/teams/41243/eu/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1261,7 +1261,7 @@ msgstr "Gehitu"
 #: model_terms:ir.ui.view,arch_db:account.invoice_form
 #: model_terms:ir.ui.view,arch_db:account.view_account_invoice_refund
 msgid "Add Credit Note"
-msgstr "Gehitu kreditu-oharra"
+msgstr "Kreditu-oharra gehitu"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice_send__add_sign
@@ -1622,7 +1622,7 @@ msgstr "Ordaindutako kopurua"
 #: selection:account.reconcile.model,match_nature:0
 #: selection:account.reconcile.model.template,match_nature:0
 msgid "Amount Paid/Received"
-msgstr "Ordainduta/Jasota kopurua"
+msgstr "Ordaindutako/Jasotako kopurua"
 
 #. module: account
 #: selection:account.reconcile.model,match_nature:0
@@ -11593,7 +11593,7 @@ msgstr ""
 #: code:addons/account/wizard/pos_box.py:36
 #, python-format
 msgid "You cannot put/take money in/out for a bank statement which is closed."
-msgstr ""
+msgstr "Ezin duzu dirua sartu/atera itxitako bankutik."
 
 #. module: account
 #: code:addons/account/models/account_payment.py:99

--- a/addons/account/i18n/eu.po
+++ b/addons/account/i18n/eu.po
@@ -18,6 +18,8 @@
 # Iñaki Ibarrola <inakiibarrola@yahoo.es>, 2020
 # Maialen Rodriguez <maialenrodriguez98@gmail.com>, 2020
 # Miren Maiz <mirenmaizz@gmail.com>, 2020
+# Mikel Galarza <mikelgalarza99@gmail.com>, 2020
+# Unai Muñoz <unaimunoz9@gmail.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -25,7 +27,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-11-14 07:33+0000\n"
 "PO-Revision-Date: 2018-08-24 09:14+0000\n"
-"Last-Translator: Miren Maiz <mirenmaizz@gmail.com>, 2020\n"
+"Last-Translator: Unai Muñoz <unaimunoz9@gmail.com>, 2020\n"
 "Language-Team: Basque (https://www.transifex.com/odoo/teams/41243/eu/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -109,7 +111,7 @@ msgstr "-> Adiskidetu"
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_move_line_form
 msgid "-> View partially reconciled entries"
-msgstr ""
+msgstr "-> Bateratutako sarrerak partzialki ikusi"
 
 #. module: account
 #: model:account.payment.term,name:account.account_payment_term_15days
@@ -634,7 +636,7 @@ msgstr "<strong>Egunkaria:</strong>"
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.report_payment_receipt_document
 msgid "<strong>Memo: </strong>"
-msgstr ""
+msgstr "<strong>Memoria:</strong>"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.report_payment_receipt_document
@@ -669,7 +671,7 @@ msgstr "Azpitotala"
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.report_journal
 msgid "<strong>Target Moves:</strong>"
-msgstr ""
+msgstr "<strong>Heburuzko mugimenduak </strong>"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.report_invoice_document
@@ -716,6 +718,10 @@ msgid ""
 "                occurring over a given period of time on a bank account. You\n"
 "                should receive this periodicaly from your bank."
 msgstr ""
+"Finantza-transakzio guztien laburpena\n"
+"bankuko kontu batean denboraz betetako denboraldia ikusten denean. \n"
+"Zu\n"
+"erakutsi zure banketik egunkari hau."
 
 #. module: account
 #: model_terms:ir.actions.act_window,help:account.action_bank_statement_line
@@ -750,7 +756,7 @@ msgstr ""
 #: code:addons/account/models/reconciliation_widget.py:681
 #, python-format
 msgid "A reconciliation must involve at least 2 move lines."
-msgstr ""
+msgstr "Adiskidetzeak gutxienez bi mugimendu-lerro izan behar ditu."
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.res_config_settings_view_form
@@ -764,13 +770,15 @@ msgstr ""
 #: code:addons/account/models/account_bank_statement.py:530
 #, python-format
 msgid "A selected move line was already reconciled."
-msgstr ""
+msgstr "Hautatutako mugimendu-lerro bat dagoeneko adiskidetuta zegoen."
 
 #. module: account
 #: code:addons/account/models/account_bank_statement.py:538
 #, python-format
 msgid "A selected statement line was already reconciled with an account move."
 msgstr ""
+"Hautatutako adierazpen-lerro bat dagoeneko kontuko mugimendu batekin lotuta "
+"zegoen."
 
 #. module: account
 #: sql_constraint:account.fiscal.position.tax:0
@@ -931,7 +939,7 @@ msgstr "Ordaintzeko kontua"
 #. module: account
 #: model:ir.model,name:account.model_account_print_journal
 msgid "Account Print Journal"
-msgstr ""
+msgstr "Print Journal kontua"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_category_property_form
@@ -988,7 +996,7 @@ msgstr "Kontu zergen txantiloia"
 #. module: account
 #: model:ir.model.fields,field_description:account.field_res_config_settings__module_account_taxcloud
 msgid "Account TaxCloud"
-msgstr ""
+msgstr "TaxCloud kontua"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_account_chart_template_seacrh
@@ -1092,6 +1100,8 @@ msgid ""
 "Account that will be set on invoice tax lines for invoices. Leave empty to "
 "use the expense account."
 msgstr ""
+"Fakturen zerga lerroetan finkatuko den kontua. Utzi hutsik gastuen kontua "
+"erabiltzeko."
 
 #. module: account
 #: model:ir.model.fields,help:account.field_account_tax_template__refund_account_id
@@ -1332,7 +1342,7 @@ msgstr "Gehitu kontaktuak jakinarazteko..."
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice_send__partner_ids
 msgid "Additional Contacts"
-msgstr ""
+msgstr "Kontatu gehigarriak"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice__comment
@@ -1893,7 +1903,7 @@ msgstr ""
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.account_invoice_send_wizard_form
 msgid "Attach a file"
-msgstr ""
+msgstr "Fitxategia eranskin "
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_bank_statement__message_attachment_count
@@ -1934,7 +1944,7 @@ msgstr ""
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice_send__author_avatar
 msgid "Author's avatar"
-msgstr ""
+msgstr "Egilearen izena"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.invoice_supplier_form
@@ -2760,7 +2770,7 @@ msgstr "Txekeak"
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice_send__child_ids
 msgid "Child Messages"
-msgstr ""
+msgstr "Haurrentzako menuak"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_tax__children_tax_ids
@@ -3002,7 +3012,7 @@ msgstr ""
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice_send__composition_mode
 msgid "Composition mode"
-msgstr ""
+msgstr "Konposaketa modua"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.res_config_settings_view_form
@@ -3378,7 +3388,7 @@ msgstr "Nork sortua"
 #: code:addons/account/models/account_invoice.py:419
 #, python-format
 msgid "Created by: %s"
-msgstr ""
+msgstr "-(a)k sortua: %s"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_account__create_date
@@ -3456,12 +3466,12 @@ msgstr ""
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice_refund__filter_refund
 msgid "Credit Method"
-msgstr ""
+msgstr "Kreditu metodoa"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_partial_reconcile__credit_move_id
 msgid "Credit Move"
-msgstr ""
+msgstr "kreditu mugimendua"
 
 #. module: account
 #: code:addons/account/models/account_invoice.py:486
@@ -3484,12 +3494,12 @@ msgstr "Kreditu oharra - %s"
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.account_journal_dashboard_kanban_view
 msgid "Credit Note Bill"
-msgstr ""
+msgstr "kreditu-oharraren Faktura"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice_refund__date_invoice
 msgid "Credit Note Date"
-msgstr ""
+msgstr "kreditu-ohar data"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_journal__refund_sequence_id
@@ -3580,7 +3590,7 @@ msgstr "Aurtengo irabaziak"
 #. module: account
 #: model:ir.model.fields,help:account.field_account_invoice_send__starred
 msgid "Current user has a starred notification linked to this message"
-msgstr ""
+msgstr "Uneko erabiltzaileak mezu honi lotutako izar-jakinarazpena du"
 
 #. module: account
 #: selection:account.abstract.payment,partner_type:0
@@ -3753,7 +3763,7 @@ msgstr "Data"
 #: model:ir.model.fields,field_description:account.field_account_payment_term_line__day_of_the_month
 #: model_terms:ir.ui.view,arch_db:account.view_payment_term_line_tree
 msgid "Day of the month"
-msgstr ""
+msgstr "Hilabeteko eguna"
 
 #. module: account
 #: model:ir.model.fields,help:account.field_account_payment_term_line__day_of_the_month
@@ -3787,12 +3797,12 @@ msgstr "Zor"
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_move_line__debit_cash_basis
 msgid "Debit Cash Basis"
-msgstr ""
+msgstr "Zorrak Eskudiruan"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_partial_reconcile__debit_move_id
 msgid "Debit Move"
-msgstr ""
+msgstr "Zor mugimendua"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_tax_adjustments_wizard__debit_account_id
@@ -4025,7 +4035,7 @@ msgstr ""
 #. module: account
 #: model:ir.model,name:account.model_digest_digest
 msgid "Digest"
-msgstr ""
+msgstr "Laburpen"
 
 #. module: account
 #: model:ir.model.fields,help:account.field_res_config_settings__group_products_in_bills
@@ -4122,7 +4132,7 @@ msgstr ""
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice_line__display_type
 msgid "Display Type"
-msgstr ""
+msgstr "Erakusketa mota"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_tax_template__description
@@ -4362,12 +4372,12 @@ msgstr "Sarrerak:"
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_journal__sequence_id
 msgid "Entry Sequence"
-msgstr ""
+msgstr "sarrera Sekuentzia"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_bank_statement__move_line_ids
 msgid "Entry lines"
-msgstr ""
+msgstr "sarrera Lerroak"
 
 #. module: account
 #: selection:account.account.type,internal_group:0
@@ -4439,7 +4449,7 @@ msgstr "Kanpo-erreferentzia"
 #: code:addons/account/static/src/xml/account_reconciliation.xml:333
 #, python-format
 msgid "External link"
-msgstr ""
+msgstr "Kanpoko Lotura"
 
 #. module: account
 #: model:account.incoterms,name:account.incoterm_FAS
@@ -4563,7 +4573,7 @@ msgstr "Urte fiskala"
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.action_account_fiscal_year_form
 msgid "Fiscal Year 2018"
-msgstr ""
+msgstr "Urte fiskala 2018"
 
 #. module: account
 #: model:ir.actions.act_window,name:account.actions_account_fiscal_year
@@ -6265,7 +6275,7 @@ msgstr "Azken jarduerak"
 #: model:ir.model.fields,field_description:account.field_res_partner__last_time_entries_checked
 #: model:ir.model.fields,field_description:account.field_res_users__last_time_entries_checked
 msgid "Latest Invoices & Payments Matching Date"
-msgstr ""
+msgstr "Azken fakturen eta ordainketen korrespondentzia data"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice_send__layout
@@ -6339,7 +6349,7 @@ msgstr ""
 #. module: account
 #: model:ir.model.fields,help:account.field_account_chart_template__tax_template_ids
 msgid "List of all the taxes that have to be installed by the wizard"
-msgstr ""
+msgstr "Morroiak instalatu beharko lituzkeen zerga guztien zerrenda"
 
 #. module: account
 #. openerp-web
@@ -6549,12 +6559,12 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:account.view_full_reconcile_form
 #: model_terms:ir.ui.view,arch_db:account.view_move_line_form
 msgid "Matching"
-msgstr ""
+msgstr "Bat datorren"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_move_line__full_reconcile_id
 msgid "Matching Number"
-msgstr ""
+msgstr "Bat datorren zenbakia"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_partial_reconcile__max_date
@@ -8170,25 +8180,25 @@ msgstr ""
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_move_form
 msgid "Reconciled entries"
-msgstr ""
+msgstr "Adiskidetutako sarrerak"
 
 #. module: account
 #: model:ir.actions.client,name:account.action_manual_reconciliation
 #: model:ir.ui.menu,name:account.menu_action_manual_reconciliation
 msgid "Reconciliation"
-msgstr ""
+msgstr "Adiskidetzea"
 
 #. module: account
 #: model:ir.actions.act_window,name:account.action_account_reconcile_model
 #: model:ir.ui.menu,name:account.action_account_reconcile_model_menu
 #: model_terms:ir.ui.view,arch_db:account.account_journal_dashboard_kanban_view
 msgid "Reconciliation Models"
-msgstr ""
+msgstr "Adiskidetze ereduak"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_full_reconcile__partial_reconcile_ids
 msgid "Reconciliation Parts"
-msgstr ""
+msgstr "Adiskidetze zatia"
 
 #. module: account
 #: model:ir.actions.client,name:account.action_bank_reconcile
@@ -8199,7 +8209,7 @@ msgstr ""
 #. module: account
 #: model_terms:ir.actions.act_window,help:account.action_vendor_bill_template
 msgid "Record a new vendor bill"
-msgstr ""
+msgstr "Hornitzailearen faktura berria erregistratu"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.res_config_settings_view_form
@@ -8252,6 +8262,8 @@ msgid ""
 "Reference of the document used to issue this payment. Eg. check number, file"
 " name, etc."
 msgstr ""
+"Ordainketa igortzeko erabilitako dokumentuaren erreferentzia. adibidez "
+"egiaztatzea zenbakia, fitxategiaren izena, etab."
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice__name
@@ -8262,7 +8274,7 @@ msgstr "Reference/Description"
 #: model:ir.actions.act_window,name:account.action_invoice_in_refund
 #: model:ir.ui.menu,name:account.menu_action_invoice_in_refund
 msgid "Refund"
-msgstr ""
+msgstr "diru-itzultze"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice__refund_invoice_ids
@@ -8300,7 +8312,7 @@ msgstr ""
 #. module: account
 #: selection:account.account.type,type:0
 msgid "Regular"
-msgstr ""
+msgstr "Erregular"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice_send__res_id
@@ -8315,7 +8327,7 @@ msgstr ""
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice_send__rating_ids
 msgid "Related ratings"
-msgstr ""
+msgstr "Balioztatze erlatiboak"
 
 #. module: account
 #: model:ir.model.fields,help:account.field_account_invoice__residual_company_signed
@@ -8335,7 +8347,7 @@ msgstr "Zorretan dagoen kopurua."
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_fiscal_position_tax_template__tax_dest_id
 msgid "Replacement Tax"
-msgstr ""
+msgstr "Ordezko zerga"
 
 #. module: account
 #: model:ir.model.fields,help:account.field_account_invoice_send__reply_to
@@ -8380,23 +8392,23 @@ msgstr "Berrezarri zirriborrora"
 #: code:addons/account/static/src/xml/account_reconciliation.xml:290
 #, python-format
 msgid "Residual"
-msgstr ""
+msgstr "soberakoa"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_move_line__amount_residual
 msgid "Residual Amount"
-msgstr ""
+msgstr "soberako kopurua"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_move_line__amount_residual_currency
 msgid "Residual Amount in Currency"
-msgstr ""
+msgstr "soberako kopurua monetan"
 
 #. module: account
 #: code:addons/account/models/account_journal_dashboard.py:32
 #, python-format
 msgid "Residual amount"
-msgstr ""
+msgstr "soberako kopurua"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_bank_statement__user_id
@@ -8406,7 +8418,7 @@ msgstr "Arduraduna"
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice__activity_user_id
 msgid "Responsible User"
-msgstr ""
+msgstr "Erabiltzaile arduraduna"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_reconcile_model__match_partner_category_ids
@@ -8450,7 +8462,7 @@ msgstr ""
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_move_reversal__date
 msgid "Reversal date"
-msgstr ""
+msgstr "Berraztertzeko data"
 
 #. module: account
 #: code:addons/account/models/account_move.py:399
@@ -8467,7 +8479,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:account.field_account_move__reverse_entry_id
 #: model_terms:ir.ui.view,arch_db:account.view_move_form
 msgid "Reverse Entry"
-msgstr ""
+msgstr "Berraztertzeko sarrera"
 
 #. module: account
 #: code:addons/account/wizard/account_move_reversal.py:20
@@ -8912,7 +8924,7 @@ msgstr ""
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_account_payment_form
 msgid "Set To Draft"
-msgstr ""
+msgstr "Ezarri zirriborro gisa"
 
 #. module: account
 #: model:ir.model.fields,help:account.field_account_account_tag__active
@@ -8999,7 +9011,7 @@ msgstr ""
 #. module: account
 #: model:res.groups,name:account.group_account_user
 msgid "Show Full Accounting Features"
-msgstr ""
+msgstr "Erakutsi kontabilitate ezaugarri osoak"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_abstract_payment__show_partner_bank_account
@@ -9208,7 +9220,7 @@ msgstr "Egoera"
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_fiscal_position__states_count
 msgid "States Count"
-msgstr ""
+msgstr "Egoera kontua"
 
 #. module: account
 #: code:addons/account/controllers/portal.py:43
@@ -9239,7 +9251,7 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:account.onboarding_fiscal_year_step
 #: model_terms:ir.ui.view,arch_db:account.onboarding_sale_tax_step
 msgid "Step Completed!"
-msgstr ""
+msgstr "Urratsa amaituta!"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice_send__subject
@@ -9249,7 +9261,7 @@ msgstr "Gaia"
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.account_invoice_send_wizard_form
 msgid "Subject..."
-msgstr ""
+msgstr "Gai..."
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_cashbox_line__subtotal
@@ -9267,7 +9279,7 @@ msgstr "Azpi-mota"
 #: code:addons/account/models/chart_template.py:933
 #, python-format
 msgid "Suggest a write-off."
-msgstr ""
+msgstr "Galera bat proposatu."
 
 #. module: account
 #: selection:account.reconcile.model,rule_type:0
@@ -9279,7 +9291,7 @@ msgstr ""
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.res_config_settings_view_form
 msgid "Supplier Payments"
-msgstr ""
+msgstr "Ordainketa hornitzaileei"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_account__tag_ids
@@ -9292,14 +9304,14 @@ msgstr "Etiketak"
 #: model:ir.actions.act_window,name:account.action_cash_box_out
 #: model_terms:ir.ui.view,arch_db:account.cash_box_out_form
 msgid "Take Money Out"
-msgstr ""
+msgstr "Dirua atera"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_common_journal_report__target_move
 #: model:ir.model.fields,field_description:account.field_account_common_report__target_move
 #: model:ir.model.fields,field_description:account.field_account_print_journal__target_move
 msgid "Target Moves"
-msgstr ""
+msgstr "Helburu mugimenduak"
 
 #. module: account
 #. openerp-web
@@ -9346,7 +9358,7 @@ msgstr ""
 #: model:ir.actions.act_window,name:account.tax_adjustments_form
 #: model:ir.ui.menu,name:account.menu_action_tax_adjustment
 msgid "Tax Adjustments"
-msgstr ""
+msgstr "Zergen doikuntzak"
 
 #. module: account
 #: model:ir.model,name:account.model_tax_adjustments_wizard
@@ -9363,12 +9375,12 @@ msgstr "Zerga kopurua"
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_reconcile_model__tax_amount_type
 msgid "Tax Amount Type"
-msgstr ""
+msgstr "Zerga kopuru mota"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_account_tax_search
 msgid "Tax Application"
-msgstr ""
+msgstr "Zerga aplikazioa"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_res_company__tax_calculation_rounding_method
@@ -9389,23 +9401,23 @@ msgstr ""
 #: model:ir.model.fields,field_description:account.field_account_tax__amount_type
 #: model:ir.model.fields,field_description:account.field_account_tax_template__amount_type
 msgid "Tax Computation"
-msgstr ""
+msgstr "Zerga kalkulua"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.report_journal
 msgid "Tax Declaration"
-msgstr ""
+msgstr "Zerga Deklarazioa"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice_tax__name
 msgid "Tax Description"
-msgstr ""
+msgstr "Zerga deskribapena"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_tax__tax_exigibility
 #: model:ir.model.fields,field_description:account.field_account_tax_template__tax_exigibility
 msgid "Tax Due"
-msgstr ""
+msgstr "Ordaintzeko zergak"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.invoice_supplier_tree
@@ -9418,7 +9430,7 @@ msgstr "Zerga baztertuta"
 #: model:ir.model.fields,field_description:account.field_account_tax__tax_group_id
 #: model:ir.model.fields,field_description:account.field_account_tax_template__tax_group_id
 msgid "Tax Group"
-msgstr ""
+msgstr "Zerga taldea"
 
 #. module: account
 #. openerp-web
@@ -9661,7 +9673,7 @@ msgstr ""
 #: model:ir.model.fields,help:account.field_account_bank_statement__journal_type
 #: model:ir.model.fields,help:account.field_account_payment__has_invoices
 msgid "Technical field used for usability purposes"
-msgstr ""
+msgstr "Erabilgarritasunerako erabilitako arlo teknikoa."
 
 #. module: account
 #: model:ir.model.fields,help:account.field_account_move__matched_percentage
@@ -9934,7 +9946,7 @@ msgstr ""
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_account_bnk_stmt_check
 msgid "The closing balance is different than the computed one!"
-msgstr ""
+msgstr "Amaierako saldoa kalkulatutakoaren desberdina da!"
 
 #. module: account
 #: sql_constraint:account.journal:0
@@ -10080,12 +10092,12 @@ msgstr ""
 #. module: account
 #: model:ir.model.fields,help:account.field_account_move_line__move_id
 msgid "The move of this entry line."
-msgstr ""
+msgstr "Sarrera lerro honen mugimendua."
 
 #. module: account
 #: model:ir.model.fields,help:account.field_account_invoice__name
 msgid "The name that will be used on account move lines"
-msgstr ""
+msgstr "Kontuko mugimendu lerroetan erabiliko den izena."
 
 #. module: account
 #: code:addons/account/models/company.py:149
@@ -10126,7 +10138,7 @@ msgstr ""
 #. module: account
 #: model:ir.model.fields,help:account.field_account_invoice__account_id
 msgid "The partner account used for this invoice."
-msgstr ""
+msgstr "Faktura honetarako erabilitako bazkide kontua."
 
 #. module: account
 #: model:ir.model.fields,help:account.field_res_partner__has_unreconciled_entries
@@ -10147,7 +10159,7 @@ msgstr ""
 #: code:addons/account/models/account_payment.py:118
 #, python-format
 msgid "The payment amount cannot be negative."
-msgstr ""
+msgstr "Ordaintzeko kopurua ezin da negatiboa izan."
 
 #. module: account
 #: code:addons/account/models/account_payment.py:602
@@ -10333,17 +10345,17 @@ msgstr ""
 #: code:addons/account/static/src/xml/account_reconciliation.xml:48
 #, python-format
 msgid "There is nothing to reconcile."
-msgstr ""
+msgstr "Ez dago ezer adiskidetzeko."
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.portal_invoice_error
 msgid "There was an error processing this page."
-msgstr ""
+msgstr "Orrialde hau prozesatzerakoan errore bat sprtu da."
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.res_config_settings_view_form
 msgid "These taxes are set in any new product created."
-msgstr ""
+msgstr "Zerga hauek sortutako edozein produktu berritan jartzen dira."
 
 #. module: account
 #: model:ir.model.fields,help:account.field_account_account_template__user_type_id
@@ -10377,7 +10389,7 @@ msgstr ""
 #. module: account
 #: model:ir.model.fields,help:account.field_product_category__property_account_income_categ_id
 msgid "This account will be used when validating a customer invoice."
-msgstr ""
+msgstr "Kontu hau bezeroen faktura balioztatzeko erabiliko da."
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.res_config_settings_view_form
@@ -10469,7 +10481,7 @@ msgstr ""
 #. module: account
 #: model_terms:ir.actions.act_window,help:account.open_account_journal_dashboard_kanban
 msgid "This is the accounting dashboard"
-msgstr ""
+msgstr "Hau da kontabilitateko taula"
 
 #. module: account
 #: code:addons/account/models/account.py:620
@@ -10664,7 +10676,7 @@ msgstr "Kobratu guztira"
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice_report__user_currency_residual
 msgid "Total Residual"
-msgstr ""
+msgstr "soberakoa"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice_report__user_currency_price_total
@@ -10740,7 +10752,7 @@ msgstr ""
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice_send__tracking_value_ids
 msgid "Tracking values"
-msgstr ""
+msgstr "Jarraipen balioak"
 
 #. module: account
 #. openerp-web
@@ -10881,27 +10893,27 @@ msgstr "Irakurri gabeko mezuen kontagailua"
 #: model_terms:ir.ui.view,arch_db:account.account_unreconcile_view
 #, python-format
 msgid "Unreconcile"
-msgstr ""
+msgstr "Ez adiskidetua"
 
 #. module: account
 #: model:ir.actions.act_window,name:account.action_account_unreconcile
 msgid "Unreconcile Entries"
-msgstr ""
+msgstr "Sarrera ez adiskidetuak"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.account_unreconcile_view
 msgid "Unreconcile Transactions"
-msgstr ""
+msgstr "Transakzio ez adiskidetuak"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_account_move_line_filter
 msgid "Unreconciled"
-msgstr ""
+msgstr "Ez adiskidetua"
 
 #. module: account
 #: model:ir.actions.act_window,name:account.act_account_acount_move_line_open_unreconciled
 msgid "Unreconciled Entries"
-msgstr ""
+msgstr "Sarrera ez adiskidetuak"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice__amount_untaxed
@@ -10933,12 +10945,12 @@ msgstr ""
 #: code:addons/account/static/src/xml/bills_tree_upload_views.xml:5
 #, python-format
 msgid "Upload"
-msgstr ""
+msgstr "igo"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.account_invoice_import_wizard_form_view
 msgid "Upload Files"
-msgstr ""
+msgstr "Fitxategiak igo"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_chart_template__use_anglo_saxon
@@ -10988,22 +11000,22 @@ msgstr ""
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.res_config_settings_view_form
 msgid "Use follow-up levels and schedule actions"
-msgstr ""
+msgstr "Jarraipen mailak eta programatutako ekintzak erabili"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_res_config_settings__group_products_in_bills
 msgid "Use products in vendor bills"
-msgstr ""
+msgstr "Hornitzailearen fakturetan produktuak erabili"
 
 #. module: account
 #: model:res.groups,name:account.group_products_in_bills
 msgid "Use products on vendor bills"
-msgstr ""
+msgstr "Hornitzailearen fakturetan produktuak erabili"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice_send__template_id
 msgid "Use template"
-msgstr ""
+msgstr "Txantiloia erabili"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_account_invoice_refund
@@ -11150,24 +11162,24 @@ msgstr "Hornitzailearen fakturak"
 #: model_terms:ir.ui.view,arch_db:account.report_invoice_document
 #, python-format
 msgid "Vendor Credit Note"
-msgstr ""
+msgstr "Hornitzailearen kreditu-oharra"
 
 #. module: account
 #: code:addons/account/models/account_invoice.py:491
 #, python-format
 msgid "Vendor Credit Note - %s"
-msgstr ""
+msgstr "Hornitzailearen kreditu-oharra -%s"
 
 #. module: account
 #: code:addons/account/models/account_invoice.py:1317
 #, python-format
 msgid "Vendor Credit note"
-msgstr ""
+msgstr "Hornitzailearen kreditu-oharra"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice__vendor_display_name
 msgid "Vendor Display Name"
-msgstr ""
+msgstr "Hornitzailearen erakusteko izena"
 
 #. module: account
 #: code:addons/account/models/account_payment.py:774
@@ -11186,7 +11198,7 @@ msgstr "Hornitzailea salmenta baldintzak"
 #: model_terms:ir.ui.view,arch_db:account.account_journal_dashboard_kanban_view
 #: model_terms:ir.ui.view,arch_db:account.view_account_payment_search
 msgid "Vendor Payments"
-msgstr ""
+msgstr "Hornitzaileen ordainketak"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.invoice_supplier_form
@@ -11216,7 +11228,7 @@ msgstr "Ikusi"
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_partner_property_form
 msgid "View accounts detail"
-msgstr ""
+msgstr "Kontuen xehetasunak ikusi"
 
 #. module: account
 #: selection:res.partner,invoice_warn:0
@@ -11249,7 +11261,7 @@ msgstr "Oharrak"
 #. module: account
 #: model:ir.model.fields,field_description:account.field_res_config_settings__group_warning_account
 msgid "Warnings in Invoices"
-msgstr ""
+msgstr "Oharrak fakturetan"
 
 #. module: account
 #: code:addons/account/models/company.py:518
@@ -11315,32 +11327,32 @@ msgstr ""
 #: model:ir.model.fields,field_description:account.field_account_common_journal_report__amount_currency
 #: model:ir.model.fields,field_description:account.field_account_print_journal__amount_currency
 msgid "With Currency"
-msgstr ""
+msgstr "monetarekin"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_account_reconcile_model_search
 msgid "With tax"
-msgstr ""
+msgstr "Zergarekin"
 
 #. module: account
 #: code:addons/account/models/account_move.py:979
 #: code:addons/account/models/account_move.py:999
 #, python-format
 msgid "Write-Off"
-msgstr ""
+msgstr "galera"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_reconcile_model__amount
 #: model:ir.model.fields,field_description:account.field_account_reconcile_model_template__amount
 msgid "Write-off Amount"
-msgstr ""
+msgstr "galera kopurua."
 
 #. module: account
 #. openerp-web
 #: code:addons/account/static/src/xml/account_reconciliation.xml:217
 #, python-format
 msgid "Writeoff Date"
-msgstr ""
+msgstr "Deuseztapen data"
 
 #. module: account
 #: sql_constraint:account.move.line:0
@@ -11656,13 +11668,13 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:account.invoice_form
 #: model_terms:ir.ui.view,arch_db:account.invoice_supplier_form
 msgid "You have"
-msgstr ""
+msgstr "Badaukazu"
 
 #. module: account
 #: code:addons/account/models/account_payment.py:622
 #, python-format
 msgid "You have to define a sequence for %s in your company."
-msgstr ""
+msgstr "%s-rako sekuentzia bat definitu behar duzu zure enpresan."
 
 #. module: account
 #: code:addons/account/wizard/pos_box.py:50
@@ -11683,14 +11695,14 @@ msgstr "Lehenik eta behin inaugurazio mugimendu bat definitu behar duzu."
 #: code:addons/account/models/account_invoice.py:1683
 #, python-format
 msgid "You must first select a partner."
-msgstr ""
+msgstr "Lehendabizi bazkide bat aukeratu behar duzu."
 
 #. module: account
 #. openerp-web
 #: code:addons/account/static/src/xml/account_reconciliation.xml:55
 #, python-format
 msgid "You reconciled"
-msgstr ""
+msgstr "Adiskidetu zinen"
 
 #. module: account
 #: code:addons/account/models/account_move.py:1624
@@ -11731,7 +11743,7 @@ msgstr ""
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_account_position_form
 msgid "Zip Range"
-msgstr ""
+msgstr "Zip sorta"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_fiscal_position__zip_from
@@ -11761,17 +11773,17 @@ msgstr "itxi"
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_account_form
 msgid "code"
-msgstr ""
+msgstr "kode"
 
 #. module: account
 #: selection:account.payment.term.line,option:0
 msgid "day(s) after the end of the invoice month"
-msgstr ""
+msgstr "fakturaren hilabetea amaitu eta hurrengo eguna(k)"
 
 #. module: account
 #: selection:account.payment.term.line,option:0
 msgid "day(s) after the invoice date"
-msgstr ""
+msgstr "faktura dataren ondorengo eguna(k)"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.setup_bank_account_wizard
@@ -11781,17 +11793,17 @@ msgstr "adib. BE15001559627230"
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.setup_bank_account_wizard
 msgid "e.g Bank of America"
-msgstr ""
+msgstr "adb. Amerikako bankua"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.setup_bank_account_wizard
 msgid "e.g Checking account"
-msgstr ""
+msgstr "adb. Kontu korrontea"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_account_reconcile_model_form
 msgid "e.g. Bank Fees"
-msgstr ""
+msgstr "adb. Banku kuota"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.invoice_form
@@ -11808,12 +11820,12 @@ msgstr ""
 #: code:addons/account/static/src/xml/account_reconciliation.xml:323
 #, python-format
 msgid "have been reconciled automatically."
-msgstr ""
+msgstr "automatikoki adiskidetu dira"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice_send__invoice_without_email
 msgid "invoice(s) that will not be sent"
-msgstr ""
+msgstr "Bidaliko es diren fakturak"
 
 #. module: account
 #. openerp-web
@@ -11825,17 +11837,17 @@ msgstr ""
 #. module: account
 #: selection:account.payment.term.line,option:0
 msgid "of the current month"
-msgstr ""
+msgstr "oraingo hilabetea"
 
 #. module: account
 #: selection:account.payment.term.line,option:0
 msgid "of the following month"
-msgstr ""
+msgstr "hurrengo hilabetea"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.invoice_supplier_form
 msgid "outstanding debits"
-msgstr ""
+msgstr "Ordaindu gabeko zorrak"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.invoice_form
@@ -11847,14 +11859,14 @@ msgstr "ordaindu gabekoak"
 #: code:addons/account/static/src/xml/account_reconciliation.xml:169
 #, python-format
 msgid "reconciliation models"
-msgstr ""
+msgstr "Adiskidetze ereduak"
 
 #. module: account
 #. openerp-web
 #: code:addons/account/static/src/xml/account_reconciliation.xml:154
 #, python-format
 msgid "remaining)"
-msgstr ""
+msgstr "gainerako)"
 
 #. module: account
 #. openerp-web
@@ -11868,12 +11880,12 @@ msgstr "segundu transakzio bakoitzeko."
 #: code:addons/account/static/src/xml/account_reconciliation.xml:319
 #, python-format
 msgid "statement lines"
-msgstr ""
+msgstr "Adierazpen lerroak"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_partner_property_form
 msgid "the parent company"
-msgstr ""
+msgstr "Guraso konpainia"
 
 #. module: account
 #. openerp-web
@@ -11890,4 +11902,4 @@ msgstr ""
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_bank_statement_form
 msgid "→ Count"
-msgstr ""
+msgstr "Kontatu"

--- a/addons/account/i18n/fr.po
+++ b/addons/account/i18n/fr.po
@@ -44,10 +44,11 @@
 # Cécile Collart <cco@odoo.com>, 2020
 # Valaeys Stéphane <svalaeys@fiefmanage.ch>, 2020
 # Sylvain Dubuisson <sylvain@orderly.fr>, 2020
-# Christelle Pinchart <cpi@odoo.com>, 2020
 # Jonathan <jcs@odoo.com>, 2020
 # Priscilla Sanchez <prs@odoo.com>, 2020
 # Vallen Delobel <edv@odoo.com>, 2020
+# Christelle Pinchart <cpi@odoo.com>, 2020
+# Jonathan Quique <jqu@odoo.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -55,7 +56,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-11-14 07:33+0000\n"
 "PO-Revision-Date: 2018-08-24 09:14+0000\n"
-"Last-Translator: Vallen Delobel <edv@odoo.com>, 2020\n"
+"Last-Translator: Jonathan Quique <jqu@odoo.com>, 2020\n"
 "Language-Team: French (https://www.transifex.com/odoo/teams/41243/fr/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1328,12 +1329,12 @@ msgstr "Affectation des comptes"
 #. module: account
 #: model:ir.model,name:account.model_account_fiscal_position_account_template
 msgid "Accounts Mapping Template of Fiscal Position"
-msgstr ""
+msgstr "Modèle de mappage des comptes de position fiscale"
 
 #. module: account
 #: model:ir.model,name:account.model_account_fiscal_position_account
 msgid "Accounts Mapping of Fiscal Position"
-msgstr ""
+msgstr "Moappage des comptes de position fiscale"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_bank_statement__message_needaction
@@ -3136,7 +3137,7 @@ msgstr ""
 #. module: account
 #: model:ir.model,name:account.model_account_common_journal_report
 msgid "Common Journal Report"
-msgstr ""
+msgstr "Rapport du journal courant"
 
 #. module: account
 #: model:ir.actions.act_window,name:account.action_account_common_menu
@@ -3219,7 +3220,7 @@ msgstr "Complétez le jeu de taxes."
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice_send__composer_id
 msgid "Composer"
-msgstr ""
+msgstr "Compositeur"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice_send__composition_mode
@@ -4953,12 +4954,13 @@ msgstr ""
 #: model:ir.model.fields,help:account.field_account_reconcile_model_template__force_second_tax_included
 msgid "Force the second tax to be managed as a price included tax."
 msgstr ""
+"Forcer la deuxième taxe à être gérée comme une taxe incluse dans le prix."
 
 #. module: account
 #: model:ir.model.fields,help:account.field_account_reconcile_model__force_tax_included
 #: model:ir.model.fields,help:account.field_account_reconcile_model_template__force_tax_included
 msgid "Force the tax to be managed as a price included tax."
-msgstr ""
+msgstr "Forcer la taxe à être gérée comme une taxe incluse dans le prix."
 
 #. module: account
 #: model:ir.model.fields,help:account.field_account_account__currency_id
@@ -5369,6 +5371,8 @@ msgid ""
 "If set, the accounting entries created during the bank statement reconciliation process will be created at this date.\n"
 "This is useful if the accounting period in which the entries should normally be booked is already closed."
 msgstr ""
+"Si cette option est activée, les écritures comptables créées lors du processus de réconciliation des relevés bancaires seront créées à cette date.\n"
+"Ceci est utile si l'exercice comptable dans lequel les écritures devraient normalement être comptabilisées est déjà clôturé."
 
 #. module: account
 #: model:ir.model.fields,help:account.field_account_tax__analytic
@@ -6263,7 +6267,7 @@ msgstr "Écritures comptables"
 #. module: account
 #: model:ir.actions.act_window,name:account.action_move_line_select_tax_audit
 msgid "Journal Items for Tax Audit"
-msgstr ""
+msgstr "Ecritures comptables pour audit fiscal"
 
 #. module: account
 #. openerp-web
@@ -6402,7 +6406,7 @@ msgstr ""
 #. module: account
 #: model:ir.model.fields,field_description:account.field_digest_digest__kpi_account_total_revenue_value
 msgid "Kpi Account Total Revenue Value"
-msgstr ""
+msgstr "Valeur des revenus totaux du compte Kpi"
 
 #. module: account
 #. openerp-web
@@ -7040,7 +7044,7 @@ msgstr "Opérations diverses"
 #. module: account
 #: sql_constraint:account.invoice.line:0
 msgid "Missing required account on accountable invoice line."
-msgstr ""
+msgstr "Absence du compte requis sur la ligne de facture imputable."
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice_send__moderator_id
@@ -7342,6 +7346,8 @@ msgid ""
 "Note that the easiest way to create a vendor credit note it to do it "
 "directly from the vendor bill."
 msgstr ""
+"Notez que la façon la plus simple de créer une note de crédit fournisseur "
+"est de le faire directement à partir de la facture fournisseur."
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_bank_statement_line__note
@@ -8310,12 +8316,12 @@ msgstr "Préfixe pour les comptes de trésorerie principaux"
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_chart_template__transfer_account_code_prefix
 msgid "Prefix of the main transfer accounts"
-msgstr ""
+msgstr "Préfixe des principaux comptes de transfert"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_res_company__transfer_account_code_prefix
 msgid "Prefix of the transfer accounts"
-msgstr ""
+msgstr "Préfixe des comptes de transfert"
 
 #. module: account
 #: model:account.account.type,name:account.data_account_type_prepayments
@@ -8602,7 +8608,7 @@ msgstr "Lettrer les écritures"
 #. module: account
 #: model:ir.model,name:account.model_account_reconcile_model_template
 msgid "Reconcile Model Template"
-msgstr ""
+msgstr "Modèle de lettrage"
 
 #. module: account
 #: selection:account.payment,state:0
@@ -8659,7 +8665,7 @@ msgstr "Enregistrer des transactions dans des devises étrangères"
 #: code:addons/account/models/account.py:930
 #, python-format
 msgid "Recursion found for tax '%s'."
-msgstr ""
+msgstr "Récursion trouvée pour la taxe '%s'."
 
 #. module: account
 #. openerp-web
@@ -8823,7 +8829,7 @@ msgstr ""
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_setup_bank_manual_config__res_partner_bank_id
 msgid "Res Partner Bank"
-msgstr ""
+msgstr "Res Banque Partenaire"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.invoice_form
@@ -8881,6 +8887,8 @@ msgstr "Limitez les partenaires à"
 msgid ""
 "Restrict to propositions having the same currency as the statement line."
 msgstr ""
+"Limitez-vous aux propositions ayant la même devise que la ligne de "
+"déclaration."
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_digest_digest__kpi_account_total_revenue
@@ -9833,7 +9841,7 @@ msgstr "Ajustements fiscaux"
 #. module: account
 #: model:ir.model,name:account.model_tax_adjustments_wizard
 msgid "Tax Adjustments Wizard"
-msgstr ""
+msgstr "Assistant d'ajustements fiscaux"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice_line__price_tax
@@ -9926,12 +9934,12 @@ msgstr "Correspondance des taxes"
 #. module: account
 #: model:ir.model,name:account.model_account_fiscal_position_tax_template
 msgid "Tax Mapping Template of Fiscal Position"
-msgstr ""
+msgstr "Modèle de mappage de taxes de la position fiscale"
 
 #. module: account
 #: model:ir.model,name:account.model_account_fiscal_position_tax
 msgid "Tax Mapping of Fiscal Position"
-msgstr ""
+msgstr "Mappage de taxes de la position fiscale"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_tax__name
@@ -11262,7 +11270,7 @@ msgstr ""
 #: code:addons/account/static/src/xml/account_reconciliation.xml:169
 #, python-format
 msgid "To speed up reconciliation, define"
-msgstr ""
+msgstr "Pour accélérer la réconciliation, définir"
 
 #. module: account
 #: selection:account.invoice,activity_state:0
@@ -11292,7 +11300,7 @@ msgstr "Montant total"
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_move_line_tax_audit_tree
 msgid "Total Base Amount"
-msgstr ""
+msgstr "Montant de base total"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_move_form
@@ -12379,6 +12387,8 @@ msgid ""
 "You cannot switch an account to prevent the reconciliation if some partial "
 "reconciliations are still pending."
 msgstr ""
+"Vous ne pouvez changer de compte pour empêcher la réconciliation dans le cas"
+" où des rapprochements partiels sont toujours en suspens. "
 
 #. module: account
 #: code:addons/account/models/account_move.py:1112
@@ -12427,6 +12437,8 @@ msgid ""
 "You have to define an 'Internal Transfer Account' in your cash register's "
 "journal."
 msgstr ""
+"Vous devez avoir défini un \"compte de transfert interne\" dans votre "
+"journal de caisse."
 
 #. module: account
 #: code:addons/account/models/account.py:142
@@ -12554,7 +12566,7 @@ msgstr "ex Bank of America"
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.setup_bank_account_wizard
 msgid "e.g Checking account"
-msgstr ""
+msgstr "ex: Compte courant"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_account_reconcile_model_form

--- a/addons/account/i18n/he.po
+++ b/addons/account/i18n/he.po
@@ -835,7 +835,7 @@ msgstr ""
 #. module: account
 #: model:ir.model,name:account.model_account_cash_rounding
 msgid "Account Cash Rounding"
-msgstr ""
+msgstr "חשבון עיגול מזומן"
 
 #. module: account
 #: model:ir.model,name:account.model_account_chart_template
@@ -3334,7 +3334,7 @@ msgstr "צור יומן חדש"
 #. module: account
 #: model_terms:ir.actions.act_window,help:account.rounding_list_action
 msgid "Create the first cash rounding"
-msgstr ""
+msgstr "צור עיגול מזומן ראשון"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_account__create_uid
@@ -4909,7 +4909,7 @@ msgstr ""
 #. module: account
 #: selection:account.cash.rounding,rounding_method:0
 msgid "HALF-UP"
-msgstr ""
+msgstr "חצי-למעלה"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_res_config_settings__has_accounting_entries
@@ -8574,7 +8574,7 @@ msgstr "דיוק עיגול"
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_cash_rounding__strategy
 msgid "Rounding Strategy"
-msgstr ""
+msgstr "אסטרטגיית עיגול"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.rounding_tree_view

--- a/addons/account/i18n/hu.po
+++ b/addons/account/i18n/hu.po
@@ -11161,7 +11161,7 @@ msgstr ""
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice_report__price_total
 msgid "Untaxed Total"
-msgstr ""
+msgstr "Összes adózatlan"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.res_config_settings_view_form

--- a/addons/account/i18n/id.po
+++ b/addons/account/i18n/id.po
@@ -23,9 +23,9 @@
 # Ikhsanul Wirsa <iwirsa02@outlook.co.id>, 2019
 # Ryanto The <ry.the77@gmail.com>, 2019
 # Martin Trigaux, 2019
-# Muhammad Syarif <mhdsyarif.ms@gmail.com>, 2019
 # PAS IRVANUS <ipankbiz@gmail.com>, 2019
 # pnyet <david@zeromail.us>, 2020
+# Muhammad Syarif <mhdsyarif.ms@gmail.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -33,7 +33,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-11-14 07:33+0000\n"
 "PO-Revision-Date: 2018-08-24 09:14+0000\n"
-"Last-Translator: pnyet <david@zeromail.us>, 2020\n"
+"Last-Translator: Muhammad Syarif <mhdsyarif.ms@gmail.com>, 2020\n"
 "Language-Team: Indonesian (https://www.transifex.com/odoo/teams/41243/id/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1236,7 +1236,7 @@ msgstr ""
 #: model:ir.cron,cron_name:account.ir_cron_reverse_entry
 #: model:ir.cron,name:account.ir_cron_reverse_entry
 msgid "Account; Reverse entries"
-msgstr ""
+msgstr "Akun; Jurnal Pembalik"
 
 #. module: account
 #: model:ir.ui.menu,name:account.account_account_menu
@@ -1668,7 +1668,7 @@ msgstr "Jumlah Mata Uang"
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice_tax__amount_rounding
 msgid "Amount Delta"
-msgstr ""
+msgstr "Jumlah Delta"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice__residual
@@ -1743,7 +1743,7 @@ msgstr "Jumlah Ditandatangani"
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice_tax__amount_total
 msgid "Amount Total"
-msgstr ""
+msgstr "Total Nilai"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_reconcile_model__amount_type
@@ -2092,12 +2092,12 @@ msgstr "Auto-validate"
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.res_config_settings_view_form
 msgid "Autocomplete Vendor Bills (OCR + AI)"
-msgstr ""
+msgstr "Tagihan Otomatis Vendor (OCR + AI)"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_res_config_settings__module_account_invoice_extract
 msgid "Automate Bill Processing"
-msgstr ""
+msgstr "Proses Tagihan Otomatis"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.res_config_settings_view_form
@@ -2130,7 +2130,7 @@ msgstr "Impor Otomatis"
 #: code:addons/account/models/account_move.py:399
 #, python-format
 msgid "Automatic reversal of: %s"
-msgstr ""
+msgstr "Pembalikan otomatis: %s"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice_report__price_average
@@ -2140,7 +2140,7 @@ msgstr "Harga Rata-rata"
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice_report__user_currency_price_average
 msgid "Average Price in Currency"
-msgstr ""
+msgstr "Harfa Rata-rata dalam Mata Uang"
 
 #. module: account
 #: code:addons/account/models/chart_template.py:410
@@ -2384,7 +2384,7 @@ msgstr "Berdasarkan pada Faktur"
 #: code:addons/account/models/company.py:19
 #, python-format
 msgid "Based on Invoice Number"
-msgstr ""
+msgstr "Berdasarkan pada Faktur"
 
 #. module: account
 #: model:ir.model.fields,help:account.field_account_tax__tax_exigibility
@@ -2699,7 +2699,7 @@ msgstr "Jurnal Pajak Basis Kas"
 #. module: account
 #: model:ir.model,name:account.model_cash_box_in
 msgid "Cash Box In"
-msgstr ""
+msgstr "Tempat Penyimpana Kas Masuk"
 
 #. module: account
 #: model:ir.model,name:account.model_cash_box_out
@@ -2961,6 +2961,8 @@ msgid ""
 "Choose how you want to credit this invoice. You cannot Modify and Cancel if "
 "the invoice is already reconciled"
 msgstr ""
+"Pilih cara Anda ingin mengkredit faktur ini. Anda tidak dapat Memodifikasi "
+"dan Membatalkan jika faktur sudah direkonsiliasi"
 
 #. module: account
 #: model_terms:ir.actions.act_window,help:account.actions_account_fiscal_year
@@ -2997,7 +2999,7 @@ msgstr ""
 #: code:addons/account/static/src/xml/account_reconciliation.xml:17
 #, python-format
 msgid "Click to Rename"
-msgstr ""
+msgstr "Klik untuk ganti nama"
 
 #. module: account
 #. openerp-web
@@ -3058,6 +3060,8 @@ msgid ""
 "Collect information and produce statistics on the trade in goods in Europe "
 "with intrastat."
 msgstr ""
+"Kumpulkan informasi dan buat statistik tentang perdagangan barang di Eropa "
+"dengan intrastat."
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_account_tag__color
@@ -3075,7 +3079,7 @@ msgstr "Entitas Komersial"
 #: code:addons/account/models/account_invoice.py:519
 #, python-format
 msgid "Commercial partner and vendor account owners must be identical."
-msgstr ""
+msgstr "Mitra komersial dan pemilik akun vendor harus identik."
 
 #. module: account
 #: model:ir.model,name:account.model_account_common_journal_report
@@ -3215,12 +3219,12 @@ msgstr "Atur"
 #: code:addons/account/static/src/js/section_and_note_fields_backend.js:102
 #, python-format
 msgid "Configure a product"
-msgstr ""
+msgstr "Konfigurasikan sebuah produk"
 
 #. module: account
 #: model:ir.actions.act_window,name:account.action_open_account_onboarding_invoice_layout
 msgid "Configure your document layout"
-msgstr ""
+msgstr "Konfigurasikan tata letak dokumen Anda"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_account_bnk_stmt_cashbox
@@ -3305,7 +3309,7 @@ msgstr "Konten"
 #: model:ir.model.fields,field_description:account.field_res_partner__contracts_count
 #: model:ir.model.fields,field_description:account.field_res_users__contracts_count
 msgid "Contracts Count"
-msgstr ""
+msgstr "Hitungan Kontrak"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_account_journal_form
@@ -3319,6 +3323,8 @@ msgid ""
 "Correction of <a href=# data-oe-model=account.invoice data-oe-"
 "id=%d>%s</a><br>Reason: %s"
 msgstr ""
+"Koreksi dari <a href=# data-oe-model=account.invoice data-oe-"
+"id=%d>%s</a><br>Alasan: %s"
 
 #. module: account
 #: model:account.account.type,name:account.data_account_type_direct_costs
@@ -3371,7 +3377,7 @@ msgstr "Buat"
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_setup_bank_manual_config__create_or_link_option
 msgid "Create Or Link Option"
-msgstr ""
+msgstr "Buat Atau Tautkan Pilihan"
 
 #. module: account
 #: code:addons/account/models/company.py:276
@@ -3486,7 +3492,7 @@ msgstr "Buat model"
 #. module: account
 #: selection:account.setup.bank.manual.config,create_or_link_option:0
 msgid "Create new journal"
-msgstr ""
+msgstr "Membuat jurnal baru"
 
 #. module: account
 #: model_terms:ir.actions.act_window,help:account.rounding_list_action
@@ -3915,7 +3921,7 @@ msgstr ""
 #. module: account
 #: model:ir.model.fields,help:account.field_account_move__reverse_date
 msgid "Date of the reverse accounting entry."
-msgstr ""
+msgstr "Tanggal entri akuntansi terbalik."
 
 #. module: account
 #. openerp-web
@@ -4008,7 +4014,7 @@ msgstr "Nomor Catatan Kredit Khusus"
 #. module: account
 #: model:ir.model.fields,field_description:account.field_res_company__invoice_reference_type
 msgid "Default Communication Type"
-msgstr ""
+msgstr "Standar Jenis Komunikasi"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_journal__default_credit_account_id
@@ -4029,7 +4035,7 @@ msgstr "Pajak Pembelian Standar"
 #. module: account
 #: model:ir.model.fields,help:account.field_res_config_settings__invoice_reference_type
 msgid "Default Reference Type on Invoices."
-msgstr ""
+msgstr "Standar Jenis Referensi pada Faktur."
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_res_company__account_sale_tax_id
@@ -4040,7 +4046,7 @@ msgstr "Pajak Penjualan Standar"
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.res_config_settings_view_form
 msgid "Default Sending Options"
-msgstr ""
+msgstr "Standar Opsi Pengiriman"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_account__tax_ids
@@ -4058,7 +4064,7 @@ msgstr "Default incoterm"
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.res_config_settings_view_form
 msgid "Default payment communication on customer invoices"
-msgstr ""
+msgstr "Standar komunikasi pembayaran pada faktur pelanggan"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.res_config_settings_view_form
@@ -4220,7 +4226,7 @@ msgstr ""
 #: code:addons/account/models/account_move.py:408
 #, python-format
 msgid "Difference debit - credit: "
-msgstr ""
+msgstr "Perbedaan debit - credit: "
 
 #. module: account
 #: model:ir.model,name:account.model_digest_digest
@@ -4243,7 +4249,7 @@ msgstr ""
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.invoice_form
 msgid "Disc (%)"
-msgstr ""
+msgstr "Potongan (%)"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice_line__discount
@@ -4508,7 +4514,7 @@ msgstr "Surel secara bawaan"
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_account_journal_form
 msgid "Email your Vendor Bills"
-msgstr ""
+msgstr "Email Tagihan Pemasok Anda"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_common_journal_report__date_to
@@ -4686,7 +4692,7 @@ msgstr "Negara Federal"
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice_import_wizard__attachment_ids
 msgid "Files"
-msgstr ""
+msgstr "Berkas"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.cash_box_in_form
@@ -4780,12 +4786,12 @@ msgstr "Fiscal Years"
 #. module: account
 #: model:ir.model.fields,help:account.field_account_financial_year_op__fiscalyear_last_day
 msgid "Fiscal year last day."
-msgstr ""
+msgstr "Hari terakhir tahun pajak."
 
 #. module: account
 #: model:ir.model.fields,help:account.field_account_financial_year_op__fiscalyear_last_month
 msgid "Fiscal year last month."
-msgstr ""
+msgstr "Bulan terakhir tahun pajak."
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_financial_year_op__fiscalyear_last_day
@@ -5092,7 +5098,7 @@ msgstr "Kelompok Baris Faktur"
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_register_payments__group_invoices
 msgid "Group Invoices"
-msgstr ""
+msgstr "Kelompok Tagihan"
 
 #. module: account
 #: selection:account.tax,amount_type:0
@@ -5140,7 +5146,7 @@ msgstr "Has all required arguments"
 #: model:ir.model.fields,field_description:account.field_account_invoice_send__has_error
 #: model:ir.model.fields,help:account.field_account_invoice_send__has_error
 msgid "Has error"
-msgstr ""
+msgstr "Ada kesalahan"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_abstract_payment__hide_payment_method

--- a/addons/account/i18n/it.po
+++ b/addons/account/i18n/it.po
@@ -9211,7 +9211,7 @@ msgstr "Selezionare un partner o scegliere una contropartita"
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.invoice_supplier_form
 msgid "Select an old vendor bill"
-msgstr "Selezionare una fattura fornitore precedente"
+msgstr "Seleziona una fattura fornitore precedente"
 
 #. module: account
 #: model:ir.model.fields,help:account.field_account_payment_term_line__value

--- a/addons/account/i18n/ja.po
+++ b/addons/account/i18n/ja.po
@@ -11466,7 +11466,7 @@ msgstr ""
 #: code:addons/account/models/account_payment.py:611
 #, python-format
 msgid "You cannot delete a payment that is already posted."
-msgstr ""
+msgstr "記帳済の支払は削除できません。"
 
 #. module: account
 #: code:addons/account/models/account_invoice.py:786
@@ -11508,6 +11508,8 @@ msgid ""
 "You cannot do this modification on a reconciled entry. You can just change some non legal fields or you must unreconcile first.\n"
 "%s."
 msgstr ""
+"この操作は消込済の仕訳では受け付けられません。会計実績に影響する項目を調整するには、まず消込を取り消してください。\n"
+"%s"
 
 #. module: account
 #: code:addons/account/models/account.py:64
@@ -11544,7 +11546,7 @@ msgstr ""
 #: code:addons/account/models/account_move.py:124
 #, python-format
 msgid "You cannot modify a journal entry linked to a posted payment."
-msgstr ""
+msgstr "記帳済の支払に紐づく仕訳は修正できません。"
 
 #. module: account
 #: code:addons/account/models/account_move.py:331

--- a/addons/account/i18n/nb.po
+++ b/addons/account/i18n/nb.po
@@ -392,7 +392,7 @@ msgstr ""
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.account_journal_dashboard_kanban_view
 msgid "<span role=\"separator\">View</span>"
-msgstr ""
+msgstr "<span role=\"separator\">Vis</span>"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.account_journal_dashboard_kanban_view

--- a/addons/account/i18n/pt_BR.po
+++ b/addons/account/i18n/pt_BR.po
@@ -46,7 +46,9 @@
 # renato sabo <renato.sabo@bradootech.com>, 2020
 # Thiago Alves Cavalcante <thiagoalcav@gmail.com>, 2020
 # Marcel Savegnago <marcel.savegnago@gmail.com>, 2020
-# Luiz Fernando Gondin <lfpsgs@outlook.com>, 2020
+# Luiz Fernando <lfpsgs@outlook.com>, 2020
+# Eduardo Aparicio <eduardo.caparica@gmail.com>, 2020
+# Guilherme Libardi <guilherme.libardig@gmail.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -54,7 +56,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-11-14 07:33+0000\n"
 "PO-Revision-Date: 2018-08-24 09:14+0000\n"
-"Last-Translator: Luiz Fernando Gondin <lfpsgs@outlook.com>, 2020\n"
+"Last-Translator: Guilherme Libardi <guilherme.libardig@gmail.com>, 2020\n"
 "Language-Team: Portuguese (Brazil) (https://www.transifex.com/odoo/teams/41243/pt_BR/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -4246,7 +4248,7 @@ msgstr "Diferença entre o saldo final calculado e o saldo final especificado."
 #: code:addons/account/models/account_move.py:408
 #, python-format
 msgid "Difference debit - credit: "
-msgstr ""
+msgstr "Diferença débito - crédito"
 
 #. module: account
 #: model:ir.model,name:account.model_digest_digest
@@ -4269,7 +4271,7 @@ msgstr ""
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.invoice_form
 msgid "Disc (%)"
-msgstr ""
+msgstr "Desc (%)"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice_line__discount
@@ -4527,7 +4529,7 @@ msgstr ""
 #. module: account
 #: model:ir.model.fields,field_description:account.field_res_company__invoice_is_email
 msgid "Email by default"
-msgstr ""
+msgstr "Email por padrão"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_account_journal_form
@@ -4576,7 +4578,7 @@ msgstr "Entradas classificadas por"
 #: code:addons/account/models/account_move.py:911
 #, python-format
 msgid "Entries are not from the same account."
-msgstr ""
+msgstr "Entradas não pertencem à mesma conta."
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.account_journal_dashboard_kanban_view
@@ -4810,7 +4812,7 @@ msgstr "Primeiro dia do ano fiscal."
 #. module: account
 #: model:ir.model.fields,help:account.field_account_financial_year_op__fiscalyear_last_month
 msgid "Fiscal year last month."
-msgstr ""
+msgstr "Ano fiscal último mês"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_financial_year_op__fiscalyear_last_day
@@ -5157,7 +5159,7 @@ msgstr "Tem entradas não reconciliadas"
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_setup_bank_manual_config__qr_code_valid
 msgid "Has all required arguments"
-msgstr ""
+msgstr "Possui todos os argumentos necessários"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice_send__has_error
@@ -5376,6 +5378,7 @@ msgstr ""
 msgid ""
 "If you have not installed a chart of account, please install one first.<br>"
 msgstr ""
+"Se você não tem um gráfico de fatura, por favor instale um primeiro.<br>"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.account_unreconcile_view
@@ -5739,7 +5742,7 @@ msgstr "\"Faixa de CEP\"inválida, por favor, configure-a corretamente."
 #: code:addons/account/models/company.py:106
 #, python-format
 msgid "Invalid fiscal year last day"
-msgstr ""
+msgstr "Último dia inválido do ano fiscal"
 
 #. module: account
 #: code:addons/account/models/account_invoice.py:1351
@@ -5988,7 +5991,7 @@ msgstr "É um seguidor"
 #: selection:account.reconcile.model,match_amount:0
 #: selection:account.reconcile.model.template,match_amount:0
 msgid "Is Greater Than"
-msgstr ""
+msgstr "É Maior Que"
 
 #. module: account
 #: selection:account.reconcile.model,match_amount:0
@@ -6009,7 +6012,7 @@ msgstr ""
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_reconcile_model__is_tax_price_included
 msgid "Is Tax Included in Price"
-msgstr ""
+msgstr "O imposto está incluso no preço"
 
 #. module: account
 #: model:ir.model.fields,help:account.field_account_invoice_line__is_rounding_line
@@ -6615,7 +6618,7 @@ msgstr "Responsabilidade"
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice_report__nbr
 msgid "Line Count"
-msgstr ""
+msgstr "Total de Linhas"
 
 #. module: account
 #: model:ir.model.fields,field_description:account.field_res_config_settings__show_line_subtotals_tax_selection
@@ -7102,7 +7105,7 @@ msgstr "Necessita ação"
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice_send__need_moderation
 msgid "Need moderation"
-msgstr ""
+msgstr "Precisa de moderação"
 
 #. module: account
 #. openerp-web
@@ -9235,7 +9238,7 @@ msgstr "Enviar Recibo Por Email"
 #. module: account
 #: model:ir.actions.act_window,name:account.action_open_account_onboarding_sample_invoice
 msgid "Send a sample invoice"
-msgstr ""
+msgstr "Enviar uma fatura de exemplo"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.onboarding_sample_invoice_step
@@ -9464,7 +9467,7 @@ msgstr "Documento de Origem"
 #. module: account
 #: model:ir.model.fields,field_description:account.field_account_invoice__source_email
 msgid "Source Email"
-msgstr ""
+msgstr "Email de origem"
 
 #. module: account
 #: model:ir.model.fields,help:account.field_account_cash_rounding__strategy
@@ -9930,7 +9933,7 @@ msgstr "Taxas Excluídas"
 #. module: account
 #: selection:res.config.settings,show_line_subtotals_tax_selection:0
 msgid "Tax-Included"
-msgstr ""
+msgstr "Imposto incluso"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.res_config_settings_view_form
@@ -10158,6 +10161,8 @@ msgid ""
 "Technical field used to know whether the field `partner_bank_account_id` "
 "needs to be displayed or not in the payments form views"
 msgstr ""
+"Campo técnico usado para saber se o campo `partner_bank_account_id` precisa "
+"ser exibido ou não nos formulários de pagamentos"
 
 #. module: account
 #: model:ir.model.fields,help:account.field_account_move_line__tax_exigible

--- a/addons/account/i18n/ro.po
+++ b/addons/account/i18n/ro.po
@@ -4586,7 +4586,7 @@ msgstr ""
 #. module: account
 #: model:account.incoterms,name:account.incoterm_FCA
 msgid "FREE CARRIER"
-msgstr ""
+msgstr "Transport gratuit"
 
 #. module: account
 #: model:account.incoterms,name:account.incoterm_FOB
@@ -9083,7 +9083,7 @@ msgstr "Trimiteți o factură pentru a testa portalul clienților."
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.onboarding_sample_invoice_step
 msgid "Send sample"
-msgstr ""
+msgstr "Trimite eșantion"
 
 #. module: account
 #: selection:account.payment,state:0

--- a/addons/account/i18n/ro.po
+++ b/addons/account/i18n/ro.po
@@ -329,6 +329,9 @@ msgid ""
 "remove\" aria-label=\"Cancelled\" title=\"Cancelled\" role=\"img\"/><span "
 "class=\"d-none d-md-inline\"> Cancelled</span></span>"
 msgstr ""
+"<span class=\"badge badge-pill badge-warning\"><i class=\"fa fa-fw fa-"
+"remove\" aria-label=\"Anulat\" title=\"Anulat\" role=\"img\"/><span "
+"class=\"d-none d-md-inline\"> Anulat</span></span>"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.res_config_settings_view_form
@@ -7830,7 +7833,7 @@ msgstr "Termeni de plată: 15 zile"
 #. module: account
 #: model:account.payment.term,note:account.account_payment_term_2months
 msgid "Payment terms: 2 Months"
-msgstr ""
+msgstr "Termeni de plată: 2 Luni"
 
 #. module: account
 #: model:account.payment.term,note:account.account_payment_term_net

--- a/addons/account/i18n/sk.po
+++ b/addons/account/i18n/sk.po
@@ -11,7 +11,7 @@
 # gebri <gebri@inmail.sk>, 2018
 # Jaroslav Bosansky <jaro.bosansky@ekoenergo.sk>, 2018
 # Matus Krnac <matus.krnac@gmail.com>, 2019
-# Jan Prokop, 2019
+# Jan Prokop, 2020
 # 
 msgid ""
 msgstr ""
@@ -19,7 +19,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-11-14 07:33+0000\n"
 "PO-Revision-Date: 2018-08-24 09:14+0000\n"
-"Last-Translator: Jan Prokop, 2019\n"
+"Last-Translator: Jan Prokop, 2020\n"
 "Language-Team: Slovak (https://www.transifex.com/odoo/teams/41243/sk/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -8753,7 +8753,7 @@ msgstr "Stornovaný záznam"
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.onboarding_chart_of_account_step
 msgid "Review"
-msgstr "Posudok"
+msgstr "Prehľad"
 
 #. module: account
 #: selection:res.company,tax_calculation_rounding_method:0

--- a/addons/account/models/account_invoice.py
+++ b/addons/account/models/account_invoice.py
@@ -867,7 +867,8 @@ class AccountInvoice(models.Model):
                     self.partner_id = False
 
         self.account_id = account_id
-        self.payment_term_id = payment_term_id
+        if payment_term_id:
+            self.payment_term_id = payment_term_id
         self.date_due = False
         self.fiscal_position_id = fiscal_position
 

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -411,7 +411,7 @@ class AccountMove(models.Model):
         # are already done. Then, this query MUST NOT depend of computed stored fields (e.g. balance).
         # It happens as the ORM makes the create with the 'no_recompute' statement.
         self._cr.execute('''
-            SELECT line.move_id, ROUND(SUM(debit - credit), currency.decimal_places)
+            SELECT line.move_id, ROUND(SUM(line.debit - line.credit), currency.decimal_places)
             FROM account_move_line line
             JOIN account_move move ON move.id = line.move_id
             JOIN account_journal journal ON journal.id = move.journal_id
@@ -419,7 +419,7 @@ class AccountMove(models.Model):
             JOIN res_currency currency ON currency.id = company.currency_id
             WHERE line.move_id IN %s
             GROUP BY line.move_id, currency.decimal_places
-            HAVING ROUND(SUM(debit - credit), currency.decimal_places) != 0.0;
+            HAVING ROUND(SUM(line.debit - line.credit), currency.decimal_places) != 0.0;
         ''', [tuple(self.ids)])
 
         res = self._cr.fetchone()

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -376,10 +376,7 @@ class AccountMove(models.Model):
 
     @api.multi
     def unlink(self):
-        for move in self:
-            #check the lock date + check if some entries are reconciled
-            move.line_ids._update_check()
-            move.line_ids.unlink()
+        self.mapped('line_ids').unlink()
         return super(AccountMove, self).unlink()
 
     @api.multi

--- a/addons/account/views/partner_view.xml
+++ b/addons/account/views/partner_view.xml
@@ -42,13 +42,13 @@
                         <group>
                             <field name="tax_ids" widget="one2many_list" nolabel="1">
                                 <tree name="tax_map_tree" string="Tax Mapping" editable="bottom">
-                                    <field name="tax_src_id" domain="[('type_tax_use', '!=', None)]"/>
-                                    <field name="tax_dest_id" domain="[('type_tax_use', '!=', None)]"/>
+                                    <field name="tax_src_id" domain="[('type_tax_use', '!=', 'none')]"/>
+                                    <field name="tax_dest_id" domain="[('type_tax_use', '!=', 'none')]"/>
                                 </tree>
                                 <form name="tax_map_form" string="Tax Mapping">
                                     <group>
-                                        <field name="tax_src_id" domain="[('type_tax_use', '!=', None)]"/>
-                                        <field name="tax_dest_id" domain="[('type_tax_use', '!=', None)]"/>
+                                        <field name="tax_src_id" domain="[('type_tax_use', '!=', 'none')]"/>
+                                        <field name="tax_dest_id" domain="[('type_tax_use', '!=','none')]"/>
                                     </group>
                                 </form>
                             </field>

--- a/addons/account_bank_statement_import/i18n/eu.po
+++ b/addons/account_bank_statement_import/i18n/eu.po
@@ -14,6 +14,7 @@
 # Victor Laskurain <blaskurain@binovo.es>, 2019
 # Maialen Rodriguez <maialenrodriguez98@gmail.com>, 2020
 # Miren Maiz <mirenmaizz@gmail.com>, 2020
+# Unai Muñoz <unaimunoz9@gmail.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -21,7 +22,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2018-09-21 13:17+0000\n"
 "PO-Revision-Date: 2018-08-24 09:15+0000\n"
-"Last-Translator: Miren Maiz <mirenmaizz@gmail.com>, 2020\n"
+"Last-Translator: Unai Muñoz <unaimunoz9@gmail.com>, 2020\n"
 "Language-Team: Basque (https://www.transifex.com/odoo/teams/41243/eu/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -565,7 +566,7 @@ msgstr ""
 #: code:addons/account_bank_statement_import/account_bank_statement_import.py:117
 #, python-format
 msgid "This file doesn't contain any statement."
-msgstr ""
+msgstr "Fitxategi honek ez du adierazpenik."
 
 #. module: account_bank_statement_import
 #: code:addons/account_bank_statement_import/account_bank_statement_import.py:125

--- a/addons/account_bank_statement_import/i18n/eu.po
+++ b/addons/account_bank_statement_import/i18n/eu.po
@@ -275,7 +275,7 @@ msgstr ""
 #. module: account_bank_statement_import
 #: model:ir.model.fields,field_description:account_bank_statement_import.field_account_bank_statement_import_journal_creation__sequence_id
 msgid "Entry Sequence"
-msgstr ""
+msgstr "sarrera Sekuentzia"
 
 #. module: account_bank_statement_import
 #: model:ir.model.fields,field_description:account_bank_statement_import.field_account_bank_statement_import__filename

--- a/addons/account_bank_statement_import/i18n/fr.po
+++ b/addons/account_bank_statement_import/i18n/fr.po
@@ -7,6 +7,7 @@
 # Eloïse Stilmant <est@odoo.com>, 2018
 # Cécile Collart <cco@odoo.com>, 2019
 # Vallen Delobel <edv@odoo.com>, 2020
+# Julien Goergen <jgo@odoo.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -14,7 +15,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2018-09-21 13:17+0000\n"
 "PO-Revision-Date: 2018-08-24 09:15+0000\n"
-"Last-Translator: Vallen Delobel <edv@odoo.com>, 2020\n"
+"Last-Translator: Julien Goergen <jgo@odoo.com>, 2020\n"
 "Language-Team: French (https://www.transifex.com/odoo/teams/41243/fr/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -357,7 +358,7 @@ msgstr "Importation d'un relevé"
 #. module: account_bank_statement_import
 #: model:ir.actions.act_window,name:account_bank_statement_import.install_more_import_formats_action
 msgid "Install Import Format"
-msgstr ""
+msgstr "Installer le Format d'Importation"
 
 #. module: account_bank_statement_import
 #: model:ir.model.fields,help:account_bank_statement_import.field_account_bank_statement_import_journal_creation__default_credit_account_id
@@ -390,7 +391,7 @@ msgstr "Création d'un journal"
 #. module: account_bank_statement_import
 #: model:ir.model,name:account_bank_statement_import.model_account_bank_statement_import_journal_creation
 msgid "Journal Creation on Bank Statement Import"
-msgstr ""
+msgstr "Création d'un Journal sur l'Importation de Relevés Bancaires"
 
 #. module: account_bank_statement_import
 #: model:ir.model.fields,field_description:account_bank_statement_import.field_account_bank_statement_import_journal_creation__name

--- a/addons/account_facturx/models/account_invoice.py
+++ b/addons/account_facturx/models/account_invoice.py
@@ -131,7 +131,10 @@ class AccountInvoice(models.Model):
             if elements:
                 date_str = elements[0].text
                 date_obj = datetime.strptime(date_str, DEFAULT_FACTURX_DATE_FORMAT)
-                invoice_form.date_due = date_obj.strftime(DEFAULT_SERVER_DATE_FORMAT)
+                date_due = date_obj.strftime(DEFAULT_SERVER_DATE_FORMAT)
+                if date_due:
+                    invoice_form.payment_term_id = self.env['account.payment.term']
+                    invoice_form.date_due = date_due
 
             # Invoice lines.
             elements = tree.xpath('//ram:IncludedSupplyChainTradeLineItem', namespaces=tree.nsmap)

--- a/addons/account_payment/i18n/nb.po
+++ b/addons/account_payment/i18n/nb.po
@@ -5,8 +5,8 @@
 # Translators:
 # Martin Trigaux, 2018
 # Jorunn D. Newth, 2018
-# Marius Stedjan <marius@stedjan.com>, 2020
 # Fredrik Ahlsen <fredrik@gdx.no>, 2020
+# Marius Stedjan <marius@stedjan.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -14,7 +14,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2018-09-18 09:49+0000\n"
 "PO-Revision-Date: 2018-08-24 09:15+0000\n"
-"Last-Translator: Fredrik Ahlsen <fredrik@gdx.no>, 2020\n"
+"Last-Translator: Marius Stedjan <marius@stedjan.com>, 2020\n"
 "Language-Team: Norwegian Bokmål (https://www.transifex.com/odoo/teams/41243/nb/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -44,17 +44,17 @@ msgstr ""
 #. module: account_payment
 #: model_terms:ir.ui.view,arch_db:account_payment.portal_invoice_page_inherit_payment
 msgid "<i class=\"fa fa-fw fa-arrow-circle-right\"/> Pay Now"
-msgstr ""
+msgstr "<i class=\"fa fa-fw fa-arrow-circle-right\"/> Betal nå"
 
 #. module: account_payment
 #: model_terms:ir.ui.view,arch_db:account_payment.portal_invoice_page_inherit_payment
 msgid "<i class=\"fa fa-fw fa-check-circle\"/> Paid"
-msgstr ""
+msgstr "<i class=\"fa fa-fw fa-check-circle\"/> Betalt"
 
 #. module: account_payment
 #: model_terms:ir.ui.view,arch_db:account_payment.portal_invoice_page_inherit_payment
 msgid "<i class=\"fa fa-fw fa-check-circle\"/> Pending"
-msgstr ""
+msgstr "<i class=\"fa fa-fw fa-check-circle\"/> Avventende"
 
 #. module: account_payment
 #: model_terms:ir.ui.view,arch_db:account_payment.portal_invoice_page_inherit_payment
@@ -62,6 +62,8 @@ msgid ""
 "<i class=\"fa fa-info\"/> You have credits card registered, you can log-in "
 "to be able to use them."
 msgstr ""
+"<i class=\"fa fa-info\"/>Du har registrerte bankkort. Logg inn for å bruke "
+"dem."
 
 #. module: account_payment
 #: model_terms:ir.ui.view,arch_db:account_payment.portal_my_invoices_payment
@@ -79,6 +81,8 @@ msgid ""
 "clock-o\"/><span class=\"d-none d-md-inline\"> Waiting for "
 "Payment</span></span>"
 msgstr ""
+"<span class=\"badge badge-pill badge-info\"><i class=\"fa fa-fw fa-"
+"clock-o\"/><span class=\"d-none d-md-inline\"> Venter på betaling</span>"
 
 #. module: account_payment
 #: model_terms:ir.ui.view,arch_db:account_payment.portal_my_invoices_payment
@@ -86,6 +90,8 @@ msgid ""
 "<span class=\"badge badge-pill badge-primary\"><i class=\"fa fa-fw fa-"
 "check\"/><span class=\"d-none d-md-inline\"> Authorized</span></span>"
 msgstr ""
+"<span class=\"badge badge-pill badge-primary\"><i class=\"fa fa-fw fa-"
+"check\"/><span class=\"d-none d-md-inline\"> Autorisert</span></span>"
 
 #. module: account_payment
 #: model_terms:ir.ui.view,arch_db:account_payment.portal_my_invoices_payment
@@ -93,6 +99,8 @@ msgid ""
 "<span class=\"badge badge-pill badge-success\"><i class=\"fa fa-fw fa-"
 "check\"/><span class=\"d-none d-md-inline\"> Paid</span></span>"
 msgstr ""
+"<span class=\"badge badge-pill badge-success\"><i class=\"fa fa-fw fa-"
+"check\"/><span class=\"d-none d-md-inline\"> Betalt</span></span>"
 
 #. module: account_payment
 #: model_terms:ir.ui.view,arch_db:account_payment.portal_my_invoices_payment
@@ -100,13 +108,15 @@ msgid ""
 "<span class=\"badge badge-pill badge-warning\"><span class=\"d-none d-md-"
 "inline\"> Pending</span></span>"
 msgstr ""
+"<span class=\"badge badge-pill badge-warning\"><span class=\"d-none d-md-"
+"inline\"> Avventende</span></span>"
 
 #. module: account_payment
 #: model_terms:ir.ui.view,arch_db:account_payment.portal_invoice_success
 msgid ""
 "Done, your online payment has been successfully processed. Thank you for "
 "your order."
-msgstr ""
+msgstr "Fullført. Din betaling er gjennomført. Takk for din ordre."
 
 #. module: account_payment
 #: code:addons/account_payment/controllers/payment.py:47
@@ -133,7 +143,7 @@ msgstr "Betal nå"
 #. module: account_payment
 #: model_terms:ir.ui.view,arch_db:account_payment.portal_my_invoices_payment
 msgid "Pay now"
-msgstr ""
+msgstr "Betal nå"
 
 #. module: account_payment
 #: model_terms:ir.ui.view,arch_db:account_payment.portal_invoice_payment

--- a/addons/account_payment/i18n/ro.po
+++ b/addons/account_payment/i18n/ro.po
@@ -4,7 +4,7 @@
 # 
 # Translators:
 # Martin Trigaux, 2018
-# Dorin Hongu <dhongu@gmail.com>, 2019
+# Dorin Hongu <dhongu@gmail.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -12,7 +12,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2018-09-18 09:49+0000\n"
 "PO-Revision-Date: 2018-08-24 09:15+0000\n"
-"Last-Translator: Dorin Hongu <dhongu@gmail.com>, 2019\n"
+"Last-Translator: Dorin Hongu <dhongu@gmail.com>, 2020\n"
 "Language-Team: Romanian (https://www.transifex.com/odoo/teams/41243/ro/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -36,11 +36,13 @@ msgid ""
 "<i class=\"fa fa-arrow-circle-right\"/><span class=\"d-none d-md-inline\"> "
 "Pay Now</span>"
 msgstr ""
+"<i class=\"fa fa-arrow-circle-right\"/><span class=\"d-none d-md-"
+"inline\">Achită acum</span>"
 
 #. module: account_payment
 #: model_terms:ir.ui.view,arch_db:account_payment.portal_invoice_page_inherit_payment
 msgid "<i class=\"fa fa-fw fa-arrow-circle-right\"/> Pay Now"
-msgstr ""
+msgstr "<i class=\"fa fa-fw fa-arrow-circle-right\"/>Achită acum"
 
 #. module: account_payment
 #: model_terms:ir.ui.view,arch_db:account_payment.portal_invoice_page_inherit_payment
@@ -130,7 +132,7 @@ msgstr "Achită acum"
 #. module: account_payment
 #: model_terms:ir.ui.view,arch_db:account_payment.portal_my_invoices_payment
 msgid "Pay now"
-msgstr ""
+msgstr "Achită acum"
 
 #. module: account_payment
 #: model_terms:ir.ui.view,arch_db:account_payment.portal_invoice_payment

--- a/addons/account_tax_python/i18n/eu.po
+++ b/addons/account_tax_python/i18n/eu.po
@@ -6,6 +6,7 @@
 # Martin Trigaux, 2019
 # Esther Martín Menéndez <esthermartin001@gmail.com>, 2019
 # Mikel Lizarralde <mikellizarralde@gmail.com>, 2019
+# Miren Maiz <mirenmaizz@gmail.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -13,7 +14,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2018-09-18 09:49+0000\n"
 "PO-Revision-Date: 2018-08-24 09:15+0000\n"
-"Last-Translator: Mikel Lizarralde <mikellizarralde@gmail.com>, 2019\n"
+"Last-Translator: Miren Maiz <mirenmaizz@gmail.com>, 2020\n"
 "Language-Team: Basque (https://www.transifex.com/odoo/teams/41243/eu/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -116,7 +117,7 @@ msgstr "Zerga"
 #: model:ir.model.fields,field_description:account_tax_python.field_account_tax__amount_type
 #: model:ir.model.fields,field_description:account_tax_python.field_account_tax_template__amount_type
 msgid "Tax Computation"
-msgstr ""
+msgstr "Zerga kalkulua"
 
 #. module: account_tax_python
 #: model:ir.model,name:account_tax_python.model_account_tax_template

--- a/addons/account_voucher/i18n/eu.po
+++ b/addons/account_voucher/i18n/eu.po
@@ -14,6 +14,7 @@
 # Victor Laskurain <blaskurain@binovo.es>, 2019
 # Gorka Toledo <gorka.toledo@gmail.com>, 2019
 # Maialen Rodriguez <maialenrodriguez98@gmail.com>, 2020
+# Miren Maiz <mirenmaizz@gmail.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -21,7 +22,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-11-14 07:33+0000\n"
 "PO-Revision-Date: 2018-08-24 09:15+0000\n"
-"Last-Translator: Maialen Rodriguez <maialenrodriguez98@gmail.com>, 2020\n"
+"Last-Translator: Miren Maiz <mirenmaizz@gmail.com>, 2020\n"
 "Language-Team: Basque (https://www.transifex.com/odoo/teams/41243/eu/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -695,4 +696,4 @@ msgstr ""
 #: code:addons/account_voucher/models/account_voucher.py:457
 #, python-format
 msgid "You must first select a partner."
-msgstr ""
+msgstr "Lehendabizi bazkide bat aukeratu behar duzu."

--- a/addons/account_voucher/i18n/eu.po
+++ b/addons/account_voucher/i18n/eu.po
@@ -15,6 +15,7 @@
 # Gorka Toledo <gorka.toledo@gmail.com>, 2019
 # Maialen Rodriguez <maialenrodriguez98@gmail.com>, 2020
 # Miren Maiz <mirenmaizz@gmail.com>, 2020
+# Unai Muñoz <unaimunoz9@gmail.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -22,7 +23,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-11-14 07:33+0000\n"
 "PO-Revision-Date: 2018-08-24 09:15+0000\n"
-"Last-Translator: Miren Maiz <mirenmaizz@gmail.com>, 2020\n"
+"Last-Translator: Unai Muñoz <unaimunoz9@gmail.com>, 2020\n"
 "Language-Team: Basque (https://www.transifex.com/odoo/teams/41243/eu/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -400,12 +401,12 @@ msgstr "Kidea"
 #. module: account_voucher
 #: selection:account.voucher,pay_now:0
 msgid "Pay Directly"
-msgstr ""
+msgstr "Zuzenean ordaindu"
 
 #. module: account_voucher
 #: selection:account.voucher,pay_now:0
 msgid "Pay Later"
-msgstr ""
+msgstr "Geroago ordaindu"
 
 #. module: account_voucher
 #: model:ir.model.fields,field_description:account_voucher.field_account_voucher__pay_now

--- a/addons/analytic/i18n/fr.po
+++ b/addons/analytic/i18n/fr.po
@@ -9,6 +9,8 @@
 # Nathan Grognet <ngr@odoo.com>, 2018
 # Martin Trigaux, 2019
 # Cécile Collart <cco@odoo.com>, 2020
+# Vallen Delobel <edv@odoo.com>, 2020
+# Priscilla Sanchez <prs@odoo.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -16,7 +18,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-03-29 10:09+0000\n"
 "PO-Revision-Date: 2018-08-24 09:15+0000\n"
-"Last-Translator: Cécile Collart <cco@odoo.com>, 2020\n"
+"Last-Translator: Priscilla Sanchez <prs@odoo.com>, 2020\n"
 "Language-Team: French (https://www.transifex.com/odoo/teams/41243/fr/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -66,7 +68,7 @@ msgstr "Compte analytique"
 #. module: analytic
 #: model:ir.model,name:analytic.model_account_analytic_distribution
 msgid "Analytic Account Distribution"
-msgstr ""
+msgstr "Distribution de compte analytique"
 
 #. module: analytic
 #: model:ir.actions.act_window,name:analytic.account_analytic_group_action
@@ -83,7 +85,7 @@ msgstr "Comptabilité analytique"
 #. module: analytic
 #: model:res.groups,name:analytic.group_analytic_tags
 msgid "Analytic Accounting Tags"
-msgstr ""
+msgstr "Etiquettes de comptabilité analytique"
 
 #. module: analytic
 #: model:ir.actions.act_window,name:analytic.action_account_analytic_account_form
@@ -531,6 +533,8 @@ msgid ""
 "The selected account belongs to another company that the one you're trying "
 "to create an analytic item for"
 msgstr ""
+"Le compte sélectionné appartient à une autre société que celle pour laquelle"
+" vous essayez de créer un élément d'analyse"
 
 #. module: analytic
 #: model_terms:ir.actions.act_window,help:analytic.account_analytic_group_action

--- a/addons/auth_oauth/i18n/fr.po
+++ b/addons/auth_oauth/i18n/fr.po
@@ -6,6 +6,7 @@
 # Martin Trigaux, 2018
 # Marie Willemyns <mwi@odoo.com>, 2018
 # Cécile Collart <cco@odoo.com>, 2020
+# Jonathan Quique <jqu@odoo.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -13,7 +14,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-11-14 07:34+0000\n"
 "PO-Revision-Date: 2018-08-24 09:15+0000\n"
-"Last-Translator: Cécile Collart <cco@odoo.com>, 2020\n"
+"Last-Translator: Jonathan Quique <jqu@odoo.com>, 2020\n"
 "Language-Team: French (https://www.transifex.com/odoo/teams/41243/fr/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -131,7 +132,7 @@ msgstr "Dernière mise à jour le"
 #. module: auth_oauth
 #: model:ir.model.fields,help:auth_oauth.field_auth_oauth_provider__body
 msgid "Link text in Login Dialog"
-msgstr ""
+msgstr "Texte du lien dans l'invite de connexion"
 
 #. module: auth_oauth
 #: model:auth.oauth.provider,body:auth_oauth.provider_facebook

--- a/addons/auth_password_policy/i18n/fr.po
+++ b/addons/auth_password_policy/i18n/fr.po
@@ -7,6 +7,7 @@
 # Marie Willemyns <mwi@odoo.com>, 2018
 # Lionel COUSTEIX <l.cousteix@outlook.com>, 2019
 # Cécile Collart <cco@odoo.com>, 2020
+# Priscilla Sanchez <prs@odoo.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -14,7 +15,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2018-10-08 06:48+0000\n"
 "PO-Revision-Date: 2018-10-08 07:10+0000\n"
-"Last-Translator: Cécile Collart <cco@odoo.com>, 2020\n"
+"Last-Translator: Priscilla Sanchez <prs@odoo.com>, 2020\n"
 "Language-Team: French (https://www.transifex.com/odoo/teams/41243/fr/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -70,7 +71,7 @@ msgstr "Utilisateurs"
 #: code:addons/auth_password_policy/static/src/js/password_gauge.js:28
 #, python-format
 msgid "at least %d character classes"
-msgstr ""
+msgstr "au moins %d classes de caractères"
 
 #. module: auth_password_policy
 #. openerp-web

--- a/addons/auth_signup/i18n/eu.po
+++ b/addons/auth_signup/i18n/eu.po
@@ -7,6 +7,7 @@
 # oihane <oihanecruce@gmail.com>, 2019
 # Esther Martín Menéndez <esthermartin001@gmail.com>, 2019
 # Maialen Rodriguez <maialenrodriguez98@gmail.com>, 2020
+# Unai Muñoz <unaimunoz9@gmail.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -14,7 +15,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-03-29 10:09+0000\n"
 "PO-Revision-Date: 2018-08-24 09:16+0000\n"
-"Last-Translator: Maialen Rodriguez <maialenrodriguez98@gmail.com>, 2020\n"
+"Last-Translator: Unai Muñoz <unaimunoz9@gmail.com>, 2020\n"
 "Language-Team: Basque (https://www.transifex.com/odoo/teams/41243/eu/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -310,7 +311,7 @@ msgstr ""
 #. module: auth_signup
 #: model_terms:ir.ui.view,arch_db:auth_signup.signup
 msgid "Already have an account?"
-msgstr ""
+msgstr "Dagoeneko kontu bat al duzu?"
 
 #. module: auth_signup
 #: code:addons/auth_signup/controllers/main.py:80
@@ -396,7 +397,7 @@ msgstr ""
 #. module: auth_signup
 #: model_terms:ir.ui.view,arch_db:auth_signup.login
 msgid "Don't have an account?"
-msgstr ""
+msgstr "Ez daukazu konturik?"
 
 #. module: auth_signup
 #: model:ir.model.fields,field_description:auth_signup.field_res_config_settings__auth_signup_reset_password
@@ -439,12 +440,12 @@ msgstr "Pasahitza"
 #. module: auth_signup
 #: model_terms:ir.ui.view,arch_db:auth_signup.res_config_settings_view_form
 msgid "Password Reset"
-msgstr ""
+msgstr "Pasahitza Berrezarri"
 
 #. module: auth_signup
 #: model:mail.template,subject:auth_signup.reset_password_email
 msgid "Password reset"
-msgstr ""
+msgstr "Pasahitza berrezarri"
 
 #. module: auth_signup
 #: code:addons/auth_signup/controllers/main.py:125

--- a/addons/auth_signup/i18n/fr.po
+++ b/addons/auth_signup/i18n/fr.po
@@ -8,6 +8,8 @@
 # Marie Willemyns <mwi@odoo.com>, 2018
 # William Olhasque <william.olhasque@scopea.fr>, 2019
 # Cécile Collart <cco@odoo.com>, 2019
+# Priscilla Sanchez <prs@odoo.com>, 2020
+# Vallen Delobel <edv@odoo.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -15,7 +17,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-03-29 10:09+0000\n"
 "PO-Revision-Date: 2018-08-24 09:16+0000\n"
-"Last-Translator: Cécile Collart <cco@odoo.com>, 2019\n"
+"Last-Translator: Vallen Delobel <edv@odoo.com>, 2020\n"
 "Language-Team: French (https://www.transifex.com/odoo/teams/41243/fr/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -790,13 +792,13 @@ msgstr "Le jeton d'inscription « %s » n'est pas valide"
 #: code:addons/auth_signup/models/res_users.py:138
 #, python-format
 msgid "Signup: invalid template user"
-msgstr ""
+msgstr "Inscriptio : Utilisateur de modèle non valide"
 
 #. module: auth_signup
 #: code:addons/auth_signup/models/res_users.py:141
 #, python-format
 msgid "Signup: no login given for new user"
-msgstr ""
+msgstr "Inscription : pas d'identifiant donné pour ce nouvel utilisateur"
 
 #. module: auth_signup
 #: code:addons/auth_signup/models/res_users.py:143
@@ -834,6 +836,9 @@ msgid ""
 "list view and click on 'Portal Access Management' option in the dropdown "
 "menu *Action*."
 msgstr ""
+"Pour envoyer des invitations en mode B2B, ouvrez un contact ou sélectionnez-"
+"en plusieurs dans la liste et cliquez sur l'option 'Portal Access "
+"Management' dans le menu déroulant * Action *."
 
 #. module: auth_signup
 #: model:ir.model,name:auth_signup.model_res_users

--- a/addons/base_automation/i18n/eu.po
+++ b/addons/base_automation/i18n/eu.po
@@ -12,7 +12,8 @@
 # Mikel Lizarralde <mikellizarralde@gmail.com>, 2019
 # Naomi Hidalgo <naomihid96@gmail.com>, 2019
 # Victor Laskurain <blaskurain@binovo.es>, 2019
-# Mikel Galarza <mikelgalarza99@gmail.com>, 2020
+# mgalarza005 <mikelgalarza99@gmail.com>, 2020
+# Unai Muñoz <unaimunoz9@gmail.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -20,7 +21,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-11-14 07:34+0000\n"
 "PO-Revision-Date: 2018-08-24 09:16+0000\n"
-"Last-Translator: Mikel Galarza <mikelgalarza99@gmail.com>, 2020\n"
+"Last-Translator: Unai Muñoz <unaimunoz9@gmail.com>, 2020\n"
 "Language-Team: Basque (https://www.transifex.com/odoo/teams/41243/eu/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -82,7 +83,7 @@ msgstr "Jarraitzaileak gehitu"
 #. module: base_automation
 #: model:ir.model.fields,field_description:base_automation.field_base_automation__filter_domain
 msgid "Apply on"
-msgstr ""
+msgstr "Aplikatu"
 
 #. module: base_automation
 #: model:ir.model.fields,field_description:base_automation.field_base_automation_lead_test__is_assigned_to_admin
@@ -93,7 +94,7 @@ msgstr ""
 #: selection:ir.actions.server,usage:0
 #: model:ir.model,name:base_automation.model_base_automation
 msgid "Automated Action"
-msgstr ""
+msgstr "Ekintza automatizatua"
 
 #. module: base_automation
 #: model:ir.actions.act_window,name:base_automation.base_automation_act
@@ -440,7 +441,7 @@ msgstr ""
 #. module: base_automation
 #: selection:base.automation,trigger:0
 msgid "On Creation"
-msgstr ""
+msgstr "Sortzen"
 
 #. module: base_automation
 #: selection:base.automation,trigger:0
@@ -455,7 +456,7 @@ msgstr ""
 #. module: base_automation
 #: selection:base.automation,trigger:0
 msgid "On Update"
-msgstr ""
+msgstr "Eguneratzen"
 
 #. module: base_automation
 #: model:ir.model.fields,help:base_automation.field_base_automation__help
@@ -603,7 +604,7 @@ msgstr ""
 #. module: base_automation
 #: model:ir.model.fields,field_description:base_automation.field_base_automation__trg_date_calendar_id
 msgid "Use Calendar"
-msgstr ""
+msgstr "Egutegia erabili"
 
 #. module: base_automation
 #: model_terms:ir.actions.act_window,help:base_automation.base_automation_act

--- a/addons/base_automation/i18n/eu.po
+++ b/addons/base_automation/i18n/eu.po
@@ -12,6 +12,7 @@
 # Mikel Lizarralde <mikellizarralde@gmail.com>, 2019
 # Naomi Hidalgo <naomihid96@gmail.com>, 2019
 # Victor Laskurain <blaskurain@binovo.es>, 2019
+# Mikel Galarza <mikelgalarza99@gmail.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -19,7 +20,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-11-14 07:34+0000\n"
 "PO-Revision-Date: 2018-08-24 09:16+0000\n"
-"Last-Translator: Victor Laskurain <blaskurain@binovo.es>, 2019\n"
+"Last-Translator: Mikel Galarza <mikelgalarza99@gmail.com>, 2020\n"
 "Language-Team: Basque (https://www.transifex.com/odoo/teams/41243/eu/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -71,12 +72,12 @@ msgstr ""
 #. module: base_automation
 #: model:ir.model.fields,field_description:base_automation.field_base_automation__channel_ids
 msgid "Add Channels"
-msgstr ""
+msgstr "Kanalak gehitu"
 
 #. module: base_automation
 #: model:ir.model.fields,field_description:base_automation.field_base_automation__partner_ids
 msgid "Add Followers"
-msgstr ""
+msgstr "Jarraitzaileak gehitu"
 
 #. module: base_automation
 #: model:ir.model.fields,field_description:base_automation.field_base_automation__filter_domain

--- a/addons/base_automation/i18n/fr.po
+++ b/addons/base_automation/i18n/fr.po
@@ -11,6 +11,8 @@
 # Martin Trigaux, 2019
 # Alexandra Jubert <aju@odoo.com>, 2020
 # Cécile Collart <cco@odoo.com>, 2020
+# Vallen Delobel <edv@odoo.com>, 2020
+# Julien Goergen <jgo@odoo.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -18,7 +20,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-11-14 07:34+0000\n"
 "PO-Revision-Date: 2018-08-24 09:16+0000\n"
-"Last-Translator: Cécile Collart <cco@odoo.com>, 2020\n"
+"Last-Translator: Julien Goergen <jgo@odoo.com>, 2020\n"
 "Language-Team: French (https://www.transifex.com/odoo/teams/41243/fr/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -29,7 +31,7 @@ msgstr ""
 #. module: base_automation
 #: model:mail.template,body_html:base_automation.test_mail_template_automation
 msgid "<div>Email automation</div>"
-msgstr ""
+msgstr "<div>Automation des e-mails</div>"
 
 #. module: base_automation
 #: model:ir.model.fields,field_description:base_automation.field_base_automation__help
@@ -102,7 +104,7 @@ msgstr "Actions automatisées"
 #. module: base_automation
 #: model:ir.model,name:base_automation.model_base_automation_line_test
 msgid "Automated Rule Line Test"
-msgstr ""
+msgstr "Test de ligne de règle automatisé"
 
 #. module: base_automation
 #: model:ir.model,name:base_automation.model_base_automation_lead_test
@@ -163,7 +165,7 @@ msgstr ""
 #: model:base.automation,name:base_automation.test_rule_on_write_recompute_send_email
 #: model:ir.actions.server,name:base_automation.test_rule_on_write_recompute_send_email_ir_actions_server
 msgid "Base Automation: test send an email"
-msgstr ""
+msgstr "Automatisation de la base : test envoyer un courriel"
 
 #. module: base_automation
 #: selection:base.automation,trigger:0

--- a/addons/base_gengo/i18n/da.po
+++ b/addons/base_gengo/i18n/da.po
@@ -8,7 +8,7 @@
 # Morten Schou <ms@msteknik.dk>, 2018
 # Jesper Carstensen <jc@danodoo.dk>, 2018
 # lhmflexerp <lhm@flexerp.dk>, 2018
-# Sanne Kristensen <sanne@vkdata.dk>, 2018
+# Sanne Kristensen <sanne@vkdata.dk>, 2020
 # 
 msgid ""
 msgstr ""
@@ -16,7 +16,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-01-22 11:11+0000\n"
 "PO-Revision-Date: 2018-08-24 09:16+0000\n"
-"Last-Translator: Sanne Kristensen <sanne@vkdata.dk>, 2018\n"
+"Last-Translator: Sanne Kristensen <sanne@vkdata.dk>, 2020\n"
 "Language-Team: Danish (https://www.transifex.com/odoo/teams/41243/da/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -291,7 +291,7 @@ msgstr "Standard"
 #. module: base_gengo
 #: model:ir.model.fields,field_description:base_gengo.field_base_gengo_translations__sync_type
 msgid "Sync Type"
-msgstr ""
+msgstr "Sync type"
 
 #. module: base_gengo
 #: code:addons/base_gengo/wizard/base_gengo_translations.py:115

--- a/addons/base_import/i18n/es.po
+++ b/addons/base_import/i18n/es.po
@@ -6,8 +6,9 @@
 # Miguel Orueta <mo@landoo.es>, 2018
 # Martin Trigaux, 2018
 # Emilio Silva <efsilvay@gmail.com>, 2018
-# Gabriel Umana <gabriel.umana@delfixcr.com>, 2019
+# gabriumaa <gabriel.umana@delfixcr.com>, 2019
 # Jon Perez <jop@odoo.com>, 2019
+# Osiris Román <osiris.roman@yachaytech.edu.ec>, 2020
 # 
 msgid ""
 msgstr ""
@@ -15,7 +16,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2018-10-02 10:05+0000\n"
 "PO-Revision-Date: 2018-08-24 09:16+0000\n"
-"Last-Translator: Jon Perez <jop@odoo.com>, 2019\n"
+"Last-Translator: Osiris Román <osiris.roman@yachaytech.edu.ec>, 2020\n"
 "Language-Team: Spanish (https://www.transifex.com/odoo/teams/41243/es/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -77,7 +78,7 @@ msgstr "Importar Base"
 #. module: base_import
 #: model:ir.model,name:base_import.model_base_import_mapping
 msgid "Base Import Mapping"
-msgstr ""
+msgstr "Mapeo de importación base"
 
 #. module: base_import
 #. openerp-web
@@ -593,7 +594,7 @@ msgstr "¿Necesitas ayuda?"
 #: code:addons/base_import/static/src/js/import_action.js:231
 #, python-format
 msgid "No Separator"
-msgstr ""
+msgstr "Sin separador"
 
 #. module: base_import
 #. openerp-web
@@ -688,77 +689,80 @@ msgstr "Probar importación"
 #. module: base_import
 #: model:ir.model,name:base_import.model_base_import_tests_models_preview
 msgid "Tests : Base Import Model Preview"
-msgstr ""
+msgstr "Pruebas: Vista previa del modelo de importación base"
 
 #. module: base_import
 #: model:ir.model,name:base_import.model_base_import_tests_models_char
 msgid "Tests : Base Import Model, Character"
-msgstr ""
+msgstr "Pruebas: modelo de importación base, personaje"
 
 #. module: base_import
 #: model:ir.model,name:base_import.model_base_import_tests_models_char_noreadonly
 msgid "Tests : Base Import Model, Character No readonly"
-msgstr ""
+msgstr "Pruebas: modelo de importación base, carácter no solo lectura"
 
 #. module: base_import
 #: model:ir.model,name:base_import.model_base_import_tests_models_char_readonly
 msgid "Tests : Base Import Model, Character readonly"
-msgstr ""
+msgstr "Pruebas: modelo de importación base, solo lectura de caracteres"
 
 #. module: base_import
 #: model:ir.model,name:base_import.model_base_import_tests_models_char_required
 msgid "Tests : Base Import Model, Character required"
-msgstr ""
+msgstr "Pruebas: Modelo de importación base, se requiere personaje"
 
 #. module: base_import
 #: model:ir.model,name:base_import.model_base_import_tests_models_char_states
 msgid "Tests : Base Import Model, Character states"
-msgstr ""
+msgstr "Pruebas: modelo de importación base, estados de caracteres"
 
 #. module: base_import
 #: model:ir.model,name:base_import.model_base_import_tests_models_char_stillreadonly
 msgid "Tests : Base Import Model, Character still readonly"
 msgstr ""
+"Pruebas: Modelo de importación base, el personaje sigue siendo de solo "
+"lectura"
 
 #. module: base_import
 #: model:ir.model,name:base_import.model_base_import_tests_models_m2o
 msgid "Tests : Base Import Model, Many to One"
-msgstr ""
+msgstr "Pruebas: Modelo de importación de base, muchos a uno"
 
 #. module: base_import
 #: model:ir.model,name:base_import.model_base_import_tests_models_m2o_related
 msgid "Tests : Base Import Model, Many to One related"
-msgstr ""
+msgstr "Pruebas: modelo base de importación, muchos a uno relacionados"
 
 #. module: base_import
 #: model:ir.model,name:base_import.model_base_import_tests_models_m2o_required
 msgid "Tests : Base Import Model, Many to One required"
-msgstr ""
+msgstr "Pruebas: modelo de importación base, se requieren muchos a uno"
 
 #. module: base_import
 #: model:ir.model,name:base_import.model_base_import_tests_models_m2o_required_related
 msgid "Tests : Base Import Model, Many to One required related"
 msgstr ""
+"Pruebas: modelo de importación base, muchos a uno requerido relacionado"
 
 #. module: base_import
 #: model:ir.model,name:base_import.model_base_import_tests_models_o2m
 msgid "Tests : Base Import Model, One to Many"
-msgstr ""
+msgstr "Pruebas: Modelo de importación base, uno a muchos"
 
 #. module: base_import
 #: model:ir.model,name:base_import.model_base_import_tests_models_o2m_child
 msgid "Tests : Base Import Model, One to Many child"
-msgstr ""
+msgstr "Pruebas: Modelo de importación base, uno a muchos niños"
 
 #. module: base_import
 #: model:ir.model,name:base_import.model_base_import_tests_models_complex
 msgid "Tests: Base Import Model Complex"
-msgstr ""
+msgstr "Pruebas: complejo de modelo de importación base"
 
 #. module: base_import
 #: model:ir.model,name:base_import.model_base_import_tests_models_float
 msgid "Tests: Base Import Model Float"
-msgstr ""
+msgstr "Pruebas: flotante de modelo de importación base"
 
 #. module: base_import
 #. openerp-web

--- a/addons/base_import/i18n/fr.po
+++ b/addons/base_import/i18n/fr.po
@@ -9,6 +9,8 @@
 # Olivier ANDRE <frsw194@gmail.com>, 2018
 # Guillaume Piens <gup@odoo.com>, 2019
 # Mélanie Botty <bom@odoo.com>, 2019
+# Julien Goergen <jgo@odoo.com>, 2020
+# Priscilla Sanchez <prs@odoo.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -16,7 +18,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2018-10-02 10:05+0000\n"
 "PO-Revision-Date: 2018-08-24 09:16+0000\n"
-"Last-Translator: Mélanie Botty <bom@odoo.com>, 2019\n"
+"Last-Translator: Priscilla Sanchez <prs@odoo.com>, 2020\n"
 "Language-Team: French (https://www.transifex.com/odoo/teams/41243/fr/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -759,17 +761,17 @@ msgstr "Tests: Modèle d'importation de base, Un à plusieurs"
 #. module: base_import
 #: model:ir.model,name:base_import.model_base_import_tests_models_o2m_child
 msgid "Tests : Base Import Model, One to Many child"
-msgstr ""
+msgstr "Tests: Modèle d'importation de base, One to Many child"
 
 #. module: base_import
 #: model:ir.model,name:base_import.model_base_import_tests_models_complex
 msgid "Tests: Base Import Model Complex"
-msgstr ""
+msgstr "Tests: Complexe du Modèle d'Importation de Base"
 
 #. module: base_import
 #: model:ir.model,name:base_import.model_base_import_tests_models_float
 msgid "Tests: Base Import Model Float"
-msgstr ""
+msgstr "Tests: Base Import Model Float"
 
 #. module: base_import
 #. openerp-web

--- a/addons/base_setup/i18n/es.po
+++ b/addons/base_setup/i18n/es.po
@@ -10,6 +10,7 @@
 # Efrem Jimenez <efj@odoo.com>, 2019
 # Pedro M. Baeza <pedro.baeza@gmail.com>, 2019
 # Jesse Garza <jga@odoo.com>, 2019
+# Osiris Román <osiris.roman@yachaytech.edu.ec>, 2020
 # 
 msgid ""
 msgstr ""
@@ -17,7 +18,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2018-09-21 13:17+0000\n"
 "PO-Revision-Date: 2018-08-24 09:16+0000\n"
-"Last-Translator: Jesse Garza <jga@odoo.com>, 2019\n"
+"Last-Translator: Osiris Román <osiris.roman@yachaytech.edu.ec>, 2020\n"
 "Language-Team: Spanish (https://www.transifex.com/odoo/teams/41243/es/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -66,7 +67,7 @@ msgstr "Permisos de acceso"
 #. module: base_setup
 #: model_terms:ir.ui.view,arch_db:base_setup.res_config_settings_view_form
 msgid "Add fun feedback and motivate your employees"
-msgstr ""
+msgstr "Agregue comentarios divertidos y motive a sus empleados"
 
 #. module: base_setup
 #: model:ir.model.fields,field_description:base_setup.field_res_config_settings__module_google_calendar
@@ -347,7 +348,7 @@ msgstr ""
 #. module: base_setup
 #: model:ir.model.fields,field_description:base_setup.field_res_config_settings__show_effect
 msgid "Show Effect"
-msgstr ""
+msgstr "Mostrar efecto"
 
 #. module: base_setup
 #: model_terms:ir.ui.view,arch_db:base_setup.res_config_settings_view_form
@@ -406,3 +407,6 @@ msgid ""
 "companies. When selecting one item, the company data and logo are auto-"
 "filled."
 msgstr ""
+"Al completar su libreta de direcciones, Odoo proporciona una lista de "
+"empresas coincidentes. Al seleccionar un elemento, los datos de la empresa y"
+" el logotipo se completan automáticamente."

--- a/addons/base_setup/i18n/fr.po
+++ b/addons/base_setup/i18n/fr.po
@@ -10,6 +10,7 @@
 # Marie Willemyns <mwi@odoo.com>, 2018
 # William Olhasque <william.olhasque@scopea.fr>, 2019
 # Cécile Collart <cco@odoo.com>, 2019
+# Vallen Delobel <edv@odoo.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -17,7 +18,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2018-09-21 13:17+0000\n"
 "PO-Revision-Date: 2018-08-24 09:16+0000\n"
-"Last-Translator: Cécile Collart <cco@odoo.com>, 2019\n"
+"Last-Translator: Vallen Delobel <edv@odoo.com>, 2020\n"
 "Language-Team: French (https://www.transifex.com/odoo/teams/41243/fr/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -354,7 +355,7 @@ msgstr ""
 #. module: base_setup
 #: model:ir.model.fields,field_description:base_setup.field_res_config_settings__show_effect
 msgid "Show Effect"
-msgstr ""
+msgstr "Montrer le résultat"
 
 #. module: base_setup
 #: model_terms:ir.ui.view,arch_db:base_setup.res_config_settings_view_form

--- a/addons/base_sparse_field/i18n/eu.po
+++ b/addons/base_sparse_field/i18n/eu.po
@@ -11,6 +11,7 @@
 # Naomi Hidalgo <naomihid96@gmail.com>, 2019
 # Victor Laskurain <blaskurain@binovo.es>, 2019
 # Maialen Rodriguez <maialenrodriguez98@gmail.com>, 2020
+# Unai Muñoz <unaimunoz9@gmail.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -18,7 +19,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2018-09-21 13:17+0000\n"
 "PO-Revision-Date: 2018-08-24 09:16+0000\n"
-"Last-Translator: Maialen Rodriguez <maialenrodriguez98@gmail.com>, 2020\n"
+"Last-Translator: Unai Muñoz <unaimunoz9@gmail.com>, 2020\n"
 "Language-Team: Basque (https://www.transifex.com/odoo/teams/41243/eu/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -29,7 +30,7 @@ msgstr ""
 #. module: base_sparse_field
 #: model:ir.model.fields,field_description:base_sparse_field.field_sparse_fields_test__boolean
 msgid "Boolean"
-msgstr ""
+msgstr "Boolean"
 
 #. module: base_sparse_field
 #: code:addons/base_sparse_field/models/models.py:25
@@ -75,7 +76,7 @@ msgstr "Eremuak"
 #. module: base_sparse_field
 #: model:ir.model.fields,field_description:base_sparse_field.field_sparse_fields_test__float
 msgid "Float"
-msgstr ""
+msgstr "Float"
 
 #. module: base_sparse_field
 #: model:ir.model.fields,field_description:base_sparse_field.field_sparse_fields_test__id
@@ -180,7 +181,7 @@ msgstr ""
 #. module: base_sparse_field
 #: selection:ir.model.fields,ttype:0
 msgid "float"
-msgstr ""
+msgstr "float"
 
 #. module: base_sparse_field
 #: selection:ir.model.fields,ttype:0
@@ -190,7 +191,7 @@ msgstr "html"
 #. module: base_sparse_field
 #: selection:ir.model.fields,ttype:0
 msgid "integer"
-msgstr ""
+msgstr "integer"
 
 #. module: base_sparse_field
 #: selection:ir.model.fields,ttype:0
@@ -220,7 +221,7 @@ msgstr ""
 #. module: base_sparse_field
 #: selection:ir.model.fields,ttype:0
 msgid "selection"
-msgstr ""
+msgstr "aukeraketa"
 
 #. module: base_sparse_field
 #: selection:ir.model.fields,ttype:0
@@ -230,4 +231,4 @@ msgstr ""
 #. module: base_sparse_field
 #: selection:ir.model.fields,ttype:0
 msgid "text"
-msgstr ""
+msgstr "Testua"

--- a/addons/base_sparse_field/i18n/fr.po
+++ b/addons/base_sparse_field/i18n/fr.po
@@ -5,6 +5,7 @@
 # Translators:
 # Martin Trigaux, 2018
 # Cécile Collart <cco@odoo.com>, 2019
+# Vallen Delobel <edv@odoo.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -12,7 +13,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2018-09-21 13:17+0000\n"
 "PO-Revision-Date: 2018-08-24 09:16+0000\n"
-"Last-Translator: Cécile Collart <cco@odoo.com>, 2019\n"
+"Last-Translator: Vallen Delobel <edv@odoo.com>, 2020\n"
 "Language-Team: French (https://www.transifex.com/odoo/teams/41243/fr/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -143,7 +144,7 @@ msgstr "Champ de sérialisation \"%s\" non trouvé pour le champ isolé \"%s\"!"
 #. module: base_sparse_field
 #: model:ir.model,name:base_sparse_field.model_sparse_fields_test
 msgid "Sparse fields Test"
-msgstr ""
+msgstr "Test sur les champs épars "
 
 #. module: base_sparse_field
 #: selection:sparse_fields.test,selection:0

--- a/addons/base_vat/i18n/eu.po
+++ b/addons/base_vat/i18n/eu.po
@@ -8,6 +8,7 @@
 # Imanol Aranburu <iaranburu@binovo.es>, 2019
 # Maialen Rodriguez <maialenrodriguez98@gmail.com>, 2020
 # Miren Maiz <mirenmaizz@gmail.com>, 2020
+# Unai Muñoz <unaimunoz9@gmail.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -15,7 +16,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-01-09 10:31+0000\n"
 "PO-Revision-Date: 2018-08-24 09:16+0000\n"
-"Last-Translator: Miren Maiz <mirenmaizz@gmail.com>, 2020\n"
+"Last-Translator: Unai Muñoz <unaimunoz9@gmail.com>, 2020\n"
 "Language-Team: Basque (https://www.transifex.com/odoo/teams/41243/eu/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -83,7 +84,7 @@ msgstr "IFZ"
 #: model:ir.model.fields,field_description:base_vat.field_res_company__vat_check_vies
 #: model:ir.model.fields,field_description:base_vat.field_res_config_settings__vat_check_vies
 msgid "Verify VAT Numbers"
-msgstr ""
+msgstr "Egiaztatu VAT zenbakiak"
 
 #. module: base_vat
 #: model_terms:ir.ui.view,arch_db:base_vat.res_config_settings_view_form

--- a/addons/calendar/i18n/it.po
+++ b/addons/calendar/i18n/it.po
@@ -1453,7 +1453,7 @@ msgstr "Messaggi non letti"
 #. module: calendar
 #: model:ir.model.fields,field_description:calendar.field_calendar_event__message_unread_counter
 msgid "Unread Messages Counter"
-msgstr "Contatore messaggi non letti"
+msgstr "Numero messaggi non letti"
 
 #. module: calendar
 #: model_terms:ir.ui.view,arch_db:calendar.view_calendar_event_form

--- a/addons/crm/i18n/et.po
+++ b/addons/crm/i18n/et.po
@@ -304,7 +304,7 @@ msgstr "Keskmine tõenäosuse kohta"
 #. module: crm
 #: model:ir.model.fields,field_description:crm.field_crm_lead__is_blacklisted
 msgid "Blacklist"
-msgstr ""
+msgstr "Must nimekiri"
 
 #. module: crm
 #: code:addons/crm/models/crm_lead.py:400

--- a/addons/crm/i18n/eu.po
+++ b/addons/crm/i18n/eu.po
@@ -14,6 +14,7 @@
 # Mikel Lizarralde <mikellizarralde@gmail.com>, 2019
 # Naomi Hidalgo <naomihid96@gmail.com>, 2019
 # Maialen Rodriguez <maialenrodriguez98@gmail.com>, 2020
+# Miren Maiz <mirenmaizz@gmail.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -21,7 +22,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-01-09 10:31+0000\n"
 "PO-Revision-Date: 2018-08-24 09:17+0000\n"
-"Last-Translator: Maialen Rodriguez <maialenrodriguez98@gmail.com>, 2020\n"
+"Last-Translator: Miren Maiz <mirenmaizz@gmail.com>, 2020\n"
 "Language-Team: Basque (https://www.transifex.com/odoo/teams/41243/eu/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -777,7 +778,7 @@ msgstr "Diseinua"
 #. module: crm
 #: model:ir.model,name:crm.model_digest_digest
 msgid "Digest"
-msgstr ""
+msgstr "Laburpen"
 
 #. module: crm
 #: model_terms:ir.ui.view,arch_db:crm.view_create_opportunity_simplified
@@ -1974,7 +1975,7 @@ msgstr "Zehaztapenak"
 #. module: crm
 #: model:ir.model.fields,field_description:crm.field_crm_lead__activity_user_id
 msgid "Responsible User"
-msgstr ""
+msgstr "Erabiltzaile arduraduna"
 
 #. module: crm
 #: model_terms:ir.ui.view,arch_db:crm.crm_case_form_view_leads

--- a/addons/crm/i18n/fr.po
+++ b/addons/crm/i18n/fr.po
@@ -22,6 +22,7 @@
 # Alexandre Fellner <afe@openerp.com>, 2019
 # Cécile Collart <cco@odoo.com>, 2019
 # Florian Hatat, 2019
+# Jonathan Quique <jqu@odoo.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -29,7 +30,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-01-09 10:31+0000\n"
 "PO-Revision-Date: 2018-08-24 09:17+0000\n"
-"Last-Translator: Florian Hatat, 2019\n"
+"Last-Translator: Jonathan Quique <jqu@odoo.com>, 2020\n"
 "Language-Team: French (https://www.transifex.com/odoo/teams/41243/fr/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1223,12 +1224,12 @@ msgstr "État kanban"
 #. module: crm
 #: model:ir.model.fields,field_description:crm.field_digest_digest__kpi_crm_lead_created_value
 msgid "Kpi Crm Lead Created Value"
-msgstr ""
+msgstr "KPI valeur d'une piste créée dans le CRM"
 
 #. module: crm
 #: model:ir.model.fields,field_description:crm.field_digest_digest__kpi_crm_opportunities_won_value
 msgid "Kpi Crm Opportunities Won Value"
-msgstr ""
+msgstr "KPI valeur d'une opportunité gagnée dans le CRM"
 
 #. module: crm
 #: model:ir.model.fields,field_description:crm.field_crm_lead__date_action_last
@@ -1905,7 +1906,7 @@ msgstr "Le partenaire est sur liste noire"
 #. module: crm
 #: model:ir.model,name:crm.model_crm_partner_binding
 msgid "Partner linking/binding in CRM wizard"
-msgstr ""
+msgstr "Relation du partenaire dans les assistants du CRM"
 
 #. module: crm
 #: model:ir.model.fields,field_description:crm.field_crm_activity_report__partner_id

--- a/addons/crm/i18n/it.po
+++ b/addons/crm/i18n/it.po
@@ -16,8 +16,8 @@
 # Léonie Bouchat <lbo@odoo.com>, 2019
 # Lorenzo Battistini <lb@takobi.online>, 2019
 # Simone Sanfilippo <s.sanfilippo@hinge16.eu>, 2019
-# Sergio Zanchetta <primes2h@gmail.com>, 2020
 # Iacopo Simonelli <lsi@odoo.com>, 2020
+# Sergio Zanchetta <primes2h@gmail.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -25,7 +25,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-01-09 10:31+0000\n"
 "PO-Revision-Date: 2018-08-24 09:17+0000\n"
-"Last-Translator: Iacopo Simonelli <lsi@odoo.com>, 2020\n"
+"Last-Translator: Sergio Zanchetta <primes2h@gmail.com>, 2020\n"
 "Language-Team: Italian (https://www.transifex.com/odoo/teams/41243/it/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -2570,7 +2570,7 @@ msgstr "Messaggi non letti"
 #. module: crm
 #: model:ir.model.fields,field_description:crm.field_crm_lead__message_unread_counter
 msgid "Unread Messages Counter"
-msgstr "Contatore messaggi non letti"
+msgstr "Numero messaggi non letti"
 
 #. module: crm
 #: model_terms:ir.ui.view,arch_db:crm.res_config_settings_view_form

--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -302,7 +302,9 @@ class Lead(models.Model):
 
     @api.model
     def create(self, vals):
-        # set up context used to find the lead's Sales Team which is needed
+        if vals.get('website'):
+            vals['website'] = self.env['res.partner']._clean_website(vals['website'])
+        # set up context used to find the lead's sales channel which is needed
         # to correctly set the default stage_id
         context = dict(self._context or {})
         if vals.get('type') and not self._context.get('default_type'):
@@ -323,6 +325,8 @@ class Lead(models.Model):
 
     @api.multi
     def write(self, vals):
+        if vals.get('website'):
+            vals['website'] = self.env['res.partner']._clean_website(vals['website'])
         # stage change: update date_last_stage_update
         if 'stage_id' in vals:
             vals['date_last_stage_update'] = fields.Datetime.now()

--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -182,7 +182,7 @@ class Lead(models.Model):
     def _compute_day_open(self):
         """ Compute difference between create date and open date """
         for lead in self.filtered(lambda l: l.date_open and l.create_date):
-            date_create = fields.Datetime.from_string(lead.create_date)
+            date_create = fields.Datetime.from_string(lead.create_date).replace(microsecond=0)
             date_open = fields.Datetime.from_string(lead.date_open)
             lead.day_open = abs((date_open - date_create).days)
 

--- a/addons/crm_reveal/i18n/da.po
+++ b/addons/crm_reveal/i18n/da.po
@@ -11,9 +11,9 @@
 # Pernille Kristensen <pernillekristensen1994@gmail.com>, 2019
 # Jesper Laugesen <jel@enigma.dk>, 2019
 # Ejner Sønniksen <ejner@vkdata.dk>, 2019
-# Sanne Kristensen <sanne@vkdata.dk>, 2019
 # lhmflexerp <lhm@flexerp.dk>, 2019
 # JonathanStein <jstein@image.dk>, 2020
+# Sanne Kristensen <sanne@vkdata.dk>, 2020
 # 
 msgid ""
 msgstr ""
@@ -21,7 +21,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-07-01 06:19+0000\n"
 "PO-Revision-Date: 2019-07-01 06:20+0000\n"
-"Last-Translator: JonathanStein <jstein@image.dk>, 2020\n"
+"Last-Translator: Sanne Kristensen <sanne@vkdata.dk>, 2020\n"
 "Language-Team: Danish (https://www.transifex.com/odoo/teams/41243/da/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1084,7 +1084,7 @@ msgstr ""
 #. module: crm_reveal
 #: model:crm.reveal.industry,name:crm_reveal.crm_reveal_industry_148
 msgid "Materials"
-msgstr ""
+msgstr "Materialer"
 
 #. module: crm_reveal
 #: model:ir.model.fields,field_description:crm_reveal.field_crm_reveal_rule__company_size_max

--- a/addons/crm_reveal/i18n/pt.po
+++ b/addons/crm_reveal/i18n/pt.po
@@ -10,12 +10,12 @@
 # Vitor Fernandes <vmlf01@gmail.com>, 2019
 # Manuela Silva <manuelarodsilva@gmail.com>, 2019
 # Joao Felix <jrmfelix@gmail.com>, 2019
-# Nuno Silva <nuno.silva@arxi.pt>, 2019
 # Reinaldo Ramos <reinaldo.ramos@arxi.pt>, 2019
 # Diogo Fonseca <dsf@thinkopensolutions.pt>, 2019
 # Catarina Rocha <cr@opencloud.pro>, 2019
 # Ricardo Santa Ana <ricardosantana@gmail.com>, 2019
 # Pedro Filipe <pedro2.10@hotmail.com>, 2019
+# Nuno Silva <nuno.silva@arxi.pt>, 2020
 # 
 msgid ""
 msgstr ""
@@ -23,7 +23,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-07-01 06:19+0000\n"
 "PO-Revision-Date: 2019-07-01 06:20+0000\n"
-"Last-Translator: Pedro Filipe <pedro2.10@hotmail.com>, 2019\n"
+"Last-Translator: Nuno Silva <nuno.silva@arxi.pt>, 2020\n"
 "Language-Team: Portuguese (https://www.transifex.com/odoo/teams/41243/pt/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1671,7 +1671,7 @@ msgstr "Título"
 #. module: crm_reveal
 #: selection:crm.reveal.view,reveal_state:0
 msgid "To Process"
-msgstr ""
+msgstr "Por Processar"
 
 #. module: crm_reveal
 #: model:crm.reveal.industry,name:crm_reveal.crm_reveal_industry_133

--- a/addons/decimal_precision/i18n/eu.po
+++ b/addons/decimal_precision/i18n/eu.po
@@ -7,6 +7,7 @@
 # oihane <oihanecruce@gmail.com>, 2019
 # Eneko <eastigarraga@codesyntax.com>, 2019
 # Victor Laskurain <blaskurain@binovo.es>, 2019
+# Unai Muñoz <unaimunoz9@gmail.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -14,7 +15,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2018-09-21 13:17+0000\n"
 "PO-Revision-Date: 2018-08-24 09:17+0000\n"
-"Last-Translator: Victor Laskurain <blaskurain@binovo.es>, 2019\n"
+"Last-Translator: Unai Muñoz <unaimunoz9@gmail.com>, 2020\n"
 "Language-Team: Basque (https://www.transifex.com/odoo/teams/41243/eu/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -66,17 +67,17 @@ msgstr "Izena erakutsi"
 #. module: decimal_precision
 #: model:ir.model.fields,field_description:decimal_precision.field_decimal_precision_test__float
 msgid "Float"
-msgstr ""
+msgstr "Float"
 
 #. module: decimal_precision
 #: model:ir.model.fields,field_description:decimal_precision.field_decimal_precision_test__float_2
 msgid "Float 2"
-msgstr ""
+msgstr "Float 2"
 
 #. module: decimal_precision
 #: model:ir.model.fields,field_description:decimal_precision.field_decimal_precision_test__float_4
 msgid "Float 4"
-msgstr ""
+msgstr "Float 4"
 
 #. module: decimal_precision
 #: model:ir.model.fields,field_description:decimal_precision.field_decimal_precision__id

--- a/addons/delivery/i18n/et.po
+++ b/addons/delivery/i18n/et.po
@@ -12,6 +12,7 @@
 # Martin Aavastik <martin@avalah.ee>, 2018
 # Helen Sulaoja <helen@avalah.ee>, 2018
 # Maidu Targama <m.targama@gmail.com>, 2019
+# Algo Kärp <algokarp@gmail.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -19,7 +20,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-11-14 07:34+0000\n"
 "PO-Revision-Date: 2018-08-24 09:17+0000\n"
-"Last-Translator: Maidu Targama <m.targama@gmail.com>, 2019\n"
+"Last-Translator: Algo Kärp <algokarp@gmail.com>, 2020\n"
 "Language-Team: Estonian (https://www.transifex.com/odoo/teams/41243/et/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -950,7 +951,7 @@ msgstr "Weight for Shipping"
 #. module: delivery
 #: model:ir.model.fields,field_description:delivery.field_choose_delivery_package__weight_uom_name
 msgid "Weight unit of measure label"
-msgstr ""
+msgstr "Kaalu mõõtühiku silt"
 
 #. module: delivery
 #: model:ir.model.fields,help:delivery.field_stock_quant_package__shipping_weight

--- a/addons/delivery/i18n/eu.po
+++ b/addons/delivery/i18n/eu.po
@@ -13,6 +13,7 @@
 # Victor Laskurain <blaskurain@binovo.es>, 2019
 # Naomi Hidalgo <naomihid96@gmail.com>, 2019
 # Maialen Rodriguez <maialenrodriguez98@gmail.com>, 2020
+# Unai Muñoz <unaimunoz9@gmail.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -20,7 +21,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-11-14 07:34+0000\n"
 "PO-Revision-Date: 2018-08-24 09:17+0000\n"
-"Last-Translator: Maialen Rodriguez <maialenrodriguez98@gmail.com>, 2020\n"
+"Last-Translator: Unai Muñoz <unaimunoz9@gmail.com>, 2020\n"
 "Language-Team: Basque (https://www.transifex.com/odoo/teams/41243/eu/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -121,7 +122,7 @@ msgstr ""
 #. module: delivery
 #: model_terms:ir.ui.view,arch_db:delivery.report_shipping2
 msgid "<strong>Weight</strong>"
-msgstr ""
+msgstr "<strong>Pisua</strong>"
 
 #. module: delivery
 #: model:ir.model.fields,help:delivery.field_delivery_carrier__integration_level
@@ -244,7 +245,7 @@ msgstr "Irteera albaranak"
 #. module: delivery
 #: model:ir.ui.menu,name:delivery.menu_delivery
 msgid "Delivery"
-msgstr ""
+msgstr "Entrega"
 
 #. module: delivery
 #: model_terms:ir.ui.view,arch_db:delivery.view_delivery_carrier_search
@@ -254,17 +255,17 @@ msgstr ""
 #. module: delivery
 #: model_terms:ir.ui.view,arch_db:delivery.view_delivery_price_rule_form
 msgid "Delivery Cost"
-msgstr ""
+msgstr "Entrega kostua"
 
 #. module: delivery
 #: model_terms:ir.ui.view,arch_db:delivery.view_picking_withcarrier_out_form
 msgid "Delivery Information"
-msgstr ""
+msgstr "Bidalketa informazioa"
 
 #. module: delivery
 #: model:ir.model.fields,field_description:delivery.field_sale_order__delivery_message
 msgid "Delivery Message"
-msgstr ""
+msgstr "Bidalketa mezua"
 
 #. module: delivery
 #: model:ir.model.fields,field_description:delivery.field_delivery_carrier__name
@@ -309,7 +310,7 @@ msgstr ""
 #. module: delivery
 #: model:ir.model.fields,field_description:delivery.field_delivery_carrier__product_id
 msgid "Delivery Product"
-msgstr ""
+msgstr "Bidalketa produktua"
 
 #. module: delivery
 #: model:ir.model.fields,field_description:delivery.field_sale_order__delivery_rating_success
@@ -504,12 +505,12 @@ msgstr "Azken eguneraketa noiz"
 #. module: delivery
 #: model:ir.model.fields,field_description:delivery.field_product_packaging__length
 msgid "Length"
-msgstr ""
+msgstr "Luzera"
 
 #. module: delivery
 #: sql_constraint:product.packaging:0
 msgid "Length must be positive"
-msgstr ""
+msgstr "Luzera positiboa izan behar du"
 
 #. module: delivery
 #: model:ir.model.fields,help:delivery.field_delivery_carrier__debug_logging
@@ -534,7 +535,7 @@ msgstr ""
 #. module: delivery
 #: model:ir.model.fields,field_description:delivery.field_product_packaging__max_weight
 msgid "Max Weight"
-msgstr ""
+msgstr "Pisu maximoa"
 
 #. module: delivery
 #: sql_constraint:product.packaging:0
@@ -544,7 +545,7 @@ msgstr ""
 #. module: delivery
 #: model:ir.model.fields,field_description:delivery.field_delivery_price_rule__max_value
 msgid "Maximum Value"
-msgstr ""
+msgstr "Balio maximoa"
 
 #. module: delivery
 #: model:ir.model.fields,help:delivery.field_product_packaging__max_weight
@@ -606,7 +607,7 @@ msgstr "Paketea"
 #. module: delivery
 #: model:ir.model.fields,field_description:delivery.field_product_packaging__shipper_package_code
 msgid "Package Code"
-msgstr ""
+msgstr "Pakete kodea"
 
 #. module: delivery
 #: code:addons/delivery/models/stock_picking.py:40
@@ -888,7 +889,7 @@ msgstr "Unitatea(k)"
 #. module: delivery
 #: model:ir.model.fields,field_description:delivery.field_delivery_price_rule__variable
 msgid "Variable"
-msgstr ""
+msgstr "Aldagaia"
 
 #. module: delivery
 #: model:ir.model.fields,field_description:delivery.field_delivery_price_rule__variable_factor
@@ -916,7 +917,7 @@ msgstr "Pisua"
 #: selection:delivery.price.rule,variable:0
 #: selection:delivery.price.rule,variable_factor:0
 msgid "Weight * Volume"
-msgstr ""
+msgstr "Pisua * Bolumena"
 
 #. module: delivery
 #: model:ir.model.fields,help:delivery.field_stock_quant_package__weight
@@ -942,7 +943,7 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:delivery.report_package_barcode_delivery
 #: model_terms:ir.ui.view,arch_db:delivery.report_package_barcode_small_delivery
 msgid "Weight:"
-msgstr ""
+msgstr "Pisua:"
 
 #. module: delivery
 #: model:ir.model.fields,field_description:delivery.field_product_packaging__width
@@ -952,7 +953,7 @@ msgstr "Zabalera"
 #. module: delivery
 #: sql_constraint:product.packaging:0
 msgid "Width must be positive"
-msgstr ""
+msgstr "Zabalera positiboa izan behar du"
 
 #. module: delivery
 #: code:addons/delivery/models/stock_picking.py:236

--- a/addons/delivery/i18n/fr.po
+++ b/addons/delivery/i18n/fr.po
@@ -13,6 +13,7 @@
 # Xavier Belmere <Info@cartmeleon.com>, 2019
 # Laura Piraux <lap@odoo.com>, 2020
 # Priscilla Sanchez <prs@odoo.com>, 2020
+# Moka Tourisme <hello@mokatourisme.fr>, 2020
 # 
 msgid ""
 msgstr ""
@@ -20,7 +21,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-11-14 07:34+0000\n"
 "PO-Revision-Date: 2018-08-24 09:17+0000\n"
-"Last-Translator: Priscilla Sanchez <prs@odoo.com>, 2020\n"
+"Last-Translator: Moka Tourisme <hello@mokatourisme.fr>, 2020\n"
 "Language-Team: French (https://www.transifex.com/odoo/teams/41243/fr/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1054,12 +1055,12 @@ msgstr ""
 #. module: delivery
 #: model:ir.model.fields,field_description:delivery.field_delivery_carrier__zip_from
 msgid "Zip From"
-msgstr "À partir de"
+msgstr "CP à partir de :"
 
 #. module: delivery
 #: model:ir.model.fields,field_description:delivery.field_delivery_carrier__zip_to
 msgid "Zip To"
-msgstr "Destinataire"
+msgstr "CP jusqu'à :"
 
 #. module: delivery
 #: model_terms:ir.ui.view,arch_db:delivery.view_delivery_carrier_form

--- a/addons/delivery/i18n/ro.po
+++ b/addons/delivery/i18n/ro.po
@@ -149,7 +149,7 @@ msgstr "Arhivat"
 #. module: delivery
 #: model:ir.model.fields,field_description:delivery.field_sale_order__available_carrier_ids
 msgid "Available Carriers"
-msgstr ""
+msgstr "Transportatori disponibili"
 
 #. module: delivery
 #: selection:delivery.carrier,delivery_type:0

--- a/addons/digest/i18n/eu.po
+++ b/addons/digest/i18n/eu.po
@@ -11,6 +11,8 @@
 # Naomi Hidalgo <naomihid96@gmail.com>, 2019
 # Victor Laskurain <blaskurain@binovo.es>, 2019
 # Maialen Rodriguez <maialenrodriguez98@gmail.com>, 2020
+# Miren Maiz <mirenmaizz@gmail.com>, 2020
+# Mikel Galarza <mikelgalarza99@gmail.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -18,7 +20,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-11-14 07:34+0000\n"
 "PO-Revision-Date: 2018-08-24 09:17+0000\n"
-"Last-Translator: Maialen Rodriguez <maialenrodriguez98@gmail.com>, 2020\n"
+"Last-Translator: Mikel Galarza <mikelgalarza99@gmail.com>, 2020\n"
 "Language-Team: Basque (https://www.transifex.com/odoo/teams/41243/eu/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -219,7 +221,7 @@ msgstr ""
 #. module: digest
 #: model:ir.model.fields,field_description:digest.field_digest_tip__group_id
 msgid "Authorized Group"
-msgstr ""
+msgstr "Talde baimendua"
 
 #. module: digest
 #: model:ir.model.fields,field_description:digest.field_digest_digest__available_fields
@@ -283,7 +285,7 @@ msgstr ""
 #. module: digest
 #: model:ir.model,name:digest.model_digest_digest
 msgid "Digest"
-msgstr ""
+msgstr "Laburpen"
 
 #. module: digest
 #: model:ir.model.fields,field_description:digest.field_res_config_settings__digest_id

--- a/addons/digest/i18n/fr.po
+++ b/addons/digest/i18n/fr.po
@@ -9,6 +9,7 @@
 # Jerther, 2019
 # Florian Hatat, 2019
 # Cécile Collart <cco@odoo.com>, 2020
+# Priscilla Sanchez <prs@odoo.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -16,7 +17,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-11-14 07:34+0000\n"
 "PO-Revision-Date: 2018-08-24 09:17+0000\n"
-"Last-Translator: Cécile Collart <cco@odoo.com>, 2020\n"
+"Last-Translator: Priscilla Sanchez <prs@odoo.com>, 2020\n"
 "Language-Team: French (https://www.transifex.com/odoo/teams/41243/fr/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -258,6 +259,8 @@ msgid ""
 "Create or edit the mail template: you may get computed KPI's value using "
 "these fields:"
 msgstr ""
+"Créez ou modifiez le modèle de courrier: vous pouvez obtenir la valeur "
+"calculée des KPI en utilisant ces champs:"
 
 #. module: digest
 #: model:ir.model.fields,field_description:digest.field_digest_digest__create_uid
@@ -373,12 +376,12 @@ msgstr "KPIs"
 #. module: digest
 #: model:ir.model.fields,field_description:digest.field_digest_digest__kpi_mail_message_total_value
 msgid "Kpi Mail Message Total Value"
-msgstr ""
+msgstr "Valeur totale du message Kpi Mail"
 
 #. module: digest
 #: model:ir.model.fields,field_description:digest.field_digest_digest__kpi_res_users_connected_value
 msgid "Kpi Res Users Connected Value"
-msgstr ""
+msgstr "Valeur connectée des utilisateurs Kpi Res"
 
 #. module: digest
 #: model:ir.model.fields,field_description:digest.field_digest_digest____last_update
@@ -472,7 +475,7 @@ msgstr "S'inscrire"
 #. module: digest
 #: model:ir.model.fields,field_description:digest.field_digest_tip__tip_description
 msgid "Tip description"
-msgstr ""
+msgstr "Description  du pourboire"
 
 #. module: digest
 #: model_terms:ir.ui.view,arch_db:digest.digest_digest_view_form
@@ -483,6 +486,8 @@ msgstr "Désinscrivez-moi"
 #: model:ir.model.fields,help:digest.field_digest_tip__sequence
 msgid "Used to display digest tip in email template base on order"
 msgstr ""
+"Utilisé pour afficher un résumé dans la base de modèles d'e-mails sur "
+"commande"
 
 #. module: digest
 #: model:ir.model,name:digest.model_res_users
@@ -536,7 +541,7 @@ msgstr ""
 #. module: digest
 #: model_terms:digest.tip,tip_description:digest.digest_tip_mail_0
 msgid "company's discussion channel."
-msgstr ""
+msgstr "canal de discussion de l'entreprise."
 
 #. module: digest
 #: model_terms:ir.ui.view,arch_db:digest.digest_digest_view_form

--- a/addons/event/i18n/eu.po
+++ b/addons/event/i18n/eu.po
@@ -14,6 +14,7 @@
 # Mikel Lizarralde <mikellizarralde@gmail.com>, 2019
 # Naomi Hidalgo <naomihid96@gmail.com>, 2019
 # Maialen Rodriguez <maialenrodriguez98@gmail.com>, 2020
+# Unai Muñoz <unaimunoz9@gmail.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -21,7 +22,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-10-07 13:44+0000\n"
 "PO-Revision-Date: 2018-08-24 09:17+0000\n"
-"Last-Translator: Maialen Rodriguez <maialenrodriguez98@gmail.com>, 2020\n"
+"Last-Translator: Unai Muñoz <unaimunoz9@gmail.com>, 2020\n"
 "Language-Team: Basque (https://www.transifex.com/odoo/teams/41243/eu/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1712,7 +1713,7 @@ msgstr "Bidalia"
 #. module: event
 #: model_terms:ir.ui.view,arch_db:event.view_event_form
 msgid "Set To Draft"
-msgstr ""
+msgstr "Ezarri zirriborro gisa"
 
 #. module: event
 #: model_terms:ir.ui.view,arch_db:event.view_event_registration_form

--- a/addons/event/views/event_views.xml
+++ b/addons/event/views/event_views.xml
@@ -192,8 +192,8 @@
                         <button string="Confirm Event" name="button_confirm" states="draft" type="object" class="oe_highlight" groups="base.group_user"/>
                         <button string="Finish Event" name="button_done" states="confirm" type="object" class="oe_highlight" groups="base.group_user"/>
                         <button string="Set To Draft" name="button_draft" states="cancel,done" type="object" groups="base.group_user"/>
-                        <button string="Cancel Event" name="button_cancel" states="draft,confirm" type="object" groups="base.group_user" attrs="{'invisible': ['|', ('seats_expected', '!=', 0)]}"/>
-                        <button string="Cancel Event" name="button_cancel" states="draft,confirm" type="object" groups="base.group_user" confirm="Are you sure you want to cancel this event? All the linked attendees will be cancelled as well." attrs="{'invisible': ['|', ('seats_expected', '=', 0)]}"/>
+                        <button string="Cancel Event" name="button_cancel" states="draft,confirm" type="object" groups="base.group_user" attrs="{'invisible': [('seats_expected', '!=', 0)]}"/>
+                        <button string="Cancel Event" name="button_cancel" states="draft,confirm" type="object" groups="base.group_user" confirm="Are you sure you want to cancel this event? All the linked attendees will be cancelled as well." attrs="{'invisible': [('seats_expected', '=', 0)]}"/>
                         <field name="state" widget="statusbar" statusbar_visible="draft,confirm,done"/>
                     </header>
                     <sheet>

--- a/addons/fleet/i18n/da.po
+++ b/addons/fleet/i18n/da.po
@@ -11,8 +11,8 @@
 # Ejner Sønniksen <ejner@vkdata.dk>, 2018
 # Martin Trigaux, 2019
 # Pernille Kristensen <pernillekristensen1994@gmail.com>, 2019
-# Sanne Kristensen <sanne@vkdata.dk>, 2019
 # lhmflexerp <lhm@flexerp.dk>, 2019
+# Sanne Kristensen <sanne@vkdata.dk>, 2020
 # 
 msgid ""
 msgstr ""
@@ -20,7 +20,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-03-29 10:10+0000\n"
 "PO-Revision-Date: 2018-08-24 09:18+0000\n"
-"Last-Translator: lhmflexerp <lhm@flexerp.dk>, 2019\n"
+"Last-Translator: Sanne Kristensen <sanne@vkdata.dk>, 2020\n"
 "Language-Team: Danish (https://www.transifex.com/odoo/teams/41243/da/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -537,7 +537,7 @@ msgstr ""
 #. module: fleet
 #: model_terms:ir.actions.act_window,help:fleet.fleet_vehicle_contract_types_action
 msgid "Create a new type of contract"
-msgstr ""
+msgstr "Opret en ny kontrakttype"
 
 #. module: fleet
 #: model_terms:ir.actions.act_window,help:fleet.fleet_vehicle_service_types_action
@@ -1806,7 +1806,7 @@ msgstr "Ydelse"
 #: model_terms:ir.ui.view,arch_db:fleet.fleet_vehicle_log_contract_view_search
 #: model_terms:ir.ui.view,arch_db:fleet.fleet_vehicle_log_services_view_form
 msgid "Service Type"
-msgstr ""
+msgstr "Service type"
 
 #. module: fleet
 #: model:ir.actions.act_window,name:fleet.fleet_vehicle_service_types_action

--- a/addons/fleet/i18n/eu.po
+++ b/addons/fleet/i18n/eu.po
@@ -15,6 +15,7 @@
 # Victor Laskurain <blaskurain@binovo.es>, 2019
 # Naomi Hidalgo <naomihid96@gmail.com>, 2019
 # Maialen Rodriguez <maialenrodriguez98@gmail.com>, 2020
+# Miren Maiz <mirenmaizz@gmail.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -22,7 +23,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-03-29 10:10+0000\n"
 "PO-Revision-Date: 2018-08-24 09:18+0000\n"
-"Last-Translator: Maialen Rodriguez <maialenrodriguez98@gmail.com>, 2020\n"
+"Last-Translator: Miren Maiz <mirenmaizz@gmail.com>, 2020\n"
 "Language-Team: Basque (https://www.transifex.com/odoo/teams/41243/eu/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1759,7 +1760,7 @@ msgstr "Arduraduna"
 #: model:ir.model.fields,field_description:fleet.field_fleet_vehicle__activity_user_id
 #: model:ir.model.fields,field_description:fleet.field_fleet_vehicle_log_contract__activity_user_id
 msgid "Responsible User"
-msgstr ""
+msgstr "Erabiltzaile arduraduna"
 
 #. module: fleet
 #: model:fleet.service.type,name:fleet.type_service_38

--- a/addons/fleet/i18n/it.po
+++ b/addons/fleet/i18n/it.po
@@ -2140,7 +2140,7 @@ msgstr "Messaggi non letti"
 #: model:ir.model.fields,field_description:fleet.field_fleet_vehicle__message_unread_counter
 #: model:ir.model.fields,field_description:fleet.field_fleet_vehicle_log_contract__message_unread_counter
 msgid "Unread Messages Counter"
-msgstr "Contatore messaggi non letti"
+msgstr "Numero messaggi non letti"
 
 #. module: fleet
 #: model:ir.model.fields,help:fleet.field_fleet_vehicle_state__sequence

--- a/addons/gamification/i18n/fr.po
+++ b/addons/gamification/i18n/fr.po
@@ -8,8 +8,9 @@
 # Nathan Grognet <ngr@odoo.com>, 2018
 # Martin Trigaux, 2019
 # Moka Tourisme <hello@mokatourisme.fr>, 2019
-# Jonathan Quique <jqu@odoo.com>, 2020
 # Cécile Collart <cco@odoo.com>, 2020
+# Priscilla Sanchez <prs@odoo.com>, 2020
+# Jonathan Quique <jqu@odoo.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -17,7 +18,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-03-29 10:10+0000\n"
 "PO-Revision-Date: 2018-08-24 09:18+0000\n"
-"Last-Translator: Cécile Collart <cco@odoo.com>, 2020\n"
+"Last-Translator: Jonathan Quique <jqu@odoo.com>, 2020\n"
 "Language-Team: French (https://www.transifex.com/odoo/teams/41243/fr/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1317,17 +1318,17 @@ msgstr "Défi de ludification"
 #. module: gamification
 #: model:ir.model,name:gamification.model_gamification_goal
 msgid "Gamification Goal"
-msgstr ""
+msgstr "Objectif de la gamification"
 
 #. module: gamification
 #: model:ir.model,name:gamification.model_gamification_goal_definition
 msgid "Gamification Goal Definition"
-msgstr ""
+msgstr "Définition d'objectif de ludification"
 
 #. module: gamification
 #: model:ir.model,name:gamification.model_gamification_goal_wizard
 msgid "Gamification Goal Wizard"
-msgstr ""
+msgstr "Assistant d'objectif de ludification"
 
 #. module: gamification
 #: model:ir.ui.menu,name:gamification.gamification_menu
@@ -1337,12 +1338,12 @@ msgstr "Outils de ludification"
 #. module: gamification
 #: model:ir.model,name:gamification.model_gamification_badge_user
 msgid "Gamification User Badge"
-msgstr ""
+msgstr "Badge d'utilisateur de gamification"
 
 #. module: gamification
 #: model:ir.model,name:gamification.model_gamification_badge_user_wizard
 msgid "Gamification User Badge Wizard"
-msgstr ""
+msgstr "Assistant de badge utilisateur de gamification"
 
 #. module: gamification
 #: model:ir.model,name:gamification.model_gamification_challenge_line

--- a/addons/gamification/i18n/he.po
+++ b/addons/gamification/i18n/he.po
@@ -484,7 +484,7 @@ msgstr ""
 #. module: gamification
 #: model:ir.model.fields,field_description:gamification.field_gamification_challenge__category
 msgid "Appears in"
-msgstr ""
+msgstr "מופיע ב"
 
 #. module: gamification
 #: model_terms:ir.ui.view,arch_db:gamification.challenge_form_view
@@ -536,7 +536,7 @@ msgstr "תג"
 #. module: gamification
 #: model_terms:ir.ui.view,arch_db:gamification.badge_form_view
 msgid "Badge Description"
-msgstr ""
+msgstr "תיאור תג"
 
 #. module: gamification
 #: model:mail.message.subtype,description:gamification.mt_badge_granted
@@ -553,7 +553,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:gamification.field_gamification_badge_user__badge_name
 #: model_terms:ir.ui.view,arch_db:gamification.badge_form_view
 msgid "Badge Name"
-msgstr ""
+msgstr "שם תג"
 
 #. module: gamification
 #: model:ir.actions.act_window,name:gamification.badge_list_action
@@ -959,12 +959,12 @@ msgstr ""
 #. module: gamification
 #: model:ir.model,name:gamification.model_gamification_badge
 msgid "Gamification Badge"
-msgstr ""
+msgstr "תג משחק"
 
 #. module: gamification
 #: model:ir.model,name:gamification.model_gamification_challenge
 msgid "Gamification Challenge"
-msgstr ""
+msgstr "אתגר משחק"
 
 #. module: gamification
 #: model:ir.model,name:gamification.model_gamification_goal

--- a/addons/gamification/i18n/it.po
+++ b/addons/gamification/i18n/it.po
@@ -2128,7 +2128,7 @@ msgstr "Messaggi non letti"
 #: model:ir.model.fields,field_description:gamification.field_gamification_badge__message_unread_counter
 #: model:ir.model.fields,field_description:gamification.field_gamification_challenge__message_unread_counter
 msgid "Unread Messages Counter"
-msgstr "Contatore messaggi non letti"
+msgstr "Numero messaggi non letti"
 
 #. module: gamification
 #: model_terms:ir.ui.view,arch_db:gamification.view_goal_wizard_update_current

--- a/addons/google_drive/i18n/fr.po
+++ b/addons/google_drive/i18n/fr.po
@@ -3,16 +3,18 @@
 # * google_drive
 # 
 # Translators:
-# Martin Trigaux, 2018
 # Eloïse Stilmant <est@odoo.com>, 2018
 # Marie Willemyns <mwi@odoo.com>, 2018
+# Martin Trigaux, 2018
+# Priscilla Sanchez <prs@odoo.com>, 2020
+# 
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2018-10-08 06:49+0000\n"
-"PO-Revision-Date: 2018-10-08 06:49+0000\n"
-"Last-Translator: Marie Willemyns <mwi@odoo.com>, 2018\n"
+"PO-Revision-Date: 2018-08-24 09:18+0000\n"
+"Last-Translator: Priscilla Sanchez <prs@odoo.com>, 2020\n"
 "Language-Team: French (https://www.transifex.com/odoo/teams/41243/fr/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -263,6 +265,10 @@ msgid ""
 "                                in the Google Drive name field, the document in your Google Drive and in Odoo attachment will be named\n"
 "                                'Deco_Addict_SO0001_Sales'."
 msgstr ""
+"Le nom du document joint peut utiliser des données fixes ou variables. Pour distinguer les documents dans\n"
+"                                Google Drive, utilisez des mots fixes et des champs. Par exemple, dans l'exemple ci-dessus, si vous avez écrit Deco_Addict_%(name)s_Sales\n"
+"                                dans le champ du nom de Google Drive, le document dans votre Google Drive et dans la pièce jointe Odoo sera nommé\n"
+"                                'Deco_Addict_SO0001_Sales'."
 
 #. module: google_drive
 #: code:addons/google_drive/models/google_drive.py:135

--- a/addons/hr/i18n/eu.po
+++ b/addons/hr/i18n/eu.po
@@ -14,6 +14,8 @@
 # Naomi Hidalgo <naomihid96@gmail.com>, 2019
 # Victor Laskurain <blaskurain@binovo.es>, 2019
 # Maialen Rodriguez <maialenrodriguez98@gmail.com>, 2020
+# Miren Maiz <mirenmaizz@gmail.com>, 2020
+# Mikel Galarza <mikelgalarza99@gmail.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -21,7 +23,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-04-12 12:19+0000\n"
 "PO-Revision-Date: 2018-08-24 09:18+0000\n"
-"Last-Translator: Maialen Rodriguez <maialenrodriguez98@gmail.com>, 2020\n"
+"Last-Translator: Mikel Galarza <mikelgalarza99@gmail.com>, 2020\n"
 "Language-Team: Basque (https://www.transifex.com/odoo/teams/41243/eu/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -206,7 +208,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:hr.field_mail_alias_mixin__alias_contact
 #: model:ir.model.fields,field_description:hr.field_mail_channel__alias_contact
 msgid "Alias Contact Security"
-msgstr ""
+msgstr "Segurtasun Kontaktu Ezizena"
 
 #. module: hr
 #: model_terms:hr.job,website_description:hr.job_consultant
@@ -229,12 +231,12 @@ msgstr "Eranskin kontagailua"
 #. module: hr
 #: selection:mail.alias,alias_contact:0
 msgid "Authenticated Employees"
-msgstr ""
+msgstr "Kautotu langileak"
 
 #. module: hr
 #: selection:mail.alias,alias_contact:0
 msgid "Authenticated Partners"
-msgstr ""
+msgstr "Kautotutako kideak"
 
 #. module: hr
 #: model_terms:ir.ui.view,arch_db:hr.mail_channel_view_form_
@@ -1312,7 +1314,7 @@ msgstr "Ardurak "
 #. module: hr
 #: model:ir.model.fields,field_description:hr.field_hr_employee__activity_user_id
 msgid "Responsible User"
-msgstr ""
+msgstr "Erabiltzaile arduraduna"
 
 #. module: hr
 #: model:ir.model.fields,field_description:hr.field_hr_employee__sinid

--- a/addons/hr/i18n/fr.po
+++ b/addons/hr/i18n/fr.po
@@ -19,6 +19,7 @@
 # Nicolas Roussey <nro@odoo.com>, 2019
 # Cécile Collart <cco@odoo.com>, 2019
 # Priscilla Sanchez <prs@odoo.com>, 2020
+# Jonathan Quique <jqu@odoo.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -26,7 +27,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-04-12 12:19+0000\n"
 "PO-Revision-Date: 2018-08-24 09:18+0000\n"
-"Last-Translator: Priscilla Sanchez <prs@odoo.com>, 2020\n"
+"Last-Translator: Jonathan Quique <jqu@odoo.com>, 2020\n"
 "Language-Team: French (https://www.transifex.com/odoo/teams/41243/fr/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -549,7 +550,7 @@ msgstr "Alias courriel"
 #. module: hr
 #: model:ir.model,name:hr.model_mail_alias_mixin
 msgid "Email Aliases Mixin"
-msgstr ""
+msgstr "Incorporer les alias courriel"
 
 #. module: hr
 #: model:ir.model.fields,field_description:hr.field_hr_employee__emergency_contact

--- a/addons/hr/i18n/it.po
+++ b/addons/hr/i18n/it.po
@@ -1642,7 +1642,7 @@ msgstr "Messaggi non letti"
 #: model:ir.model.fields,field_description:hr.field_hr_employee__message_unread_counter
 #: model:ir.model.fields,field_description:hr.field_hr_job__message_unread_counter
 msgid "Unread Messages Counter"
-msgstr "Contatore messaggi non letti"
+msgstr "Numero messaggi non letti"
 
 #. module: hr
 #: model_terms:ir.ui.view,arch_db:hr.view_employee_form

--- a/addons/hr/i18n/it.po
+++ b/addons/hr/i18n/it.po
@@ -11,7 +11,6 @@
 # Cesare Cugnasco <cesare.cugnasco@gmail.com>, 2018
 # Maurizio Delmonte <maurizio.delmonte@gmail.com>, 2018
 # Paolo Valier, 2018
-# Manuela Feliciani <mfeliciani@alice.it>, 2018
 # maiolif <maiolif@mgftools.com>, 2018
 # Francesco Garganese <francesco.garganese@aeromnia.aero>, 2018
 # Martin Trigaux, 2018
@@ -153,8 +152,8 @@ msgstr ""
 "            <table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" width=\"590\" style=\"min-width: 590px; background-color: white; padding: 0px 8px 0px 8px; border-collapse:separate;\">\n"
 "                <tr><td valign=\"top\" style=\"font-size: 13px;\">\n"
 "                    <div>\n"
-"                        Ciao,<br/>\n"
-"                        Il tuo documento non è stato creato perché il tuo indirizzo email non è riconosciuto. Per favore invia le email con l'indirizzo registrato nelle tue informazioni relative al dipendente, o contatta il tuo responsabile risorse umane.\n"
+"                        Buongiorno,<br/>\n"
+"                        Il documento non è stato creato perché l'indirizzo e-mail è sconosciuto. Inviare le e-mail utilizzando l'indirizzo registrato nelle informazioni del dipendente, oppure contattare il responsabile risorse umane.\n"
 "                    </div>\n"
 "                </td></tr>\n"
 "            </table>\n"
@@ -162,11 +161,11 @@ msgstr ""
 "</tbody>\n"
 "</table>\n"
 "</td></tr>\n"
-"<!-- POWERED BY -->\n"
+"<!-- FORNITO DA -->\n"
 "<tr><td align=\"center\" style=\"min-width: 590px;\">\n"
 "    <table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" width=\"590\" style=\"min-width: 590px; background-color: #F1F1F1; color: #454748; padding: 8px; border-collapse:separate;\">\n"
 "      <tr><td style=\"text-align: center; font-size: 13px;\">\n"
-"        Powered by <a target=\"_blank\" href=\"https://www.odoo.com?utm_source=db&amp;utm_medium=hr\" style=\"color: #875A7B;\">Odoo</a>\n"
+"        Fornito da <a target=\"_blank\" href=\"https://www.odoo.com?utm_source=db&amp;utm_medium=hr\" style=\"color: #875A7B;\">Odoo</a>\n"
 "      </td></tr>\n"
 "    </table>\n"
 "</td></tr>\n"
@@ -231,7 +230,7 @@ msgstr "Stato attività"
 #: model_terms:ir.actions.act_window,help:hr.act_employee_from_department
 #: model_terms:ir.actions.act_window,help:hr.open_view_employee_list_my
 msgid "Add a new employee"
-msgstr "Aggiungi nuovo dipendente"
+msgstr "Aggiungi un nuovo dipendente"
 
 #. module: hr
 #: model:ir.model.fields,field_description:hr.field_hr_employee__additional_note
@@ -277,12 +276,12 @@ msgstr "Partner autenticati"
 #. module: hr
 #: model_terms:ir.ui.view,arch_db:hr.mail_channel_view_form_
 msgid "Auto Subscribe Departments"
-msgstr "Dipartimenti ad iscrizione automatica"
+msgstr "Iscrizione automatica uffici"
 
 #. module: hr
 #: model:ir.model.fields,help:hr.field_mail_channel__subscription_department_ids
 msgid "Automatically subscribe members of those departments to the channel."
-msgstr "Iscrivere automaticamente al canale i membri di questi reparti."
+msgstr "Iscrizione automatica al canale per gli affiliati a questi uffici."
 
 #. module: hr
 #: selection:hr.employee,certificate:0
@@ -358,7 +357,7 @@ msgstr "Direttore tecnico"
 #. module: hr
 #: model:ir.model.fields,field_description:hr.field_hr_department__child_ids
 msgid "Child Departments"
-msgstr "Reparti secondari"
+msgstr "Uffici secondari"
 
 #. module: hr
 #: model_terms:ir.ui.view,arch_db:hr.view_employee_form
@@ -443,7 +442,7 @@ msgstr "Informazioni contatto"
 #: model_terms:hr.job,website_description:hr.job_developer
 #: model_terms:hr.job,website_description:hr.job_trainee
 msgid "Contributions to open source projects"
-msgstr "Contributi ai progetti open source"
+msgstr "Contributi a progetti open source"
 
 #. module: hr
 #: model:ir.model.fields,field_description:hr.field_hr_employee__country_of_birth
@@ -453,7 +452,7 @@ msgstr "Nazione di nascita"
 #. module: hr
 #: model_terms:ir.actions.act_window,help:hr.open_module_tree_department
 msgid "Create a new department"
-msgstr "Crea un nuovo reparto"
+msgstr "Crea un nuovo ufficio"
 
 #. module: hr
 #: model:ir.model.fields,field_description:hr.field_hr_department__create_uid
@@ -650,8 +649,8 @@ msgstr "Nuovi dipendenti previsti"
 msgid ""
 "Expected number of employees for this job position after new recruitment."
 msgstr ""
-"Numero atteso di dipendenti per questa posizione lavorativa dopo le nuove "
-"assunzioni."
+"Numero atteso di dipendenti, dopo la nuova selezione, per questa posizione "
+"lavorativa."
 
 #. module: hr
 #: model:hr.job,name:hr.job_developer
@@ -758,12 +757,12 @@ msgstr "Raggruppa per"
 #. module: hr
 #: model:ir.model,name:hr.model_hr_department
 msgid "HR Department"
-msgstr "Reparto risorse umane"
+msgstr "Ufficio risorse umane"
 
 #. module: hr
 #: model:ir.model.fields,field_description:hr.field_mail_channel__subscription_department_ids
 msgid "HR Departments"
-msgstr "Reparti risorse umane"
+msgstr "Uffici risorse umane"
 
 #. module: hr
 #: model_terms:ir.ui.view,arch_db:hr.view_employee_form
@@ -803,7 +802,7 @@ msgstr "Risorse umane"
 #. module: hr
 #: model:hr.job,name:hr.job_hrm
 msgid "Human Resources Manager"
-msgstr "Direttore risorse umane"
+msgstr "Responsabile risorse umane"
 
 #. module: hr
 #: model:ir.model.fields,field_description:hr.field_hr_department__id
@@ -1005,7 +1004,7 @@ msgstr "Maschio"
 #: model_terms:ir.ui.view,arch_db:hr.view_employee_filter
 #: model:res.groups,name:hr.group_hr_manager
 msgid "Manager"
-msgstr "Manager"
+msgstr "Responsabile"
 
 #. module: hr
 #: model:ir.model.fields,field_description:hr.field_hr_employee__marital
@@ -1015,7 +1014,7 @@ msgstr "Stato civile"
 #. module: hr
 #: model:hr.job,name:hr.job_marketing
 msgid "Marketing and Community Manager"
-msgstr "Manager di Marketing e Community"
+msgstr "Responsabile marketing e community"
 
 #. module: hr
 #: selection:hr.employee,marital:0
@@ -1118,7 +1117,7 @@ msgstr "Bello avere"
 #. module: hr
 #: selection:hr.job,state:0
 msgid "Not Recruiting"
-msgstr "Non assumendo"
+msgstr "Selezione terminata"
 
 #. module: hr
 #: model:ir.model.fields,field_description:hr.field_hr_department__note
@@ -1233,7 +1232,7 @@ msgstr "In ritardo"
 #. module: hr
 #: model:ir.model.fields,field_description:hr.field_hr_department__parent_id
 msgid "Parent Department"
-msgstr "Dipartimento Superiore"
+msgstr "Ufficio superiore"
 
 #. module: hr
 #: model_terms:hr.job,website_description:hr.job_developer
@@ -1322,17 +1321,17 @@ msgstr "Studente veloce ed autonomo"
 #. module: hr
 #: model_terms:ir.actions.act_window,help:hr.action_hr_job
 msgid "Ready to recruit more efficiently?"
-msgstr "Pronto per assumere più efficientemente?"
+msgstr "Pronto per una selezione più efficiente?"
 
 #. module: hr
 #: model_terms:ir.ui.view,arch_db:hr.view_hr_job_form
 msgid "Recruitment"
-msgstr "Assunzioni"
+msgstr "Selezione del personale"
 
 #. module: hr
 #: selection:hr.job,state:0
 msgid "Recruitment in Progress"
-msgstr "Assunzioni in Corso"
+msgstr "Selezione in corso"
 
 #. module: hr
 #: model_terms:ir.ui.view,arch_db:hr.view_employee_form
@@ -1416,8 +1415,8 @@ msgstr ""
 msgid ""
 "Set whether the recruitment process is open or closed for this job position."
 msgstr ""
-"Imposta se il processo di assunzione è aperto o chiuso per questa posizione "
-"lavorativa."
+"Indica se il processo di selezione per questa posizione lavorativa è aperto "
+"o chiuso."
 
 #. module: hr
 #: model:ir.actions.act_window,name:hr.hr_config_settings_action
@@ -1495,7 +1494,7 @@ msgstr "Nome completo del coniuge"
 #. module: hr
 #: model_terms:ir.ui.view,arch_db:hr.view_hr_job_form
 msgid "Start Recruitment"
-msgstr "Inizia assunzioni"
+msgstr "Avvia selezione"
 
 #. module: hr
 #: model:ir.model.fields,field_description:hr.field_hr_job__state
@@ -1520,7 +1519,7 @@ msgstr ""
 #. module: hr
 #: model_terms:ir.ui.view,arch_db:hr.view_hr_job_form
 msgid "Stop Recruitment"
-msgstr "Ferma Assunzioni"
+msgstr "Termina selezione"
 
 #. module: hr
 #: model:ir.actions.act_window,name:hr.hr_employee_action_subordinate_hierachy
@@ -1561,8 +1560,7 @@ msgstr "L'indirizzo del dipendente ha un'azienda collegata"
 #: sql_constraint:hr.job:0
 msgid "The name of the job position must be unique per department in company!"
 msgstr ""
-"Il nome della posizione lavorativa deve essere unico per dipartimento "
-"nell'azienda!"
+"Il nome della posizione lavorativa deve essere univoco per ufficio aziendale"
 
 #. module: hr
 #: model:res.groups,comment:hr.group_hr_user
@@ -1919,13 +1917,13 @@ msgstr "Sei pronto a lavorare in un'azienda dinamica"
 #: code:addons/hr/models/hr.py:206
 #, python-format
 msgid "You cannot create a recursive hierarchy."
-msgstr "Non puoi creare una gerarchia ricorsiva."
+msgstr "Impossibile creare una gerarchia ricorsiva."
 
 #. module: hr
 #: code:addons/hr/models/hr.py:331
 #, python-format
 msgid "You cannot create recursive departments."
-msgstr "Non puoi creare dipartimenti ricorsivi."
+msgstr "Impossibile creare uffici ricorsivi."
 
 #. module: hr
 #: model_terms:hr.job,website_description:hr.job_consultant
@@ -2059,7 +2057,7 @@ msgstr "Il tuo documento non è stato creato"
 #. module: hr
 #: model_terms:ir.ui.view,arch_db:hr.view_department_form
 msgid "department"
-msgstr "reparto"
+msgstr "ufficio"
 
 #. module: hr
 #: model_terms:ir.ui.view,arch_db:hr.view_employee_form

--- a/addons/hr_attendance/i18n/it.po
+++ b/addons/hr_attendance/i18n/it.po
@@ -614,7 +614,7 @@ msgstr "Stampa tesserino"
 #. module: hr_attendance
 #: model:ir.ui.menu,name:hr_attendance.menu_hr_attendance_report
 msgid "Reporting"
-msgstr "Report"
+msgstr "Resoconti"
 
 #. module: hr_attendance
 #. openerp-web

--- a/addons/hr_contract/i18n/eu.po
+++ b/addons/hr_contract/i18n/eu.po
@@ -14,6 +14,7 @@
 # Mikel Lizarralde <mikellizarralde@gmail.com>, 2020
 # Victor Laskurain <blaskurain@binovo.es>, 2020
 # Maialen Rodriguez <maialenrodriguez98@gmail.com>, 2020
+# Miren Maiz <mirenmaizz@gmail.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -21,7 +22,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2020-02-06 19:08+0000\n"
 "PO-Revision-Date: 2018-08-24 09:18+0000\n"
-"Last-Translator: Maialen Rodriguez <maialenrodriguez98@gmail.com>, 2020\n"
+"Last-Translator: Miren Maiz <mirenmaizz@gmail.com>, 2020\n"
 "Language-Team: Basque (https://www.transifex.com/odoo/teams/41243/eu/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -499,7 +500,7 @@ msgstr ""
 #. module: hr_contract
 #: model:ir.model.fields,field_description:hr_contract.field_hr_contract__activity_user_id
 msgid "Responsible User"
-msgstr ""
+msgstr "Erabiltzaile arduraduna"
 
 #. module: hr_contract
 #: selection:hr.contract,state:0

--- a/addons/hr_contract/i18n/it.po
+++ b/addons/hr_contract/i18n/it.po
@@ -209,7 +209,7 @@ msgstr "Elimina"
 #. module: hr_contract
 #: model:ir.model.fields,field_description:hr_contract.field_hr_contract__department_id
 msgid "Department"
-msgstr "Dipartimento"
+msgstr "Ufficio"
 
 #. module: hr_contract
 #: model:ir.model.fields,field_description:hr_contract.field_hr_contract__display_name

--- a/addons/hr_expense/i18n/et.po
+++ b/addons/hr_expense/i18n/et.po
@@ -6,12 +6,12 @@
 # Wanradt Koell <wanradt@gmail.com>, 2018
 # Ahto Reinaru <ahto.reinaru@gmail.com>, 2018
 # Marek Pontus, 2018
+# Martin Aavastik <martin@avalah.ee>, 2018
 # Helen Sulaoja <helen@avalah.ee>, 2018
 # Rivo Zängov <eraser@eraser.ee>, 2018
 # Martin Trigaux, 2018
 # Arma Gedonsky <armagedonsky@hot.ee>, 2018
 # Egon Raamat <egon@avalah.ee>, 2018
-# Martin Aavastik <martin@avalah.ee>, 2018
 # Eneli Õigus <enelioigus@gmail.com>, 2018
 # Algo Kärp <algokarp@gmail.com>, 2020
 # 
@@ -171,7 +171,7 @@ msgstr "Tegelikud kuluaruanded, mitte tagasilükatud"
 #: code:addons/hr_expense/models/hr_expense.py:158
 #, python-format
 msgid "Add a new expense,"
-msgstr ""
+msgstr "Lisage uus kulu,"
 
 #. module: hr_expense
 #: model:product.product,name:hr_expense.air_ticket
@@ -325,7 +325,7 @@ msgstr ""
 #. module: hr_expense
 #: model_terms:ir.actions.act_window,help:hr_expense.hr_expense_product
 msgid "Create a new expense category"
-msgstr ""
+msgstr "Looge uus kulukategooria"
 
 #. module: hr_expense
 #: model_terms:ir.actions.act_window,help:hr_expense.action_hr_expense_sheet_all_all
@@ -638,7 +638,7 @@ msgstr "Kulud arveks"
 #. module: hr_expense
 #: model_terms:ir.ui.view,arch_db:hr_expense.account_journal_dashboard_kanban_view_inherit_hr_expense
 msgid "Expenses to Process"
-msgstr ""
+msgstr "Töötlemiskulud\n"
 
 #. module: hr_expense
 #: model:ir.model.fields,field_description:hr_expense.field_hr_expense__is_refused
@@ -917,7 +917,7 @@ msgstr "Töötajal %s ei leitud kodust aadressi, palun seadista üks."
 #. module: hr_expense
 #: model_terms:ir.actions.act_window,help:hr_expense.action_approved_expense
 msgid "No approved employee expenses"
-msgstr ""
+msgstr "Kinnitatud töötaja kulud puuduvad"
 
 #. module: hr_expense
 #: code:addons/hr_expense/models/hr_expense.py:257
@@ -930,6 +930,8 @@ msgstr "Kandes %s ei leitud kreeditkontot, palun seadista üks."
 #: model_terms:ir.actions.act_window,help:hr_expense.action_hr_expense_sheet_all_to_approve
 msgid "No expense reports to approve"
 msgstr ""
+"\n"
+"Kinnitatavaid kuluaruandeid pole"
 
 #. module: hr_expense
 #: model_terms:ir.actions.act_window,help:hr_expense.action_unsubmitted_expense
@@ -1017,6 +1019,8 @@ msgstr ""
 #, python-format
 msgid "Only Managers and HR Officers can approve expenses"
 msgstr ""
+"\n"
+"Ainult juhid ja personalijuhid saavad kulud heaks kiita"
 
 #. module: hr_expense
 #: model_terms:ir.ui.view,arch_db:hr_expense.view_hr_expense_sheet_form
@@ -1039,7 +1043,7 @@ msgstr "Makstud"
 #: model:ir.model.fields,field_description:hr_expense.field_hr_expense__payment_mode
 #: model:ir.model.fields,field_description:hr_expense.field_hr_expense_sheet__payment_mode
 msgid "Paid By"
-msgstr ""
+msgstr "Maksis"
 
 #. module: hr_expense
 #: model:ir.model.fields,field_description:hr_expense.field_hr_expense_sheet_register_payment_wizard__partner_id
@@ -1070,7 +1074,7 @@ msgstr "Makse tüüp"
 #: selection:hr.expense,activity_state:0
 #: selection:hr.expense.sheet,activity_state:0
 msgid "Planned"
-msgstr "Planned"
+msgstr "Planeeritud"
 
 #. module: hr_expense
 #: code:addons/hr_expense/models/hr_expense.py:248
@@ -1397,7 +1401,7 @@ msgstr "Esitamise ootel"
 #. module: hr_expense
 #: model_terms:ir.ui.view,arch_db:hr_expense.view_hr_expense_filter
 msgid "To report"
-msgstr ""
+msgstr "Teatada"
 
 #. module: hr_expense
 #: selection:hr.expense,activity_state:0
@@ -1419,7 +1423,7 @@ msgstr "Kokku"
 #. module: hr_expense
 #: model:ir.model.fields,field_description:hr_expense.field_hr_expense__total_amount_company
 msgid "Total (Company Currency)"
-msgstr ""
+msgstr "Kokku (Ettevõtte valuuta)"
 
 #. module: hr_expense
 #: model:ir.model.fields,field_description:hr_expense.field_hr_expense_sheet__total_amount
@@ -1514,7 +1518,7 @@ msgstr "Veebilehe suhtluse ajalugu"
 #: code:addons/hr_expense/models/hr_expense.py:675
 #, python-format
 msgid "You can only approve your department expenses"
-msgstr ""
+msgstr "Te saate kinnitada ainult oma osakonna kulud."
 
 #. module: hr_expense
 #: code:addons/hr_expense/models/hr_expense.py:620
@@ -1554,13 +1558,15 @@ msgstr ""
 #: code:addons/hr_expense/models/hr_expense.py:672
 #, python-format
 msgid "You cannot approve your own expenses"
-msgstr ""
+msgstr "Sa ei saa enda kulusid kinnitada"
 
 #. module: hr_expense
 #: code:addons/hr_expense/models/hr_expense.py:145
 #, python-format
 msgid "You cannot delete a posted or approved expense."
 msgstr ""
+"\n"
+"Postitatud või kinnitatud kulu ei saa kustutada."
 
 #. module: hr_expense
 #: code:addons/hr_expense/models/hr_expense.py:587

--- a/addons/hr_expense/i18n/eu.po
+++ b/addons/hr_expense/i18n/eu.po
@@ -14,6 +14,7 @@
 # Naomi Hidalgo <naomihid96@gmail.com>, 2019
 # Victor Laskurain <blaskurain@binovo.es>, 2019
 # Maialen Rodriguez <maialenrodriguez98@gmail.com>, 2020
+# Miren Maiz <mirenmaizz@gmail.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -21,7 +22,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2018-12-19 08:20+0000\n"
 "PO-Revision-Date: 2018-08-24 09:18+0000\n"
-"Last-Translator: Maialen Rodriguez <maialenrodriguez98@gmail.com>, 2020\n"
+"Last-Translator: Miren Maiz <mirenmaizz@gmail.com>, 2020\n"
 "Language-Team: Basque (https://www.transifex.com/odoo/teams/41243/eu/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1227,7 +1228,7 @@ msgstr "Berrezarri zirriborrora"
 #: model:ir.model.fields,field_description:hr_expense.field_hr_expense__activity_user_id
 #: model:ir.model.fields,field_description:hr_expense.field_hr_expense_sheet__activity_user_id
 msgid "Responsible User"
-msgstr ""
+msgstr "Erabiltzaile arduraduna"
 
 #. module: hr_expense
 #: code:addons/hr_expense/models/hr_expense.py:135

--- a/addons/hr_expense/i18n/it.po
+++ b/addons/hr_expense/i18n/it.po
@@ -1485,7 +1485,7 @@ msgstr "Messaggi non letti"
 #: model:ir.model.fields,field_description:hr_expense.field_hr_expense__message_unread_counter
 #: model:ir.model.fields,field_description:hr_expense.field_hr_expense_sheet__message_unread_counter
 msgid "Unread Messages Counter"
-msgstr "Contatore messaggi non letti"
+msgstr "Numero messaggi non letti"
 
 #. module: hr_expense
 #: model:ir.actions.act_window,name:hr_expense.action_unsubmitted_expense

--- a/addons/hr_expense/i18n/pt_BR.po
+++ b/addons/hr_expense/i18n/pt_BR.po
@@ -15,6 +15,7 @@
 # Mateus Lopes <mateus1@gmail.com>, 2018
 # Fernanda Marques <fem@odoo.com>, 2020
 # Marcel Savegnago <marcel.savegnago@gmail.com>, 2020
+# Eduardo Aparicio <eduardo.caparica@gmail.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -22,7 +23,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2018-12-19 08:20+0000\n"
 "PO-Revision-Date: 2018-08-24 09:18+0000\n"
-"Last-Translator: Marcel Savegnago <marcel.savegnago@gmail.com>, 2020\n"
+"Last-Translator: Eduardo Aparicio <eduardo.caparica@gmail.com>, 2020\n"
 "Language-Team: Portuguese (Brazil) (https://www.transifex.com/odoo/teams/41243/pt_BR/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -36,6 +37,8 @@ msgid ""
 "<i class=\"text-muted oe_edit_only\">Use [Reference] as a subject prefix for"
 " incoming receipts</i>"
 msgstr ""
+"<i class=\"text-muted oe_edit_only\">Use [Referência] como prefixo do título"
+" para recebimento de recibos</i>"
 
 #. module: hr_expense
 #. openerp-web
@@ -45,6 +48,8 @@ msgid ""
 "<p>Approve the report here.</p><p>Tip: if you refuse, don’t forget to give "
 "the reason thanks to the hereunder message tool</p>"
 msgstr ""
+"<p>Aprove o relatório aqui.</p><p>Dica: se você recusar, não se esqueça de "
+"apontar o motivo aqui embaixo na ferramenta de mensagens</p>"
 
 #. module: hr_expense
 #. openerp-web
@@ -54,27 +59,29 @@ msgid ""
 "<p>Click on <b> Action Create Report </b> to submit selected expenses to "
 "your manager</p>"
 msgstr ""
+"<p>Clique na <b>ação Criar Relatório </b>para enviar as despesas "
+"selecionadas ao seu gerente.</p> "
 
 #. module: hr_expense
 #. openerp-web
 #: code:addons/hr_expense/static/src/js/tour.js:32
 #, python-format
 msgid "<p>Click on <b> Create Report </b> to create the report.</p>"
-msgstr ""
+msgstr "<p>Clique em <b>Criar Relatório</b>para criar o relatório.</p>"
 
 #. module: hr_expense
 #. openerp-web
 #: code:addons/hr_expense/static/src/js/tour.js:23
 #, python-format
 msgid "<p>Once your <b> Expense </b> is ready, you can save it.</p>"
-msgstr ""
+msgstr "<p>Quando sua <b>Despesa</b>estiver pronta, você pode salvá-la.</p>"
 
 #. module: hr_expense
 #. openerp-web
 #: code:addons/hr_expense/static/src/js/tour.js:36
 #, python-format
 msgid "<p>Select expenses to submit them to your manager</p>"
-msgstr ""
+msgstr "<p>Selecione as despesas que deseja reportar ao seu gerente.</p>"
 
 #. module: hr_expense
 #. openerp-web
@@ -84,6 +91,9 @@ msgid ""
 "<p>The accountant receive approved expense reports.</p><p>He can post "
 "journal entries in one click if taxes and accounts are right.</p>"
 msgstr ""
+"<p>O contador recebe o relatório de despesas aprovado.</p><p>Ele pode lançar"
+" as transações no diário com um clique, se impostos e contas contábeis "
+"estiverem corretas.</p>"
 
 #. module: hr_expense
 #: model_terms:ir.ui.view,arch_db:hr_expense.report_expense_sheet
@@ -103,7 +113,7 @@ msgstr "<strong>Funcionário:</strong>"
 #. module: hr_expense
 #: model_terms:ir.ui.view,arch_db:hr_expense.report_expense_sheet
 msgid "<strong>Payment By:</strong>"
-msgstr ""
+msgstr "<strong>Pagamento por:</strong>"
 
 #. module: hr_expense
 #: model_terms:ir.ui.view,arch_db:hr_expense.report_expense_sheet
@@ -122,6 +132,8 @@ msgid ""
 "A payment of %s %s with the reference <a href='/mail/view?%s'>%s</a> related"
 " to your expense %s has been made."
 msgstr ""
+"Um pagamento de %s%s com a referência <a href='/mail/view?%s'>%s</a> "
+"relacionado a sua despesa %s foi feito."
 
 #. module: hr_expense
 #: model:ir.model.fields,field_description:hr_expense.field_hr_expense__account_id
@@ -160,13 +172,13 @@ msgstr "Tipos de Atividades"
 #. module: hr_expense
 #: model_terms:ir.ui.view,arch_db:hr_expense.view_hr_expense_filter
 msgid "Actual expense sheets, not the refused ones"
-msgstr ""
+msgstr "Folha de despesas atual, não as recusadas"
 
 #. module: hr_expense
 #: code:addons/hr_expense/models/hr_expense.py:158
 #, python-format
 msgid "Add a new expense,"
-msgstr ""
+msgstr "Adicione nova despesa,"
 
 #. module: hr_expense
 #: model:product.product,name:hr_expense.air_ticket
@@ -177,17 +189,17 @@ msgstr "Voo"
 #. module: hr_expense
 #: model:ir.actions.act_window,name:hr_expense.action_hr_expense_sheet_all_all
 msgid "All Expense Reports"
-msgstr ""
+msgstr "Todos os Relatórios de Despesas"
 
 #. module: hr_expense
 #: model:ir.actions.act_window,name:hr_expense.hr_expense_actions_all
 msgid "All Expenses"
-msgstr ""
+msgstr "Todas as Despesas"
 
 #. module: hr_expense
 #: model:ir.model.fields,help:hr_expense.field_hr_expense__account_id
 msgid "An expense account is expected"
-msgstr ""
+msgstr "Uma conta de despesas é esperada"
 
 #. module: hr_expense
 #: model:ir.model.fields,field_description:hr_expense.field_hr_expense__analytic_account_id
@@ -227,7 +239,7 @@ msgstr "Anexar um documento"
 #: code:addons/hr_expense/static/src/js/tour.js:27
 #, python-format
 msgid "Attach your receipt here."
-msgstr ""
+msgstr "Anexe o seu recibo aqui."
 
 #. module: hr_expense
 #: model:ir.model.fields,field_description:hr_expense.field_hr_expense__message_attachment_count
@@ -248,7 +260,7 @@ msgstr "Conta de Referência"
 #. module: hr_expense
 #: model:ir.model.fields,field_description:hr_expense.field_hr_expense_sheet__can_reset
 msgid "Can Reset"
-msgstr ""
+msgstr "Pode Redefinir"
 
 #. module: hr_expense
 #: model:ir.model.fields,field_description:hr_expense.field_product_template__can_be_expensed
@@ -308,7 +320,7 @@ msgstr "Despesas Confirmadas"
 #. module: hr_expense
 #: model_terms:ir.ui.view,arch_db:hr_expense.hr_expense_view_form
 msgid "Create Report"
-msgstr ""
+msgstr "Criar Relatório"
 
 #. module: hr_expense
 #: model_terms:ir.actions.act_window,help:hr_expense.action_request_approve_expense_sheet
@@ -317,12 +329,12 @@ msgstr ""
 #: model_terms:ir.actions.act_window,help:hr_expense.hr_expense_actions_all
 #: model_terms:ir.actions.act_window,help:hr_expense.hr_expense_actions_my_unsubmitted
 msgid "Create a new expense"
-msgstr ""
+msgstr "Criar nova despesa"
 
 #. module: hr_expense
 #: model_terms:ir.actions.act_window,help:hr_expense.hr_expense_product
 msgid "Create a new expense category"
-msgstr ""
+msgstr "Criar nova categoria de despesas"
 
 #. module: hr_expense
 #: model_terms:ir.actions.act_window,help:hr_expense.action_hr_expense_sheet_all_all
@@ -330,7 +342,7 @@ msgstr ""
 #: model_terms:ir.actions.act_window,help:hr_expense.action_hr_expense_sheet_all_to_post
 #: model_terms:ir.actions.act_window,help:hr_expense.action_hr_expense_sheet_my_all
 msgid "Create a new expense report"
-msgstr ""
+msgstr "Criar novo relatório de despesas"
 
 #. module: hr_expense
 #: model:ir.model.fields,field_description:hr_expense.field_hr_expense__create_uid
@@ -367,7 +379,7 @@ msgstr "Data"
 #. module: hr_expense
 #: model:ir.model.fields,field_description:hr_expense.field_res_config_settings__expense_alias_prefix
 msgid "Default Alias Name for Expenses"
-msgstr ""
+msgstr "Apelido Padrão para Despesas"
 
 #. module: hr_expense
 #: model:ir.model.fields,field_description:hr_expense.field_hr_expense_sheet__department_id
@@ -403,7 +415,7 @@ msgstr "Provisório"
 #. module: hr_expense
 #: model_terms:ir.ui.view,arch_db:hr_expense.hr_expense_sheet_register_payment_view_form
 msgid "Draft Payment"
-msgstr ""
+msgstr "Pagamento Provisório"
 
 #. module: hr_expense
 #: model_terms:ir.ui.view,arch_db:hr_expense.res_config_settings_view_form
@@ -437,7 +449,7 @@ msgstr "Despesas de Funcionário"
 #. module: hr_expense
 #: model:ir.model.fields,field_description:hr_expense.field_hr_expense_sheet__address_id
 msgid "Employee Home Address"
-msgstr ""
+msgstr "Endereço Residencial do Funcionário"
 
 #. module: hr_expense
 #: model:ir.model,name:hr_expense.model_hr_expense
@@ -451,7 +463,7 @@ msgstr "Despesa"
 #. module: hr_expense
 #: model:mail.activity.type,name:hr_expense.mail_act_expense_approval
 msgid "Expense Approval"
-msgstr ""
+msgstr "Aprovação da Despesa"
 
 #. module: hr_expense
 #: model_terms:ir.ui.view,arch_db:hr_expense.view_hr_expense_filter
@@ -478,29 +490,29 @@ msgstr "Produtos de Despesas"
 #. module: hr_expense
 #: model:ir.model,name:hr_expense.model_hr_expense_refuse_wizard
 msgid "Expense Refuse Reason Wizard"
-msgstr ""
+msgstr "Assistente de Motivos para Recusa de Despesas"
 
 #. module: hr_expense
 #: model:ir.model,name:hr_expense.model_hr_expense_sheet_register_payment_wizard
 msgid "Expense Register Payment Wizard"
-msgstr ""
+msgstr "Assistente de Registro de Pagamento de Despesas"
 
 #. module: hr_expense
 #: model:ir.model,name:hr_expense.model_hr_expense_sheet
 #: model:ir.model.fields,field_description:hr_expense.field_hr_expense__sheet_id
 #: model_terms:ir.ui.view,arch_db:hr_expense.view_hr_expense_sheet_tree
 msgid "Expense Report"
-msgstr ""
+msgstr "Relatório de Despesas"
 
 #. module: hr_expense
 #: model:ir.model.fields,help:hr_expense.field_hr_expense_sheet__state
 msgid "Expense Report State"
-msgstr ""
+msgstr "Estado do Relatório de Despesas"
 
 #. module: hr_expense
 #: model:ir.model.fields,field_description:hr_expense.field_hr_expense_sheet__name
 msgid "Expense Report Summary"
-msgstr ""
+msgstr "Resumo do Relatório de Despesas"
 
 #. module: hr_expense
 #: model:ir.ui.menu,name:hr_expense.menu_hr_expense_report
@@ -508,33 +520,33 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:hr_expense.view_hr_expense_sheet_form
 #: model_terms:ir.ui.view,arch_db:hr_expense.view_hr_expense_sheet_tree
 msgid "Expense Reports"
-msgstr ""
+msgstr "Relatórios de Despesas"
 
 #. module: hr_expense
 #: model:ir.actions.act_window,name:hr_expense.action_hr_expense_sheet_department_filtered
 msgid "Expense Reports Analysis"
-msgstr ""
+msgstr "Análise de Relatórios de Despesas"
 
 #. module: hr_expense
 #: model:ir.actions.act_window,name:hr_expense.action_hr_expense_sheet_all_to_pay
 msgid "Expense Reports To Pay"
-msgstr ""
+msgstr "Relatórios de Despesas Para Pagar"
 
 #. module: hr_expense
 #: model:ir.actions.act_window,name:hr_expense.action_hr_expense_sheet_all_to_post
 msgid "Expense Reports To Post"
-msgstr ""
+msgstr "Relatórios de Despesas Para Lançar"
 
 #. module: hr_expense
 #: model:ir.actions.act_window,name:hr_expense.action_hr_expense_sheet_all_to_approve
 #: model:ir.actions.act_window,name:hr_expense.action_hr_expense_sheet_department_to_approve
 msgid "Expense Reports to Approve"
-msgstr ""
+msgstr "Relatórios de Despesas Para Aprovar"
 
 #. module: hr_expense
 #: model:ir.model.fields,field_description:hr_expense.field_hr_employee__expense_manager_id
 msgid "Expense Responsible"
-msgstr ""
+msgstr "Responsável pela Despesa"
 
 #. module: hr_expense
 #: model_terms:ir.ui.view,arch_db:hr_expense.hr_expense_refuse_wizard_view_form
@@ -544,22 +556,22 @@ msgstr "Razão de recusa da despesa"
 #. module: hr_expense
 #: model:mail.message.subtype,description:hr_expense.mt_expense_approved
 msgid "Expense report approved"
-msgstr ""
+msgstr "Relatório de despesas aprovado"
 
 #. module: hr_expense
 #: model:mail.message.subtype,description:hr_expense.mt_expense_paid
 msgid "Expense report paid"
-msgstr ""
+msgstr "Relatório de despesas pago"
 
 #. module: hr_expense
 #: model:mail.message.subtype,description:hr_expense.mt_expense_refused
 msgid "Expense report refused"
-msgstr ""
+msgstr "Relatório de despesas recusado"
 
 #. module: hr_expense
 #: model:ir.model.fields,help:hr_expense.field_account_move_line__expense_id
 msgid "Expense where the move line come from"
-msgstr ""
+msgstr "Despesa onde a linha do movimento se origina"
 
 #. module: hr_expense
 #: model:ir.ui.menu,name:hr_expense.menu_hr_expense_root
@@ -588,28 +600,29 @@ msgstr "Análise de Despesas"
 #: model:ir.actions.report,name:hr_expense.action_report_hr_expense_sheet
 #: model_terms:ir.ui.view,arch_db:hr_expense.report_expense_sheet
 msgid "Expenses Report"
-msgstr ""
+msgstr "Relatórios de Despesas"
 
 #. module: hr_expense
 #: model:ir.model.fields,field_description:hr_expense.field_hr_department__expense_sheets_to_approve_count
 msgid "Expenses Reports to Approve"
-msgstr ""
+msgstr "Relatórios de Despesas para Aprovar"
 
 #. module: hr_expense
 #: model_terms:ir.ui.view,arch_db:hr_expense.view_hr_expense_sheet_filter
 msgid "Expenses by Date"
-msgstr ""
+msgstr "Despesas por Data"
 
 #. module: hr_expense
 #: model_terms:ir.ui.view,arch_db:hr_expense.view_hr_expense_sheet_filter
 msgid "Expenses in Draft"
-msgstr ""
+msgstr "Despesas Provisórias"
 
 #. module: hr_expense
 #: code:addons/hr_expense/models/hr_expense.py:568
 #, python-format
 msgid "Expenses must be paid by the same entity (Company or employee)."
 msgstr ""
+"Despesas devem ser pagas pela mesma entidade (empresa ou funcionário)."
 
 #. module: hr_expense
 #: code:addons/hr_expense/models/hr_expense.py:623
@@ -635,12 +648,12 @@ msgstr "Despesas para Faturar"
 #. module: hr_expense
 #: model_terms:ir.ui.view,arch_db:hr_expense.account_journal_dashboard_kanban_view_inherit_hr_expense
 msgid "Expenses to Process"
-msgstr ""
+msgstr "Despesas para Processar"
 
 #. module: hr_expense
 #: model:ir.model.fields,field_description:hr_expense.field_hr_expense__is_refused
 msgid "Explicitely Refused by manager or acccountant"
-msgstr ""
+msgstr "Explicitamente Recusado pelo gerente ou contador."
 
 #. module: hr_expense
 #: model:ir.model.fields,field_description:hr_expense.field_hr_expense__message_follower_ids
@@ -701,7 +714,7 @@ msgstr "Departamento de RH"
 #. module: hr_expense
 #: model:ir.model.fields,field_description:hr_expense.field_hr_expense_sheet__is_multiple_currency
 msgid "Handle lines with different currencies"
-msgstr ""
+msgstr "Manipular linhas com diferentes moedas"
 
 #. module: hr_expense
 #: model:ir.model.fields,field_description:hr_expense.field_hr_expense_sheet_register_payment_wizard__hide_payment_method
@@ -711,12 +724,12 @@ msgstr "Esconder Método de Pagamento"
 #. module: hr_expense
 #: model:ir.model.fields,field_description:hr_expense.field_hr_expense_refuse_wizard__hr_expense_ids
 msgid "Hr Expense"
-msgstr ""
+msgstr "RH Despesas"
 
 #. module: hr_expense
 #: model:ir.model.fields,field_description:hr_expense.field_hr_expense_refuse_wizard__hr_expense_sheet_id
 msgid "Hr Expense Sheet"
-msgstr ""
+msgstr "RH Folha de Despesas"
 
 #. module: hr_expense
 #: model:ir.model.fields,field_description:hr_expense.field_hr_expense__id
@@ -799,7 +812,7 @@ msgstr "Últimas Atividades"
 #: model:ir.model.fields,field_description:hr_expense.field_res_config_settings__use_mailgateway
 #: model_terms:ir.ui.view,arch_db:hr_expense.res_config_settings_view_form
 msgid "Let your employees record expenses by email"
-msgstr ""
+msgstr "Permitir que seus funcionários relatem despesas por e-mail"
 
 #. module: hr_expense
 #: model:ir.model.fields,field_description:hr_expense.field_hr_expense__message_main_attachment_id
@@ -818,7 +831,7 @@ msgstr "Gerente"
 #: code:addons/hr_expense/static/src/js/tour.js:61
 #, python-format
 msgid "Managers can get all reports to approve from this menu."
-msgstr ""
+msgstr "Gerentes podem acessar todos os relatórios para aprovação neste menu."
 
 #. module: hr_expense
 #: model:ir.model.fields,field_description:hr_expense.field_hr_expense_sheet_register_payment_wizard__communication
@@ -841,7 +854,7 @@ msgstr "Mensagens"
 #: model:ir.actions.act_window,name:hr_expense.action_hr_expense_sheet_my_all
 #: model:ir.ui.menu,name:hr_expense.menu_hr_expense_sheet_my_reports
 msgid "My Expense Reports"
-msgstr ""
+msgstr "Meus Relatórios de Despesas"
 
 #. module: hr_expense
 #: model:ir.actions.act_window,name:hr_expense.hr_expense_actions_my_unsubmitted
@@ -854,7 +867,7 @@ msgstr "Minhas despesas"
 #. module: hr_expense
 #: model_terms:ir.ui.view,arch_db:hr_expense.view_hr_expense_sheet_filter
 msgid "My Reports"
-msgstr ""
+msgstr "Meus Relatórios"
 
 #. module: hr_expense
 #: model_terms:ir.ui.view,arch_db:hr_expense.view_hr_expense_filter
@@ -864,7 +877,7 @@ msgstr "Despesas de Minha Equipe"
 #. module: hr_expense
 #: model_terms:ir.ui.view,arch_db:hr_expense.view_hr_expense_sheet_filter
 msgid "My Team Reports"
-msgstr ""
+msgstr "Relatórios da Minha Equipe"
 
 #. module: hr_expense
 #: model_terms:ir.ui.view,arch_db:hr_expense.report_expense_sheet
@@ -875,7 +888,7 @@ msgstr "Nome"
 #: code:addons/hr_expense/models/hr_expense.py:186
 #, python-format
 msgid "New Expense Report"
-msgstr ""
+msgstr "Novo Relatório de Despesas"
 
 #. module: hr_expense
 #: model:ir.model.fields,field_description:hr_expense.field_hr_expense__activity_date_deadline
@@ -902,6 +915,8 @@ msgid ""
 "No Expense account found for the product %s (or for its category), please "
 "configure one."
 msgstr ""
+"Não foi encontrada uma conta contábil para o produto %s (ou para sua "
+"categoria), por favor configure uma."
 
 #. module: hr_expense
 #: code:addons/hr_expense/models/hr_expense.py:261
@@ -914,7 +929,7 @@ msgstr ""
 #. module: hr_expense
 #: model_terms:ir.actions.act_window,help:hr_expense.action_approved_expense
 msgid "No approved employee expenses"
-msgstr ""
+msgstr "Nenhuma despesa de funcionário aprovada"
 
 #. module: hr_expense
 #: code:addons/hr_expense/models/hr_expense.py:257
@@ -928,12 +943,12 @@ msgstr ""
 #. module: hr_expense
 #: model_terms:ir.actions.act_window,help:hr_expense.action_hr_expense_sheet_all_to_approve
 msgid "No expense reports to approve"
-msgstr ""
+msgstr "Nenhum relatório de despesas para aprovar"
 
 #. module: hr_expense
 #: model_terms:ir.actions.act_window,help:hr_expense.action_unsubmitted_expense
 msgid "No unreported employee expenses"
-msgstr ""
+msgstr "Nenhuma despesa de funcionário não reportada"
 
 #. module: hr_expense
 #: model:ir.model.fields,field_description:hr_expense.field_hr_expense__description
@@ -1005,19 +1020,23 @@ msgid ""
 "Once your <b>Expense report</b> is ready, you can submit it to your manager "
 "and wait for the approval from your manager."
 msgstr ""
+"Assim que o seu <b>Relatório de Despesas</b> estiver pronto, você poderá "
+"enviá-lo ao seu gerente e aguardar por sua aprovação."
 
 #. module: hr_expense
 #: code:addons/hr_expense/models/hr_expense.py:706
 #, python-format
 msgid "Only HR Officers or the concerned employee can reset to draft."
 msgstr ""
+"Apenas a equipe do RH ou o funcionário que reportou a despesa podem "
+"redefiní-la como provisória."
 
 #. module: hr_expense
 #: code:addons/hr_expense/models/hr_expense.py:667
 #: code:addons/hr_expense/models/hr_expense.py:688
 #, python-format
 msgid "Only Managers and HR Officers can approve expenses"
-msgstr ""
+msgstr "Apenas Gerentes e Equipe do RH podem aprovar despesas"
 
 #. module: hr_expense
 #: model_terms:ir.ui.view,arch_db:hr_expense.view_hr_expense_sheet_form
@@ -1040,7 +1059,7 @@ msgstr "Pago"
 #: model:ir.model.fields,field_description:hr_expense.field_hr_expense__payment_mode
 #: model:ir.model.fields,field_description:hr_expense.field_hr_expense_sheet__payment_mode
 msgid "Paid By"
-msgstr ""
+msgstr "Pago Por"
 
 #. module: hr_expense
 #: model:ir.model.fields,field_description:hr_expense.field_hr_expense_sheet_register_payment_wizard__partner_id
@@ -1101,7 +1120,7 @@ msgstr "Preço"
 #. module: hr_expense
 #: model_terms:ir.ui.view,arch_db:hr_expense.report_expense_sheet
 msgid "Price in Company Currency"
-msgstr ""
+msgstr "Preço na Moeda da Empresa"
 
 #. module: hr_expense
 #: model:ir.model.fields,field_description:hr_expense.field_hr_expense__product_id
@@ -1142,12 +1161,12 @@ msgstr "Motivo"
 #. module: hr_expense
 #: model_terms:ir.ui.view,arch_db:hr_expense.hr_expense_template_refuse_reason
 msgid "Reason :"
-msgstr ""
+msgstr "Motivo:"
 
 #. module: hr_expense
 #: model_terms:ir.ui.view,arch_db:hr_expense.hr_expense_refuse_wizard_view_form
 msgid "Reason to refuse Expense"
-msgstr ""
+msgstr "Motivo da recusa da Despesa"
 
 #. module: hr_expense
 #: model:ir.model.fields,field_description:hr_expense.field_hr_expense_sheet_register_payment_wizard__partner_bank_account_id
@@ -1157,7 +1176,7 @@ msgstr "Conta Bancária Destinatária"
 #. module: hr_expense
 #: model_terms:ir.ui.view,arch_db:hr_expense.res_config_settings_view_form
 msgid "Recording"
-msgstr ""
+msgstr "Gravação"
 
 #. module: hr_expense
 #: model_terms:ir.ui.view,arch_db:hr_expense.report_expense_sheet
@@ -1186,7 +1205,7 @@ msgstr "Recusado"
 #. module: hr_expense
 #: model_terms:ir.ui.view,arch_db:hr_expense.view_hr_expense_filter
 msgid "Refused Expenses"
-msgstr ""
+msgstr "Despesas Recusadas"
 
 #. module: hr_expense
 #: model:ir.actions.act_window,name:hr_expense.hr_expense_sheet_register_payment_wizard_action
@@ -1204,12 +1223,12 @@ msgstr "Relatório"
 #. module: hr_expense
 #: model:ir.model.fields,field_description:hr_expense.field_hr_expense__company_currency_id
 msgid "Report Company Currency"
-msgstr ""
+msgstr "Moeda da Empresa no Relatório"
 
 #. module: hr_expense
 #: model_terms:ir.ui.view,arch_db:hr_expense.view_hr_expense_filter
 msgid "Reported"
-msgstr ""
+msgstr "Relatado"
 
 #. module: hr_expense
 #: model:ir.ui.menu,name:hr_expense.menu_hr_expense_reports
@@ -1219,17 +1238,17 @@ msgstr "Relatórios"
 #. module: hr_expense
 #: model:ir.actions.act_window,name:hr_expense.action_request_approve_expense_sheet
 msgid "Reports to Approve"
-msgstr ""
+msgstr "Relatórios para Aprovar"
 
 #. module: hr_expense
 #: model:ir.actions.act_window,name:hr_expense.action_request_to_pay_expense_sheet
 msgid "Reports to Pay"
-msgstr ""
+msgstr "Relatórios para Pagar"
 
 #. module: hr_expense
 #: model:ir.actions.act_window,name:hr_expense.action_request_to_post_expense_sheet
 msgid "Reports to Post"
-msgstr ""
+msgstr "Relatórios para Lançar"
 
 #. module: hr_expense
 #: model_terms:ir.ui.view,arch_db:hr_expense.view_hr_expense_sheet_form
@@ -1278,7 +1297,7 @@ msgstr ""
 #. module: hr_expense
 #: model:ir.model.fields,help:hr_expense.field_product_template__can_be_expensed
 msgid "Specify whether the product can be selected in an expense."
-msgstr ""
+msgstr "Especifique se o produto pode ser selecionado em uma despesa."
 
 #. module: hr_expense
 #: model_terms:ir.ui.view,arch_db:hr_expense.view_hr_expense_sheet_filter
@@ -1309,12 +1328,12 @@ msgstr ""
 #. module: hr_expense
 #: model:ir.model.fields,help:hr_expense.field_hr_expense__state
 msgid "Status of the expense."
-msgstr ""
+msgstr "Status da despesa."
 
 #. module: hr_expense
 #: model:ir.actions.server,name:hr_expense.hr_expense_submit_action_server
 msgid "Submit Report"
-msgstr ""
+msgstr "Enviar Relatório"
 
 #. module: hr_expense
 #: model_terms:ir.ui.view,arch_db:hr_expense.view_hr_expense_sheet_form
@@ -1352,6 +1371,8 @@ msgid ""
 "Technical field used to know whether the field `partner_bank_account_id` "
 "needs to be displayed or not in the payments form views"
 msgstr ""
+"Campo técnico usado para saber se o campo `partner_bank_account_id` precisa "
+"ser exibido ou não nos formulários de pagamentos"
 
 #. module: hr_expense
 #. openerp-web
@@ -1360,6 +1381,8 @@ msgstr ""
 msgid ""
 "The accountant can register a payment to reimburse the employee directly."
 msgstr ""
+"O contador pode registrar um pagamento para reembolsar o funcionário "
+"diretamente."
 
 #. module: hr_expense
 #: model:ir.model.fields,help:hr_expense.field_hr_expense_sheet__journal_id
@@ -1393,7 +1416,7 @@ msgstr "A pagar"
 #: model:ir.ui.menu,name:hr_expense.menu_hr_expense_sheet_all_to_post
 #: model_terms:ir.ui.view,arch_db:hr_expense.view_hr_expense_sheet_filter
 msgid "To Post"
-msgstr ""
+msgstr "Para Lançar"
 
 #. module: hr_expense
 #: selection:hr.expense,state:0
@@ -1403,7 +1426,7 @@ msgstr "Para Enviar"
 #. module: hr_expense
 #: model_terms:ir.ui.view,arch_db:hr_expense.view_hr_expense_filter
 msgid "To report"
-msgstr ""
+msgstr "Para reportar"
 
 #. module: hr_expense
 #: selection:hr.expense,activity_state:0
@@ -1425,7 +1448,7 @@ msgstr "Total"
 #. module: hr_expense
 #: model:ir.model.fields,field_description:hr_expense.field_hr_expense__total_amount_company
 msgid "Total (Company Currency)"
-msgstr ""
+msgstr "Total (Moeda da Empresa)"
 
 #. module: hr_expense
 #: model:ir.model.fields,field_description:hr_expense.field_hr_expense_sheet__total_amount
@@ -1468,13 +1491,15 @@ msgstr "Contador de Mensagens Não Lidas"
 #. module: hr_expense
 #: model:ir.actions.act_window,name:hr_expense.action_unsubmitted_expense
 msgid "Unreported Expenses"
-msgstr ""
+msgstr "Despesas Não Reportadas"
 
 #. module: hr_expense
 #: model:ir.model.fields,help:hr_expense.field_hr_employee__expense_manager_id
 msgid ""
 "User responsible of expense approval. Should be Expense Officer or Manager."
 msgstr ""
+"Usuário responsável pela aprovação da despesa. Deve ser da Equipe de "
+"Despesas ou Gerente."
 
 #. module: hr_expense
 #: model_terms:ir.ui.view,arch_db:hr_expense.hr_expense_sheet_register_payment_view_form
@@ -1484,17 +1509,17 @@ msgstr "Validar"
 #. module: hr_expense
 #: model_terms:ir.ui.view,arch_db:hr_expense.view_expenses_tree
 msgid "View Attached Documents"
-msgstr ""
+msgstr "Visualizar Documentos Anexados"
 
 #. module: hr_expense
 #: model_terms:ir.ui.view,arch_db:hr_expense.view_hr_expense_sheet_form
 msgid "View Attachments"
-msgstr ""
+msgstr "Visualizar Anexos"
 
 #. module: hr_expense
 #: model_terms:ir.ui.view,arch_db:hr_expense.hr_expense_view_form
 msgid "View Report"
-msgstr ""
+msgstr "Visualizar Relatório"
 
 #. module: hr_expense
 #. openerp-web
@@ -1502,7 +1527,7 @@ msgstr ""
 #: code:addons/hr_expense/static/src/js/tour.js:18
 #, python-format
 msgid "Want to manage your expenses? It starts here."
-msgstr ""
+msgstr "Gostaria de gerenciar suas despesas? Comece aqui."
 
 #. module: hr_expense
 #: model:ir.model.fields,field_description:hr_expense.field_hr_expense__website_message_ids
@@ -1520,7 +1545,7 @@ msgstr "Histórico de Comunicação do Site"
 #: code:addons/hr_expense/models/hr_expense.py:675
 #, python-format
 msgid "You can only approve your department expenses"
-msgstr ""
+msgstr "Você só pode aprovar despesas do seu departamento"
 
 #. module: hr_expense
 #: code:addons/hr_expense/models/hr_expense.py:620
@@ -1532,7 +1557,7 @@ msgstr "Você só pode gerar entrada contábil de despesa(s) aprovada(s)."
 #: code:addons/hr_expense/models/hr_expense.py:696
 #, python-format
 msgid "You can only refuse your department expenses"
-msgstr ""
+msgstr "Você só pode recusar despesas do seu departamento"
 
 #. module: hr_expense
 #: model_terms:ir.ui.view,arch_db:hr_expense.res_config_settings_view_form
@@ -1543,73 +1568,80 @@ msgid ""
 "between brackets, the product will be set automatically. Type the expense "
 "amount in the mail subject to set it on the expense too."
 msgstr ""
+"Você pode configurar um apelido de e-mail genérico para criar despesas "
+"facilmente. Escreva um e-mail com o recibo anexado para criar uma linha de "
+"despesa com um clique. Se o título do e-mail contiver a referência interna "
+"do produto entre colchetes, o produto será atribuído automaticamente. Digite"
+" o valor da despesa no título do e-mail para informá-lo também."
 
 #. module: hr_expense
 #: code:addons/hr_expense/models/hr_expense.py:575
 #, python-format
 msgid "You cannot add expenses of another employee."
-msgstr ""
+msgstr "Você não pode adicionar despesas de outro funcionário."
 
 #. module: hr_expense
 #: code:addons/hr_expense/models/hr_expense.py:672
 #, python-format
 msgid "You cannot approve your own expenses"
-msgstr ""
+msgstr "Você não pode aprovar suas próprias despesas"
 
 #. module: hr_expense
 #: code:addons/hr_expense/models/hr_expense.py:145
 #, python-format
 msgid "You cannot delete a posted or approved expense."
-msgstr ""
+msgstr "Você não pode remover uma despesa lançada ou aprovada."
 
 #. module: hr_expense
 #: code:addons/hr_expense/models/hr_expense.py:587
 #, python-format
 msgid "You cannot delete a posted or paid expense."
-msgstr ""
+msgstr "Você não pode remover uma despesa lançada ou paga."
 
 #. module: hr_expense
 #: code:addons/hr_expense/models/hr_expense.py:693
 #, python-format
 msgid "You cannot refuse your own expenses"
-msgstr ""
+msgstr "Você não pode recusar suas próprias despesas"
 
 #. module: hr_expense
 #: code:addons/hr_expense/models/hr_expense.py:182
 #, python-format
 msgid "You cannot report expenses for different employees in the same report."
 msgstr ""
+"Você não pode reportar despesas para diferentes funcionários no mesmo "
+"relatório."
 
 #. module: hr_expense
 #: code:addons/hr_expense/models/hr_expense.py:180
 #, python-format
 msgid "You cannot report twice the same line!"
-msgstr ""
+msgstr "Você não pode reportar a mesma linha duas vezes."
 
 #. module: hr_expense
 #: model_terms:ir.ui.view,arch_db:hr_expense.hr_expense_template_refuse_reason
 msgid "Your Expense"
-msgstr ""
+msgstr "Sua Despesa"
 
 #. module: hr_expense
 #: model_terms:ir.ui.view,arch_db:hr_expense.product_product_expense_form_view
 msgid "e.g. Lunch"
-msgstr ""
+msgstr "p. ex., Almoço"
 
 #. module: hr_expense
 #: model_terms:ir.ui.view,arch_db:hr_expense.hr_expense_view_form
 msgid "e.g. Lunch with Customer"
-msgstr ""
+msgstr "p. ex., Almoço com Cliente"
 
 #. module: hr_expense
 #: model_terms:ir.ui.view,arch_db:hr_expense.view_hr_expense_sheet_form
 msgid "e.g. Trip to NY"
-msgstr ""
+msgstr "p. ex., Viagem a NY"
 
 #. module: hr_expense
 #: model_terms:ir.ui.view,arch_db:hr_expense.hr_expense_template_refuse_reason
 msgid "has been refused"
-msgstr ""
+msgstr "foi recusada"
 
 #. module: hr_expense
 #: model:product.product,weight_uom_name:hr_expense.air_ticket
@@ -1631,4 +1663,4 @@ msgstr "km"
 #: code:addons/hr_expense/models/hr_expense.py:159
 #, python-format
 msgid "or send receipts by email to %s."
-msgstr ""
+msgstr "ou envie recibos por e-mail para %s."

--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -338,6 +338,8 @@ class HrExpense(models.Model):
                     'expense_id': expense.id,
                     'partner_id': partner_id,
                     'currency_id': expense.currency_id.id if different_currency else False,
+                    'analytic_account_id': expense.analytic_account_id.id if tax['analytic'] else False,
+                    'analytic_tag_ids': [(6, 0, expense.analytic_tag_ids.ids)] if tax['analytic'] else False,
                 }
                 total_amount -= amount
                 total_amount_currency -= move_line_tax_values['amount_currency'] or amount

--- a/addons/hr_expense_check/i18n/pt_BR.po
+++ b/addons/hr_expense_check/i18n/pt_BR.po
@@ -5,13 +5,15 @@
 # Translators:
 # Mateus Lopes <mateus1@gmail.com>, 2018
 # grazziano <gra.negocia@gmail.com>, 2018
+# Eduardo Aparicio <eduardo.caparica@gmail.com>, 2020
+# 
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server saas~11.5\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2018-09-21 13:17+0000\n"
-"PO-Revision-Date: 2018-09-21 13:17+0000\n"
-"Last-Translator: grazziano <gra.negocia@gmail.com>, 2018\n"
+"PO-Revision-Date: 2018-08-24 09:18+0000\n"
+"Last-Translator: Eduardo Aparicio <eduardo.caparica@gmail.com>, 2020\n"
 "Language-Team: Portuguese (Brazil) (https://www.transifex.com/odoo/teams/41243/pt_BR/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -37,7 +39,7 @@ msgstr "Marque esta opção se seus cheques pré-impressos não são numerados."
 #. module: hr_expense_check
 #: model:ir.model,name:hr_expense_check.model_hr_expense_sheet_register_payment_wizard
 msgid "Expense Register Payment Wizard"
-msgstr ""
+msgstr "Assistente de Registro de Pagamento de Despesas"
 
 #. module: hr_expense_check
 #: model:ir.model.fields,field_description:hr_expense_check.field_hr_expense_sheet_register_payment_wizard__check_manual_sequencing
@@ -58,7 +60,7 @@ msgstr ""
 #. module: hr_expense_check
 #: model:ir.model.fields,field_description:hr_expense_check.field_hr_expense_sheet_register_payment_wizard__payment_method_code_2
 msgid "Payment Method Code 2"
-msgstr ""
+msgstr "Código 2 do Método de Pagamento"
 
 #. module: hr_expense_check
 #: model:ir.model.fields,help:hr_expense_check.field_hr_expense_sheet_register_payment_wizard__payment_method_code_2

--- a/addons/hr_gamification/i18n/fr.po
+++ b/addons/hr_gamification/i18n/fr.po
@@ -7,6 +7,7 @@
 # Eloïse Stilmant <est@odoo.com>, 2018
 # Nathan Grognet <ngr@odoo.com>, 2018
 # Jonathan Quique <jqu@odoo.com>, 2020
+# Priscilla Sanchez <prs@odoo.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -14,7 +15,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2018-09-21 13:17+0000\n"
 "PO-Revision-Date: 2018-08-24 09:19+0000\n"
-"Last-Translator: Jonathan Quique <jqu@odoo.com>, 2020\n"
+"Last-Translator: Priscilla Sanchez <prs@odoo.com>, 2020\n"
 "Language-Team: French (https://www.transifex.com/odoo/teams/41243/fr/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -129,12 +130,12 @@ msgstr "Badge de ludification"
 #. module: hr_gamification
 #: model:ir.model,name:hr_gamification.model_gamification_badge_user
 msgid "Gamification User Badge"
-msgstr ""
+msgstr "Badge d'utilisateur de gamification"
 
 #. module: hr_gamification
 #: model:ir.model,name:hr_gamification.model_gamification_badge_user_wizard
 msgid "Gamification User Badge Wizard"
-msgstr ""
+msgstr "Assistant de badge utilisateur de gamification"
 
 #. module: hr_gamification
 #: model:ir.model.fields,field_description:hr_gamification.field_res_users__goal_ids

--- a/addons/hr_gamification/i18n/he.po
+++ b/addons/hr_gamification/i18n/he.po
@@ -114,7 +114,7 @@ msgstr ""
 #. module: hr_gamification
 #: model:ir.model,name:hr_gamification.model_gamification_badge
 msgid "Gamification Badge"
-msgstr ""
+msgstr "תג משחק"
 
 #. module: hr_gamification
 #: model:ir.model,name:hr_gamification.model_gamification_badge_user

--- a/addons/hr_holidays/i18n/et.po
+++ b/addons/hr_holidays/i18n/et.po
@@ -6,10 +6,10 @@
 # Wanradt Koell <wanradt@gmail.com>, 2018
 # Egon Raamat <egon@avalah.ee>, 2018
 # Martin Aavastik <martin@avalah.ee>, 2018
+# Helen Sulaoja <helen@avalah.ee>, 2018
 # Rivo Zängov <eraser@eraser.ee>, 2018
 # Martin Trigaux, 2018
 # Arma Gedonsky <armagedonsky@hot.ee>, 2018
-# Helen Sulaoja <helen@avalah.ee>, 2019
 # Eneli Õigus <enelioigus@gmail.com>, 2019
 # Algo Kärp <algokarp@gmail.com>, 2020
 # 
@@ -46,7 +46,7 @@ msgstr ""
 #: code:addons/hr_holidays/models/hr_leave_type.py:265
 #, python-format
 msgid " hours"
-msgstr ""
+msgstr "tunnid"
 
 #. module: hr_holidays
 #: model_terms:ir.ui.view,arch_db:hr_holidays.report_holidayssummary
@@ -397,7 +397,7 @@ msgstr ""
 #. module: hr_holidays
 #: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_view_form
 msgid "<span class=\"ml8\">Hours</span>"
-msgstr ""
+msgstr "<span class=\"ml8\">tundi</span>"
 
 #. module: hr_holidays
 #: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_allocation_view_form_manager
@@ -492,7 +492,7 @@ msgstr ""
 #. module: hr_holidays
 #: model_terms:ir.ui.view,arch_db:hr_holidays.view_hr_leave_allocation_filter
 msgid "Accrual Allocations"
-msgstr ""
+msgstr "Tekkepõhised taotlused"
 
 #. module: hr_holidays
 #: model:ir.actions.server,name:hr_holidays.hr_leave_allocation_cron_accrual_ir_actions_server
@@ -515,7 +515,7 @@ msgstr "Aktiivne"
 #. module: hr_holidays
 #: model_terms:ir.ui.view,arch_db:hr_holidays.view_hr_leave_allocation_filter
 msgid "Active Allocations"
-msgstr ""
+msgstr "Aktiivsed taotlused"
 
 #. module: hr_holidays
 #: model_terms:ir.ui.view,arch_db:hr_holidays.view_hr_holidays_filter
@@ -563,17 +563,17 @@ msgstr ""
 #. module: hr_holidays
 #: selection:hr.leave,request_date_from_period:0
 msgid "Afternoon"
-msgstr ""
+msgstr "Pärastlõuna"
 
 #. module: hr_holidays
 #: model:ir.ui.menu,name:hr_holidays.hr_holidays_menu_manager_all
 msgid "All"
-msgstr "All"
+msgstr "Kõik"
 
 #. module: hr_holidays
 #: model:ir.actions.act_window,name:hr_holidays.hr_leave_allocation_action_all
 msgid "All Allocations"
-msgstr ""
+msgstr "Kõik taotlused"
 
 #. module: hr_holidays
 #: model:ir.actions.act_window,name:hr_holidays.action_hr_holidays_dashboard
@@ -598,7 +598,7 @@ msgstr ""
 #. module: hr_holidays
 #: model:mail.message.subtype,name:hr_holidays.mt_department_leave_allocation_approved
 msgid "Allocation Approved"
-msgstr ""
+msgstr "Taotlused heaks kiidetud"
 
 #. module: hr_holidays
 #: model:ir.model.fields,field_description:hr_holidays.field_hr_leave__holiday_type
@@ -616,24 +616,24 @@ msgstr ""
 #: selection:hr.leave.report,type:0
 #: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_allocation_view_form
 msgid "Allocation Request"
-msgstr "Puhkuse eraldamise taotlused"
+msgstr "Puhkuse eraldamine"
 
 #. module: hr_holidays
 #: model_terms:ir.ui.view,arch_db:hr_holidays.hr_department_view_kanban
 #: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_allocation_view_tree
 msgid "Allocation Requests"
-msgstr "Jaotamise taotlus"
+msgstr "Puhkuse eraldamine"
 
 #. module: hr_holidays
 #: model:mail.activity.type,name:hr_holidays.mail_act_leave_allocation_second_approval
 msgid "Allocation Second Approve"
-msgstr ""
+msgstr "Taotluse teistkordne kinnitamine"
 
 #. module: hr_holidays
 #: code:addons/hr_holidays/models/hr_leave_allocation.py:302
 #, python-format
 msgid "Allocation of %s : %.2f %s to %s"
-msgstr ""
+msgstr "%s - puhkusepäevade eraldamine: %.2f %s %s"
 
 #. module: hr_holidays
 #: model:ir.model.fields,field_description:hr_holidays.field_hr_department__allocation_to_approve_count
@@ -649,7 +649,7 @@ msgstr "Puhkuste jaotamine"
 #. module: hr_holidays
 #: model:ir.ui.menu,name:hr_holidays.menu_open_allocation
 msgid "Allocations Requests"
-msgstr ""
+msgstr "Jaotuse taotlused"
 
 #. module: hr_holidays
 #: model:ir.model.fields,help:hr_holidays.field_hr_leave_allocation__holiday_type
@@ -703,7 +703,7 @@ msgstr "Kinnitatud"
 #. module: hr_holidays
 #: model_terms:ir.ui.view,arch_db:hr_holidays.view_hr_leave_allocation_filter
 msgid "Approved Allocations"
-msgstr ""
+msgstr "Heakskiidetud taotlused"
 
 #. module: hr_holidays
 #: model_terms:ir.ui.view,arch_db:hr_holidays.view_hr_holidays_filter
@@ -713,7 +713,7 @@ msgstr "Kinnitatud puudumised"
 #. module: hr_holidays
 #: model_terms:ir.ui.view,arch_db:hr_holidays.view_hr_holidays_filter_report
 msgid "Approved Requests"
-msgstr ""
+msgstr "Kinnitatud taotlused"
 
 #. module: hr_holidays
 #: model:ir.model.fields,field_description:hr_holidays.field_hr_leave__message_attachment_count
@@ -791,7 +791,7 @@ msgstr "Kalender"
 #: model:ir.model.fields,field_description:hr_holidays.field_hr_leave__can_approve
 #: model:ir.model.fields,field_description:hr_holidays.field_hr_leave_allocation__can_approve
 msgid "Can Approve"
-msgstr "Can Approve"
+msgstr "Võib kinnitada"
 
 #. module: hr_holidays
 #: model:ir.model.fields,field_description:hr_holidays.field_hr_leave__can_reset
@@ -876,7 +876,7 @@ msgstr ""
 #: model_terms:ir.actions.act_window,help:hr_holidays.hr_leave_allocation_action_all
 #: model_terms:ir.actions.act_window,help:hr_holidays.hr_leave_allocation_action_my
 msgid "Create a new leave allocation request"
-msgstr ""
+msgstr "Loo uus puhkuse eraldamise taotlus"
 
 #. module: hr_holidays
 #: model_terms:ir.actions.act_window,help:hr_holidays.hr_leave_action_action_approve_department
@@ -886,7 +886,7 @@ msgstr ""
 #: model_terms:ir.actions.act_window,help:hr_holidays.hr_leave_action_payroll
 #: model_terms:ir.actions.act_window,help:hr_holidays.open_company_allocation
 msgid "Create a new leave request"
-msgstr ""
+msgstr "Loo uus puhkusetaotlus"
 
 #. module: hr_holidays
 #: model:ir.model.fields,field_description:hr_holidays.field_hr_holidays_summary_dept__create_uid
@@ -926,12 +926,12 @@ msgstr "Käesolev aasta"
 #. module: hr_holidays
 #: model:ir.model.fields,field_description:hr_holidays.field_hr_leave__request_unit_hours
 msgid "Custom Hours"
-msgstr ""
+msgstr "Kohandatud tunnid"
 
 #. module: hr_holidays
 #: model:ir.model.fields,field_description:hr_holidays.field_hr_leave__request_date_from_period
 msgid "Date Period Start"
-msgstr ""
+msgstr "Perioodi alguskuupäev"
 
 #. module: hr_holidays
 #: model:ir.model.fields,field_description:hr_holidays.field_hr_leave_allocation__nextcall
@@ -1027,32 +1027,32 @@ msgstr "Kestvus"
 #. module: hr_holidays
 #: model:ir.model.fields,field_description:hr_holidays.field_hr_leave__number_of_days
 msgid "Duration (Days)"
-msgstr ""
+msgstr "Kestus (päevades)"
 
 #. module: hr_holidays
 #: model:ir.model.fields,field_description:hr_holidays.field_hr_leave_allocation__number_of_days_display
 msgid "Duration (days)"
-msgstr ""
+msgstr "Kestus (päevades)"
 
 #. module: hr_holidays
 #: model:ir.model.fields,field_description:hr_holidays.field_hr_leave_allocation__number_of_hours_display
 msgid "Duration (hours)"
-msgstr ""
+msgstr "Kestus (tundides)"
 
 #. module: hr_holidays
 #: model:ir.model.fields,field_description:hr_holidays.field_hr_leave__number_of_days_display
 msgid "Duration in days"
-msgstr ""
+msgstr "Kestus päevades"
 
 #. module: hr_holidays
 #: model:ir.model.fields,help:hr_holidays.field_hr_leave_allocation__number_of_days
 msgid "Duration in days. Reference field to use when necessary."
-msgstr ""
+msgstr "Kestus tundides. Viiteväli, mida vajadusel kasutada."
 
 #. module: hr_holidays
 #: model:ir.model.fields,field_description:hr_holidays.field_hr_leave__number_of_hours_display
 msgid "Duration in hours"
-msgstr ""
+msgstr "Kestus tundides"
 
 #. module: hr_holidays
 #: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_allocation_view_kanban
@@ -1234,7 +1234,7 @@ msgstr "Personali puudumisi kokkuvõttev aruanne töötajate lõikes"
 #. module: hr_holidays
 #: model:ir.model.fields,field_description:hr_holidays.field_hr_leave__request_unit_half
 msgid "Half Day"
-msgstr ""
+msgstr "Pool päeva"
 
 #. module: hr_holidays
 #: model:ir.model,name:hr_holidays.model_report_hr_holidays_report_holidayssummary
@@ -1244,17 +1244,17 @@ msgstr ""
 #. module: hr_holidays
 #: model:ir.model.fields,field_description:hr_holidays.field_hr_leave__request_hour_from
 msgid "Hour from"
-msgstr ""
+msgstr "Tund alates"
 
 #. module: hr_holidays
 #: model:ir.model.fields,field_description:hr_holidays.field_hr_leave__request_hour_to
 msgid "Hour to"
-msgstr ""
+msgstr "Tund kuni"
 
 #. module: hr_holidays
 #: selection:hr.leave.allocation,unit_per_interval:0
 msgid "Hour(s)"
-msgstr "Hour(s)"
+msgstr "Tund(id)"
 
 #. module: hr_holidays
 #: selection:hr.leave.type,request_unit:0
@@ -1518,7 +1518,7 @@ msgstr ""
 #. module: hr_holidays
 #: model:mail.message.subtype,name:hr_holidays.mt_department_leave_approved
 msgid "Leaves Approved"
-msgstr ""
+msgstr "Puudumine kinnitatud"
 
 #. module: hr_holidays
 #: model_terms:ir.ui.view,arch_db:hr_holidays.view_employee_form_leave_inherit
@@ -1535,12 +1535,12 @@ msgstr ""
 #: model:ir.actions.act_window,name:hr_holidays.hr_leave_action_payroll
 #: model:ir.ui.menu,name:hr_holidays.hr_leave_menu_my
 msgid "Leaves Requests"
-msgstr ""
+msgstr "Puhkuse taotlused"
 
 #. module: hr_holidays
 #: model:mail.activity.type,name:hr_holidays.mail_act_leave_second_approval
 msgid "Leaves Second Approve"
-msgstr ""
+msgstr "Puudumise taotluse teistkordne kinnitamine"
 
 #. module: hr_holidays
 #: model:ir.actions.act_window,name:hr_holidays.action_hr_holidays_summary_employee
@@ -1575,7 +1575,7 @@ msgstr "Sinu tiimi liikme puudumised"
 #. module: hr_holidays
 #: model:ir.ui.menu,name:hr_holidays.hr_holidays_menu_manager_payroll_to_report
 msgid "Leaves to report"
-msgstr ""
+msgstr "Puhkused teatamiseks"
 
 #. module: hr_holidays
 #: model_terms:ir.ui.view,arch_db:hr_holidays.report_holidayssummary
@@ -1717,18 +1717,18 @@ msgstr "Kuu"
 #. module: hr_holidays
 #: selection:hr.leave.allocation,interval_unit:0
 msgid "Month(s)"
-msgstr "Month(s)"
+msgstr "Kuu(d)"
 
 #. module: hr_holidays
 #: selection:hr.leave,request_date_from_period:0
 msgid "Morning"
-msgstr ""
+msgstr "Hommik"
 
 #. module: hr_holidays
 #: model:ir.actions.act_window,name:hr_holidays.hr_leave_allocation_action_my
 #: model_terms:ir.ui.view,arch_db:hr_holidays.view_hr_leave_allocation_filter
 msgid "My Allocations"
-msgstr ""
+msgstr "Minu taotlused"
 
 #. module: hr_holidays
 #: model_terms:ir.ui.view,arch_db:hr_holidays.view_hr_holidays_filter
@@ -1764,7 +1764,7 @@ msgstr "Uus"
 #: model:ir.actions.act_window,name:hr_holidays.hr_leave_action_new_request
 #: model:ir.ui.menu,name:hr_holidays.hr_leave_menu_new_request
 msgid "New Request"
-msgstr "New Request"
+msgstr "Uued taotlused"
 
 #. module: hr_holidays
 #: model:ir.model.fields,field_description:hr_holidays.field_hr_leave__activity_date_deadline
@@ -1818,6 +1818,8 @@ msgstr "Puhkusepäevade arv vastavalt teie töögraafikule."
 #: model:ir.model.fields,help:hr_holidays.field_hr_leave__number_of_days_display
 msgid "Number of days of the leave request. Used for interface."
 msgstr ""
+"\n"
+"Puhkusetaotluse päevade arv. Kasutatakse liidese jaoks."
 
 #. module: hr_holidays
 #: model:ir.model.fields,field_description:hr_holidays.field_hr_leave__message_has_error_counter
@@ -1892,7 +1894,7 @@ msgstr ""
 #: code:addons/hr_holidays/models/hr_leave_allocation.py:495
 #, python-format
 msgid "Only a Leave Manager can approve its own requests."
-msgstr ""
+msgstr "Ainult puhkusehaldur saab oma avaldused heaks kiita."
 
 #. module: hr_holidays
 #: code:addons/hr_holidays/models/hr_leave.py:698
@@ -1966,7 +1968,7 @@ msgstr "Palgaarvestus"
 #: selection:hr.leave,activity_state:0
 #: selection:hr.leave.allocation,activity_state:0
 msgid "Planned"
-msgstr "Planned"
+msgstr "Planeeritud"
 
 #. module: hr_holidays
 #: model_terms:ir.ui.view,arch_db:hr_holidays.view_hr_holidays_summary_dept
@@ -2034,7 +2036,7 @@ msgstr "Allesjäänud puhkusepäevi"
 #. module: hr_holidays
 #: model:ir.ui.menu,name:hr_holidays.menu_hr_holidays_summary_dept
 msgid "Report by Department"
-msgstr ""
+msgstr "Osakonna aruanne"
 
 #. module: hr_holidays
 #: model:ir.model.fields,field_description:hr_holidays.field_hr_leave__payslip_status
@@ -2050,12 +2052,12 @@ msgstr "Aruandlus"
 #. module: hr_holidays
 #: model:ir.model.fields,field_description:hr_holidays.field_hr_leave__request_date_to
 msgid "Request End Date"
-msgstr ""
+msgstr "Taotle lõppkuupäeva"
 
 #. module: hr_holidays
 #: model:ir.model.fields,field_description:hr_holidays.field_hr_leave__request_date_from
 msgid "Request Start Date"
-msgstr ""
+msgstr "Taotle alguskuupäeva"
 
 #. module: hr_holidays
 #: model:ir.model.fields,field_description:hr_holidays.field_hr_leave_report__type
@@ -2120,7 +2122,7 @@ msgstr "Otsi puudumise tüüpi"
 #. module: hr_holidays
 #: model_terms:ir.ui.view,arch_db:hr_holidays.view_hr_leave_allocation_filter
 msgid "Search allocations"
-msgstr ""
+msgstr "Otsi taotlusi"
 
 #. module: hr_holidays
 #: selection:hr.leave,state:0 selection:hr.leave.allocation,state:0
@@ -2423,7 +2425,7 @@ msgstr "Kasutaja"
 #. module: hr_holidays
 #: model:ir.model.fields,field_description:hr_holidays.field_hr_leave_type__valid
 msgid "Valid"
-msgstr ""
+msgstr "Kehtiv"
 
 #. module: hr_holidays
 #: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_allocation_view_form_manager
@@ -2491,7 +2493,7 @@ msgstr "Veebilehe suhtluse ajalugu"
 #. module: hr_holidays
 #: selection:hr.leave.allocation,interval_unit:0
 msgid "Week(s)"
-msgstr "Week(s)"
+msgstr "Nädal(ad)"
 
 #. module: hr_holidays
 #: selection:hr.leave.type,color_name:0
@@ -2528,7 +2530,7 @@ msgstr ""
 #: code:addons/hr_holidays/models/hr_leave.py:397
 #, python-format
 msgid "You can not have 2 leaves that overlaps on the same day."
-msgstr ""
+msgstr "Teil ei saa olla kahte puhkust, mis omavahel kattuvad."
 
 #. module: hr_holidays
 #: code:addons/hr_holidays/models/hr_leave.py:520
@@ -2583,7 +2585,7 @@ msgstr "Päev(ad)"
 #: model_terms:ir.ui.view,arch_db:hr_holidays.view_employee_form_leave_inherit
 #, python-format
 msgid "days"
-msgstr "päeva pärast"
+msgstr "päev(a)"
 
 #. module: hr_holidays
 #: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_view_form_manager
@@ -2594,7 +2596,7 @@ msgstr "nt teatage järgmisel kuul ..."
 #: code:addons/hr_holidays/models/hr_leave.py:398
 #, python-format
 msgid "hour(s)"
-msgstr "tund(i)"
+msgstr "tund(id)"
 
 #. module: hr_holidays
 #: code:addons/hr_holidays/models/hr_leave_allocation.py:222

--- a/addons/hr_holidays/i18n/eu.po
+++ b/addons/hr_holidays/i18n/eu.po
@@ -15,6 +15,7 @@
 # Victor Laskurain <blaskurain@binovo.es>, 2019
 # Maialen Rodriguez <maialenrodriguez98@gmail.com>, 2020
 # Miren Maiz <mirenmaizz@gmail.com>, 2020
+# Unai Muñoz <unaimunoz9@gmail.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -22,7 +23,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-01-09 10:31+0000\n"
 "PO-Revision-Date: 2018-08-24 09:19+0000\n"
-"Last-Translator: Miren Maiz <mirenmaizz@gmail.com>, 2020\n"
+"Last-Translator: Unai Muñoz <unaimunoz9@gmail.com>, 2020\n"
 "Language-Team: Basque (https://www.transifex.com/odoo/teams/41243/eu/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -86,7 +87,7 @@ msgstr ""
 #: code:addons/hr_holidays/models/hr_leave.py:428
 #, python-format
 msgid "%s : %.2f day(s)"
-msgstr ""
+msgstr "%s : %.2f egun(ak)"
 
 #. module: hr_holidays
 #: code:addons/hr_holidays/models/hr_leave.py:466
@@ -550,7 +551,7 @@ msgstr "Jarduera motak"
 #. module: hr_holidays
 #: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_allocation_view_form
 msgid "Add a reason..."
-msgstr ""
+msgstr "Gehitu arrazoia"
 
 #. module: hr_holidays
 #: model:ir.model.fields,help:hr_holidays.field_hr_leave_type__validity_start
@@ -918,7 +919,7 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:hr_holidays.view_hr_holidays_filter_report
 #: model_terms:ir.ui.view,arch_db:hr_holidays.view_hr_leave_allocation_filter
 msgid "Current Year"
-msgstr ""
+msgstr "Urtea:"
 
 #. module: hr_holidays
 #: model:ir.model.fields,field_description:hr_holidays.field_hr_leave__request_unit_hours
@@ -981,7 +982,7 @@ msgstr ""
 #. module: hr_holidays
 #: model:ir.model.fields,field_description:hr_holidays.field_hr_holidays_summary_dept__depts
 msgid "Department(s)"
-msgstr ""
+msgstr "Saila(k)"
 
 #. module: hr_holidays
 #: model:ir.model.fields,field_description:hr_holidays.field_hr_leave__name
@@ -1579,7 +1580,7 @@ msgstr ""
 #. module: hr_holidays
 #: selection:hr.leave.type,color_name:0
 msgid "Light Blue"
-msgstr ""
+msgstr "Urdin argia"
 
 #. module: hr_holidays
 #: selection:hr.leave.type,color_name:0
@@ -1594,12 +1595,12 @@ msgstr ""
 #. module: hr_holidays
 #: selection:hr.leave.type,color_name:0
 msgid "Light Green"
-msgstr ""
+msgstr "Berde argia"
 
 #. module: hr_holidays
 #: selection:hr.leave.type,color_name:0
 msgid "Light Pink"
-msgstr ""
+msgstr "Arrosa argia"
 
 #. module: hr_holidays
 #: selection:hr.leave.type,color_name:0
@@ -1648,7 +1649,7 @@ msgstr ""
 #. module: hr_holidays
 #: model:ir.model.fields,field_description:hr_holidays.field_hr_leave_type__max_leaves
 msgid "Maximum Allowed"
-msgstr ""
+msgstr "Gehienez onartuta"
 
 #. module: hr_holidays
 #: model:ir.model.fields,help:hr_holidays.field_hr_leave_type__remaining_leaves
@@ -1961,7 +1962,7 @@ msgstr "Inprimatu"
 #: model:ir.model.fields,field_description:hr_holidays.field_hr_leave__notes
 #: model:ir.model.fields,field_description:hr_holidays.field_hr_leave_allocation__notes
 msgid "Reasons"
-msgstr ""
+msgstr "Arrazoiak"
 
 #. module: hr_holidays
 #: selection:hr.leave.type,color_name:0
@@ -2166,7 +2167,7 @@ msgstr ""
 #. module: hr_holidays
 #: model_terms:ir.ui.view,arch_db:hr_holidays.report_holidayssummary
 msgid "Sum"
-msgstr ""
+msgstr "Batura"
 
 #. module: hr_holidays
 #: model:ir.ui.menu,name:hr_holidays.menu_open_company_allocation
@@ -2195,7 +2196,7 @@ msgstr ""
 #. module: hr_holidays
 #: sql_constraint:hr.leave.allocation:0
 msgid "The number of days must be greater than 0."
-msgstr ""
+msgstr "Egun kopurua 0 baino handiagoa izan behar du"
 
 #. module: hr_holidays
 #: code:addons/hr_holidays/models/hr_leave.py:407
@@ -2213,7 +2214,7 @@ msgstr ""
 #. module: hr_holidays
 #: sql_constraint:hr.leave:0
 msgid "The start date must be anterior to the end date."
-msgstr ""
+msgstr "Hasierako data amaiera data baino lehenagokoa izan behar da."
 
 #. module: hr_holidays
 #: model:ir.model.fields,help:hr_holidays.field_hr_leave__state
@@ -2366,7 +2367,7 @@ msgstr ""
 #. module: hr_holidays
 #: model:hr.leave.type,name:hr_holidays.holiday_status_unpaid
 msgid "Unpaid"
-msgstr ""
+msgstr "Ordaindu gabea"
 
 #. module: hr_holidays
 #: model:ir.model.fields,field_description:hr_holidays.field_hr_leave__message_unread

--- a/addons/hr_holidays/i18n/eu.po
+++ b/addons/hr_holidays/i18n/eu.po
@@ -14,6 +14,7 @@
 # Naomi Hidalgo <naomihid96@gmail.com>, 2019
 # Victor Laskurain <blaskurain@binovo.es>, 2019
 # Maialen Rodriguez <maialenrodriguez98@gmail.com>, 2020
+# Miren Maiz <mirenmaizz@gmail.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -21,7 +22,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-01-09 10:31+0000\n"
 "PO-Revision-Date: 2018-08-24 09:19+0000\n"
-"Last-Translator: Maialen Rodriguez <maialenrodriguez98@gmail.com>, 2020\n"
+"Last-Translator: Miren Maiz <mirenmaizz@gmail.com>, 2020\n"
 "Language-Team: Basque (https://www.transifex.com/odoo/teams/41243/eu/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -2076,7 +2077,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:hr_holidays.field_hr_leave__activity_user_id
 #: model:ir.model.fields,field_description:hr_holidays.field_hr_leave_allocation__activity_user_id
 msgid "Responsible User"
-msgstr ""
+msgstr "Erabiltzaile arduraduna"
 
 #. module: hr_holidays
 #: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_allocation_view_form_manager

--- a/addons/hr_holidays/i18n/fr.po
+++ b/addons/hr_holidays/i18n/fr.po
@@ -10,6 +10,7 @@
 # Jérôme Tanché <jerome.tanche@ouest-dsi.fr>, 2018
 # Martin Trigaux, 2019
 # Cécile Collart <cco@odoo.com>, 2020
+# Jonathan Quique <jqu@odoo.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -17,7 +18,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-01-09 10:31+0000\n"
 "PO-Revision-Date: 2018-08-24 09:19+0000\n"
-"Last-Translator: Cécile Collart <cco@odoo.com>, 2020\n"
+"Last-Translator: Jonathan Quique <jqu@odoo.com>, 2020\n"
 "Language-Team: French (https://www.transifex.com/odoo/teams/41243/fr/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -739,7 +740,7 @@ msgstr "Nombre de pièces jointes"
 #. module: hr_holidays
 #: model:ir.model.fields,field_description:hr_holidays.field_hr_leave_allocation__accrual_limit
 msgid "Balance limit"
-msgstr ""
+msgstr "Limite du solde"
 
 #. module: hr_holidays
 #: selection:hr.leave.type,color_name:0
@@ -971,7 +972,7 @@ msgstr "Jours Alloués"
 #. module: hr_holidays
 #: model:ir.model.fields,field_description:hr_holidays.field_hr_leave__request_unit_custom
 msgid "Days-long custom hours"
-msgstr ""
+msgstr "Personnaliser l'horaire de la journée entière"
 
 #. module: hr_holidays
 #: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_allocation_view_kanban
@@ -1267,7 +1268,7 @@ msgstr "Demi-journée"
 #. module: hr_holidays
 #: model:ir.model,name:hr_holidays.model_report_hr_holidays_report_holidayssummary
 msgid "Holidays Summary Report"
-msgstr ""
+msgstr "Rapport Résumé des Vacances"
 
 #. module: hr_holidays
 #: model:ir.model.fields,field_description:hr_holidays.field_hr_leave__request_hour_from

--- a/addons/hr_holidays/i18n/it.po
+++ b/addons/hr_holidays/i18n/it.po
@@ -2479,7 +2479,7 @@ msgstr "Messaggi non letti"
 #: model:ir.model.fields,field_description:hr_holidays.field_hr_leave__message_unread_counter
 #: model:ir.model.fields,field_description:hr_holidays.field_hr_leave_allocation__message_unread_counter
 msgid "Unread Messages Counter"
-msgstr "Contatore messaggi non letti"
+msgstr "Numero messaggi non letti"
 
 #. module: hr_holidays
 #: model:ir.model.fields,field_description:hr_holidays.field_hr_leave__user_id

--- a/addons/hr_holidays/i18n/ja.po
+++ b/addons/hr_holidays/i18n/ja.po
@@ -11,8 +11,8 @@
 # Martin Trigaux, 2019
 # Norimichi Sugimoto <norimichi.sugimoto@tls-ltd.co.jp>, 2019
 # Tim Siu Lai <tl@roomsfor.hk>, 2019
-# Yoshi Tashiro <tashiro@roomsfor.hk>, 2020
 # Hau Dao <hau@quartile.co>, 2020
+# Yoshi Tashiro <tashiro@roomsfor.hk>, 2020
 # 
 msgid ""
 msgstr ""
@@ -20,7 +20,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-01-09 10:31+0000\n"
 "PO-Revision-Date: 2018-08-24 09:19+0000\n"
-"Last-Translator: Hau Dao <hau@quartile.co>, 2020\n"
+"Last-Translator: Yoshi Tashiro <tashiro@roomsfor.hk>, 2020\n"
 "Language-Team: Japanese (https://www.transifex.com/odoo/teams/41243/ja/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -565,7 +565,7 @@ msgstr ""
 #. module: hr_holidays
 #: selection:hr.leave,request_date_from_period:0
 msgid "Afternoon"
-msgstr ""
+msgstr "午後"
 
 #. module: hr_holidays
 #: model:ir.ui.menu,name:hr_holidays.hr_holidays_menu_manager_all
@@ -1182,7 +1182,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:hr_holidays.field_hr_holidays_summary_employee__date_from
 #: model_terms:ir.ui.view,arch_db:hr_holidays.hr_leave_view_form
 msgid "From"
-msgstr "差出人"
+msgstr "由"
 
 #. module: hr_holidays
 #: model:ir.model.fields,field_description:hr_holidays.field_hr_employee__leave_date_from
@@ -1714,7 +1714,7 @@ msgstr "月"
 #. module: hr_holidays
 #: selection:hr.leave,request_date_from_period:0
 msgid "Morning"
-msgstr ""
+msgstr "午前"
 
 #. module: hr_holidays
 #: model:ir.actions.act_window,name:hr_holidays.hr_leave_allocation_action_my

--- a/addons/hr_maintenance/i18n/et.po
+++ b/addons/hr_maintenance/i18n/et.po
@@ -7,6 +7,7 @@
 # Eneli Õigus <enelioigus@gmail.com>, 2018
 # Martin Aavastik <martin@avalah.ee>, 2018
 # Helen Sulaoja <helen@avalah.ee>, 2018
+# Algo Kärp <algokarp@gmail.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -14,7 +15,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2018-09-21 13:18+0000\n"
 "PO-Revision-Date: 2018-08-24 09:19+0000\n"
-"Last-Translator: Helen Sulaoja <helen@avalah.ee>, 2018\n"
+"Last-Translator: Algo Kärp <algokarp@gmail.com>, 2020\n"
 "Language-Team: Estonian (https://www.transifex.com/odoo/teams/41243/et/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -41,7 +42,7 @@ msgstr "Loonud"
 #. module: hr_maintenance
 #: model:ir.model.fields,field_description:hr_maintenance.field_maintenance_request__owner_user_id
 msgid "Created by User"
-msgstr ""
+msgstr "Loodud kasutaja poolt"
 
 #. module: hr_maintenance
 #: model:ir.model.fields,field_description:hr_maintenance.field_maintenance_request__department_id

--- a/addons/hr_maintenance/i18n/it.po
+++ b/addons/hr_maintenance/i18n/it.po
@@ -5,7 +5,7 @@
 # Translators:
 # Luigi Di Naro <gigidn@gmail.com>, 2018
 # Paolo Valier, 2018
-# Sergio Zanchetta <primes2h@gmail.com>, 2019
+# Sergio Zanchetta <primes2h@gmail.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -13,7 +13,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2018-09-21 13:18+0000\n"
 "PO-Revision-Date: 2018-08-24 09:19+0000\n"
-"Last-Translator: Sergio Zanchetta <primes2h@gmail.com>, 2019\n"
+"Last-Translator: Sergio Zanchetta <primes2h@gmail.com>, 2020\n"
 "Language-Team: Italian (https://www.transifex.com/odoo/teams/41243/it/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -49,7 +49,7 @@ msgstr "Creato dall'utente"
 #: model_terms:ir.ui.view,arch_db:hr_maintenance.maintenance_equipment_view_tree_inherit_hr
 #: selection:maintenance.equipment,equipment_assign_to:0
 msgid "Department"
-msgstr "Dipartimento"
+msgstr "Ufficio"
 
 #. module: hr_maintenance
 #: model:ir.model.fields,field_description:hr_maintenance.field_maintenance_request__employee_id

--- a/addons/hr_payroll/i18n/et.po
+++ b/addons/hr_payroll/i18n/et.po
@@ -11,6 +11,7 @@
 # Martin Aavastik <martin@avalah.ee>, 2018
 # Eneli Õigus <enelioigus@gmail.com>, 2019
 # Arma Gedonsky <armagedonsky@hot.ee>, 2019
+# Algo Kärp <algokarp@gmail.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -18,7 +19,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-11-14 07:33+0000\n"
 "PO-Revision-Date: 2018-08-24 09:19+0000\n"
-"Last-Translator: Arma Gedonsky <armagedonsky@hot.ee>, 2019\n"
+"Last-Translator: Algo Kärp <algokarp@gmail.com>, 2020\n"
 "Language-Team: Estonian (https://www.transifex.com/odoo/teams/41243/et/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -174,7 +175,7 @@ msgstr "Aktiivne"
 #. module: hr_payroll
 #: model_terms:ir.actions.act_window,help:hr_payroll.action_contribution_register_form
 msgid "Add a new contribution register"
-msgstr ""
+msgstr "Lisage uus kaastööde register"
 
 #. module: hr_payroll
 #: model_terms:ir.ui.view,arch_db:hr_payroll.view_hr_payslip_form
@@ -653,7 +654,7 @@ msgstr "Töötaja tööplaan."
 #: model_terms:ir.ui.view,arch_db:hr_payroll.view_hr_payslip_filter
 #: model_terms:ir.ui.view,arch_db:hr_payroll.view_hr_payslip_line_filter
 msgid "Employees"
-msgstr " töötajad"
+msgstr "Töötajad"
 
 #. module: hr_payroll
 #: code:addons/hr_payroll/models/hr_salary_rule.py:92
@@ -1122,7 +1123,7 @@ msgstr ""
 #. module: hr_payroll
 #: model:ir.model,name:hr_payroll.model_report_hr_payroll_report_payslipdetails
 msgid "Payslip Details Report"
-msgstr ""
+msgstr "Palgalehe üksikasjade aruanne"
 
 #. module: hr_payroll
 #: model:ir.model,name:hr_payroll.model_hr_payslip_input
@@ -1338,7 +1339,7 @@ msgstr "Palgaarvestus"
 #. module: hr_payroll
 #: model:ir.model,name:hr_payroll.model_hr_salary_rule
 msgid "Salary Rule"
-msgstr ""
+msgstr "Palgareegel"
 
 #. module: hr_payroll
 #: model:ir.actions.act_window,name:hr_payroll.action_hr_salary_rule_category

--- a/addons/hr_payroll/i18n/eu.po
+++ b/addons/hr_payroll/i18n/eu.po
@@ -13,6 +13,7 @@
 # Victor Laskurain <blaskurain@binovo.es>, 2019
 # oihane <oihanecruce@gmail.com>, 2019
 # Maialen Rodriguez <maialenrodriguez98@gmail.com>, 2020
+# Miren Maiz <mirenmaizz@gmail.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -20,7 +21,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-11-14 07:33+0000\n"
 "PO-Revision-Date: 2018-08-24 09:19+0000\n"
-"Last-Translator: Maialen Rodriguez <maialenrodriguez98@gmail.com>, 2020\n"
+"Last-Translator: Miren Maiz <mirenmaizz@gmail.com>, 2020\n"
 "Language-Team: Basque (https://www.transifex.com/odoo/teams/41243/eu/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1283,7 +1284,7 @@ msgstr "Erreferentzia"
 #. module: hr_payroll
 #: model_terms:ir.ui.view,arch_db:hr_payroll.view_hr_payslip_form
 msgid "Refund"
-msgstr ""
+msgstr "diru-itzultze"
 
 #. module: hr_payroll
 #: code:addons/hr_payroll/models/hr_payslip.py:102

--- a/addons/hr_payroll/i18n/eu.po
+++ b/addons/hr_payroll/i18n/eu.po
@@ -14,6 +14,7 @@
 # oihane <oihanecruce@gmail.com>, 2019
 # Maialen Rodriguez <maialenrodriguez98@gmail.com>, 2020
 # Miren Maiz <mirenmaizz@gmail.com>, 2020
+# Unai Muñoz <unaimunoz9@gmail.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -21,7 +22,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-11-14 07:33+0000\n"
 "PO-Revision-Date: 2018-08-24 09:19+0000\n"
-"Last-Translator: Miren Maiz <mirenmaizz@gmail.com>, 2020\n"
+"Last-Translator: Unai Muñoz <unaimunoz9@gmail.com>, 2020\n"
 "Language-Team: Basque (https://www.transifex.com/odoo/teams/41243/eu/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -64,19 +65,19 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:hr_payroll.report_payslip
 #: model_terms:ir.ui.view,arch_db:hr_payroll.report_payslipdetails
 msgid "<strong>Address</strong>"
-msgstr ""
+msgstr "Helbidea"
 
 #. module: hr_payroll
 #: model_terms:ir.ui.view,arch_db:hr_payroll.report_payslip
 #: model_terms:ir.ui.view,arch_db:hr_payroll.report_payslipdetails
 msgid "<strong>Authorized signature</strong>"
-msgstr ""
+msgstr "<strong>Baimendutako sinadura</strong>"
 
 #. module: hr_payroll
 #: model_terms:ir.ui.view,arch_db:hr_payroll.report_payslip
 #: model_terms:ir.ui.view,arch_db:hr_payroll.report_payslipdetails
 msgid "<strong>Bank Account</strong>"
-msgstr ""
+msgstr "<strong>Banku Kontua</strong>"
 
 #. module: hr_payroll
 #: model_terms:ir.ui.view,arch_db:hr_payroll.report_contributionregister
@@ -183,7 +184,7 @@ msgstr "Erantsi barne oharra"
 #. module: hr_payroll
 #: model_terms:ir.ui.view,arch_db:hr_payroll.hr_contract_advantage_template_view_form
 msgid "Advantage Name"
-msgstr ""
+msgstr "Abantailaren izena"
 
 #. module: hr_payroll
 #: model:ir.actions.act_window,name:hr_payroll.act_children_salary_rules
@@ -199,7 +200,7 @@ msgstr ""
 #: selection:hr.payslip.line,condition_select:0
 #: selection:hr.salary.rule,condition_select:0
 msgid "Always True"
-msgstr ""
+msgstr "Egia da beti"
 
 #. module: hr_payroll
 #: model:ir.model.fields,field_description:hr_payroll.field_hr_payslip_input__amount
@@ -220,7 +221,7 @@ msgstr "Kopuru mota"
 #. module: hr_payroll
 #: selection:hr.contract,schedule_pay:0
 msgid "Annually"
-msgstr ""
+msgstr "Urtero"
 
 #. module: hr_payroll
 #: model:ir.model.fields,field_description:hr_payroll.field_hr_payslip_line__appears_on_payslip
@@ -340,7 +341,7 @@ msgstr "Kodea"
 #: model_terms:ir.ui.view,arch_db:hr_payroll.hr_payroll_structure_view_kanban
 #: model_terms:ir.ui.view,arch_db:hr_payroll.hr_salary_rule_view_kanban
 msgid "Code:"
-msgstr ""
+msgstr "Kodea:"
 
 #. module: hr_payroll
 #: model_terms:ir.ui.view,arch_db:hr_payroll.view_hr_payslip_filter
@@ -366,7 +367,7 @@ msgstr ""
 #. module: hr_payroll
 #: model_terms:ir.ui.view,arch_db:hr_payroll.hr_salary_rule_form
 msgid "Computation"
-msgstr ""
+msgstr "Konputazioa"
 
 #. module: hr_payroll
 #: model_terms:ir.ui.view,arch_db:hr_payroll.view_hr_payslip_form
@@ -789,7 +790,7 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:hr_payroll.hr_salary_rule_form
 #: model_terms:ir.ui.view,arch_db:hr_payroll.view_hr_payslip_form
 msgid "Input Data"
-msgstr ""
+msgstr "Sarrera datuak"
 
 #. module: hr_payroll
 #: model:ir.model.fields,field_description:hr_payroll.field_hr_payslip_line__input_ids
@@ -908,7 +909,7 @@ msgstr "Kudeatzailea"
 #: model:ir.model.fields,field_description:hr_payroll.field_hr_payslip_line__condition_range_max
 #: model:ir.model.fields,field_description:hr_payroll.field_hr_salary_rule__condition_range_max
 msgid "Maximum Range"
-msgstr ""
+msgstr "Gehieneko tartea"
 
 #. module: hr_payroll
 #: model:hr.salary.rule,name:hr_payroll.hr_salary_rule_meal_voucher
@@ -1182,7 +1183,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:hr_payroll.field_hr_payslip_line__amount_percentage
 #: model:ir.model.fields,field_description:hr_payroll.field_hr_salary_rule__amount_percentage
 msgid "Percentage (%)"
-msgstr ""
+msgstr "Ehuneko (%)"
 
 #. module: hr_payroll
 #: model:ir.model.fields,field_description:hr_payroll.field_hr_payslip_line__amount_percentage_base
@@ -1228,13 +1229,13 @@ msgstr "Python Kodea"
 #: model:ir.model.fields,field_description:hr_payroll.field_hr_payslip_line__condition_python
 #: model:ir.model.fields,field_description:hr_payroll.field_hr_salary_rule__condition_python
 msgid "Python Condition"
-msgstr ""
+msgstr "Python baldintza"
 
 #. module: hr_payroll
 #: selection:hr.payslip.line,condition_select:0
 #: selection:hr.salary.rule,condition_select:0
 msgid "Python Expression"
-msgstr ""
+msgstr "Python adierazpena"
 
 #. module: hr_payroll
 #: model:ir.model.fields,field_description:hr_payroll.field_hr_payslip_line__quantity
@@ -1441,7 +1442,7 @@ msgstr "Egoera"
 #. module: hr_payroll
 #: model:ir.model.fields,field_description:hr_payroll.field_hr_payslip__struct_id
 msgid "Structure"
-msgstr ""
+msgstr "Egitura"
 
 #. module: hr_payroll
 #: model:ir.model.fields,help:hr_payroll.field_hr_payslip_line__code
@@ -1456,7 +1457,7 @@ msgstr ""
 #: model:ir.model.fields,help:hr_payroll.field_hr_payslip_worked_days__code
 #: model:ir.model.fields,help:hr_payroll.field_hr_rule_input__code
 msgid "The code that can be used in the salary rules"
-msgstr ""
+msgstr "Soldata-arauetan erabil daitekeen kodea"
 
 #. module: hr_payroll
 #: model:ir.model.fields,help:hr_payroll.field_hr_payslip_line__amount_select
@@ -1474,13 +1475,13 @@ msgstr ""
 #: model:ir.model.fields,help:hr_payroll.field_hr_payslip_line__condition_range_max
 #: model:ir.model.fields,help:hr_payroll.field_hr_salary_rule__condition_range_max
 msgid "The maximum amount, applied for this rule."
-msgstr ""
+msgstr "Arau hau aplikatzeko gehieneko zenbatekoa."
 
 #. module: hr_payroll
 #: model:ir.model.fields,help:hr_payroll.field_hr_payslip_line__condition_range_min
 #: model:ir.model.fields,help:hr_payroll.field_hr_salary_rule__condition_range_min
 msgid "The minimum amount, applied for this rule."
-msgstr ""
+msgstr "Arau hau aplikatzeko gutxieneko zenbatekoa."
 
 #. module: hr_payroll
 #: model:ir.model.fields,help:hr_payroll.field_hr_payslip_line__condition_range

--- a/addons/hr_payroll_account/i18n/et.po
+++ b/addons/hr_payroll_account/i18n/et.po
@@ -6,6 +6,7 @@
 # Martin Trigaux, 2018
 # Arma Gedonsky <armagedonsky@hot.ee>, 2018
 # Eneli Õigus <enelioigus@gmail.com>, 2018
+# Algo Kärp <algokarp@gmail.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -13,7 +14,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2018-09-21 13:17+0000\n"
 "PO-Revision-Date: 2018-08-24 09:19+0000\n"
-"Last-Translator: Eneli Õigus <enelioigus@gmail.com>, 2018\n"
+"Last-Translator: Algo Kärp <algokarp@gmail.com>, 2020\n"
 "Language-Team: Estonian (https://www.transifex.com/odoo/teams/41243/et/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -110,7 +111,7 @@ msgstr "Palgaandmik"
 #. module: hr_payroll_account
 #: model:ir.model,name:hr_payroll_account.model_hr_salary_rule
 msgid "Salary Rule"
-msgstr ""
+msgstr "Palgareegel"
 
 #. module: hr_payroll_account
 #: model:ir.model.fields,field_description:hr_payroll_account.field_hr_payslip_line__account_tax_id

--- a/addons/hr_recruitment/i18n/eu.po
+++ b/addons/hr_recruitment/i18n/eu.po
@@ -16,6 +16,8 @@
 # Naomi Hidalgo <naomihid96@gmail.com>, 2019
 # Maialen Rodriguez <maialenrodriguez98@gmail.com>, 2020
 # Miren Maiz <mirenmaizz@gmail.com>, 2020
+# mgalarza005 <mikelgalarza99@gmail.com>, 2020
+# Unai Muñoz <unaimunoz9@gmail.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -23,7 +25,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-01-09 10:31+0000\n"
 "PO-Revision-Date: 2018-08-24 09:19+0000\n"
-"Last-Translator: Miren Maiz <mirenmaizz@gmail.com>, 2020\n"
+"Last-Translator: Unai Muñoz <unaimunoz9@gmail.com>, 2020\n"
 "Language-Team: Basque (https://www.transifex.com/odoo/teams/41243/eu/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -378,13 +380,13 @@ msgstr ""
 #. module: hr_recruitment
 #: model:ir.ui.menu,name:hr_recruitment.menu_crm_case_categ_all_app
 msgid "All Applications"
-msgstr ""
+msgstr "Aplikazio guztiak"
 
 #. module: hr_recruitment
 #: model:ir.model,name:hr_recruitment.model_hr_applicant
 #: model:ir.model.fields,field_description:hr_recruitment.field_calendar_event__applicant_id
 msgid "Applicant"
-msgstr ""
+msgstr "Eskatzailea"
 
 #. module: hr_recruitment
 #: model:ir.model,name:hr_recruitment.model_hr_recruitment_degree
@@ -395,7 +397,7 @@ msgstr ""
 #: model:mail.message.subtype,name:hr_recruitment.mt_applicant_hired
 #: model:mail.message.subtype,name:hr_recruitment.mt_job_applicant_hired
 msgid "Applicant Hired"
-msgstr ""
+msgstr "Kontratatutako eskatzailea"
 
 #. module: hr_recruitment
 #: model:mail.message.subtype,name:hr_recruitment.mt_job_applicant_stage_changed
@@ -410,18 +412,18 @@ msgstr ""
 #. module: hr_recruitment
 #: model:mail.message.subtype,description:hr_recruitment.mt_applicant_hired
 msgid "Applicant hired"
-msgstr ""
+msgstr "Kontratatutako eskatzailea"
 
 #. module: hr_recruitment
 #: model:ir.model.fields,field_description:hr_recruitment.field_hr_applicant__partner_name
 msgid "Applicant's Name"
-msgstr ""
+msgstr "Eskatzailearen izena"
 
 #. module: hr_recruitment
 #: model_terms:ir.ui.view,arch_db:hr_recruitment.crm_case_tree_view_job
 #: model_terms:ir.ui.view,arch_db:hr_recruitment.hr_applicant_calendar_view
 msgid "Applicants"
-msgstr ""
+msgstr "Eskatzaileak"
 
 #. module: hr_recruitment
 #: model_terms:ir.actions.act_window,help:hr_recruitment.action_hr_job_applications
@@ -464,7 +466,7 @@ msgstr ""
 #. module: hr_recruitment
 #: model_terms:ir.ui.view,arch_db:hr_recruitment.view_hr_job_kanban
 msgid "Application(s)"
-msgstr ""
+msgstr "Aplikazioa(k)"
 
 #. module: hr_recruitment
 #: model:ir.actions.act_window,name:hr_recruitment.action_hr_job_applications
@@ -473,12 +475,12 @@ msgstr ""
 #: model:ir.ui.menu,name:hr_recruitment.menu_crm_case_categ0_act_job
 #: model_terms:ir.ui.view,arch_db:hr_recruitment.hr_job_survey
 msgid "Applications"
-msgstr ""
+msgstr "Aplikazioak"
 
 #. module: hr_recruitment
 #: model:ir.model.fields,field_description:hr_recruitment.field_hr_applicant__job_id
 msgid "Applied Job"
-msgstr ""
+msgstr "Eskatutako lana"
 
 #. module: hr_recruitment
 #: model:ir.model.fields,field_description:hr_recruitment.field_hr_applicant__priority
@@ -726,12 +728,12 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:hr_recruitment.hr_recruitment_degree_tree
 #: model_terms:ir.ui.view,arch_db:hr_recruitment.view_crm_case_jobs_filter
 msgid "Degree"
-msgstr ""
+msgstr "Gradua"
 
 #. module: hr_recruitment
 #: model:ir.ui.menu,name:hr_recruitment.menu_hr_recruitment_degree
 msgid "Degrees"
-msgstr ""
+msgstr "Graduak"
 
 #. module: hr_recruitment
 #: model:ir.model.fields,field_description:hr_recruitment.field_hr_applicant__delay_close
@@ -840,7 +842,7 @@ msgstr "Eposta ezizena "
 #. module: hr_recruitment
 #: model_terms:ir.ui.view,arch_db:hr_recruitment.hr_job_survey
 msgid "Email alias"
-msgstr ""
+msgstr "posten ezizena"
 
 #. module: hr_recruitment
 #: model:ir.model.fields,help:hr_recruitment.field_hr_job__alias_id
@@ -881,7 +883,7 @@ msgstr "Gertakizuna"
 #. module: hr_recruitment
 #: selection:hr.applicant,priority:0
 msgid "Excellent"
-msgstr ""
+msgstr "Ederto"
 
 #. module: hr_recruitment
 #: model:ir.model.fields,field_description:hr_recruitment.field_hr_department__expected_employee
@@ -891,7 +893,7 @@ msgstr ""
 #. module: hr_recruitment
 #: model:ir.model.fields,field_description:hr_recruitment.field_hr_applicant__salary_expected
 msgid "Expected Salary"
-msgstr ""
+msgstr "Esperotako soldata"
 
 #. module: hr_recruitment
 #: model:ir.model.fields,field_description:hr_recruitment.field_hr_applicant__salary_expected_extra
@@ -916,7 +918,7 @@ msgstr ""
 #. module: hr_recruitment
 #: model:hr.recruitment.stage,name:hr_recruitment.stage_job2
 msgid "First Interview"
-msgstr ""
+msgstr "Lehenengo elkarrizketa"
 
 #. module: hr_recruitment
 #: model:ir.model.fields,field_description:hr_recruitment.field_hr_recruitment_stage__fold
@@ -956,7 +958,7 @@ msgstr ""
 #. module: hr_recruitment
 #: selection:hr.applicant,priority:0
 msgid "Good"
-msgstr ""
+msgstr "Ondo"
 
 #. module: hr_recruitment
 #: model:hr.recruitment.degree,name:hr_recruitment.degree_graduate
@@ -976,7 +978,7 @@ msgstr ""
 #. module: hr_recruitment
 #: selection:hr.applicant,kanban_state:0
 msgid "Grey"
-msgstr ""
+msgstr "Grisa"
 
 #. module: hr_recruitment
 #: model:ir.model.fields,field_description:hr_recruitment.field_hr_recruitment_stage__legend_normal
@@ -1094,7 +1096,7 @@ msgstr "Lana"
 #. module: hr_recruitment
 #: model_terms:ir.ui.view,arch_db:hr_recruitment.crm_case_pivot_view_job
 msgid "Job Applications"
-msgstr ""
+msgstr "Lan aplikazioak"
 
 #. module: hr_recruitment
 #: model:utm.campaign,name:hr_recruitment.utm_campaign_job

--- a/addons/hr_recruitment/i18n/eu.po
+++ b/addons/hr_recruitment/i18n/eu.po
@@ -15,6 +15,7 @@
 # Mikel Lizarralde <mikellizarralde@gmail.com>, 2019
 # Naomi Hidalgo <naomihid96@gmail.com>, 2019
 # Maialen Rodriguez <maialenrodriguez98@gmail.com>, 2020
+# Miren Maiz <mirenmaizz@gmail.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -22,7 +23,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-01-09 10:31+0000\n"
 "PO-Revision-Date: 2018-08-24 09:19+0000\n"
-"Last-Translator: Maialen Rodriguez <maialenrodriguez98@gmail.com>, 2020\n"
+"Last-Translator: Miren Maiz <mirenmaizz@gmail.com>, 2020\n"
 "Language-Team: Basque (https://www.transifex.com/odoo/teams/41243/eu/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -767,7 +768,7 @@ msgstr "Deskribapena"
 #. module: hr_recruitment
 #: model:ir.model,name:hr_recruitment.model_digest_digest
 msgid "Digest"
-msgstr ""
+msgstr "Laburpen"
 
 #. module: hr_recruitment
 #: model_terms:ir.ui.view,arch_db:hr_recruitment.hr_job_simple_form
@@ -1626,7 +1627,7 @@ msgstr "Arduraduna"
 #. module: hr_recruitment
 #: model:ir.model.fields,field_description:hr_recruitment.field_hr_applicant__activity_user_id
 msgid "Responsible User"
-msgstr ""
+msgstr "Erabiltzaile arduraduna"
 
 #. module: hr_recruitment
 #: model:ir.actions.act_window,name:hr_recruitment.hr_applicant_resumes

--- a/addons/hr_recruitment/i18n/it.po
+++ b/addons/hr_recruitment/i18n/it.po
@@ -4,10 +4,8 @@
 # 
 # Translators:
 # Francesco Garganese <francesco.garganese@aeromnia.aero>, 2018
-# Giacomo Grasso <giacomo.grasso.82@gmail.com>, 2018
 # SebastianoPistore <SebastianoPistore.info@protonmail.ch>, 2018
 # Christian <chris@effeci.info>, 2018
-# Cécile Collart <cco@odoo.com>, 2018
 # Martin Trigaux, 2018
 # Luigi Di Naro <gigidn@gmail.com>, 2018
 # Maurizio Delmonte <maurizio.delmonte@gmail.com>, 2018
@@ -15,9 +13,8 @@
 # Manuela Feliciani <mfeliciani@alice.it>, 2018
 # David Minneci <david@numeko.it>, 2018
 # Léonie Bouchat <lbo@odoo.com>, 2019
-# Simone Sanfilippo <s.sanfilippo@hinge16.eu>, 2019
-# Sergio Zanchetta <primes2h@gmail.com>, 2020
 # Lorenzo Battistini <lb@takobi.online>, 2020
+# Sergio Zanchetta <primes2h@gmail.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -25,7 +22,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-01-09 10:31+0000\n"
 "PO-Revision-Date: 2018-08-24 09:19+0000\n"
-"Last-Translator: Lorenzo Battistini <lb@takobi.online>, 2020\n"
+"Last-Translator: Sergio Zanchetta <primes2h@gmail.com>, 2020\n"
 "Language-Team: Italian (https://www.transifex.com/odoo/teams/41243/it/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -61,7 +58,7 @@ msgstr "<i class=\"fa fa-mobile mr4\" role=\"img\" aria-label=\"Mobile\" title=\
 #. module: hr_recruitment
 #: model_terms:ir.ui.view,arch_db:hr_recruitment.crm_case_form_view_job
 msgid "<span class=\"o_stat_text\">Meetings</span>"
-msgstr "<span class=\"o_stat_text\">Riunioni</span>"
+msgstr "<span class=\"o_stat_text\">Appuntamenti</span>"
 
 #. module: hr_recruitment
 #: model_terms:ir.ui.view,arch_db:hr_recruitment.hr_job_survey
@@ -80,7 +77,7 @@ msgstr ""
 #. module: hr_recruitment
 #: model_terms:ir.ui.view,arch_db:hr_recruitment.view_hr_recruitment_stage_kanban
 msgid "<span>Folded in Recruitment Pipe: </span>"
-msgstr "<span>Minimizzata nel flusso di selezione del personale: </span>"
+msgstr "<span>Minimizzata nel flusso di selezione: </span>"
 
 #. module: hr_recruitment
 #: model_terms:digest.tip,tip_description:hr_recruitment.digest_tip_hr_recruitment_0
@@ -393,7 +390,7 @@ msgstr "Candidato"
 #. module: hr_recruitment
 #: model:ir.model,name:hr_recruitment.model_hr_recruitment_degree
 msgid "Applicant Degree"
-msgstr "Laurea candidato"
+msgstr "Titolo di studio del candidato"
 
 #. module: hr_recruitment
 #: model:mail.message.subtype,name:hr_recruitment.mt_applicant_hired
@@ -490,7 +487,7 @@ msgstr "Candidature"
 #. module: hr_recruitment
 #: model:ir.model.fields,field_description:hr_recruitment.field_hr_applicant__job_id
 msgid "Applied Job"
-msgstr "Lavoro Richiesto"
+msgstr "Lavoro richiesto"
 
 #. module: hr_recruitment
 #: model:ir.model.fields,field_description:hr_recruitment.field_hr_applicant__priority
@@ -738,17 +735,17 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:hr_recruitment.hr_recruitment_degree_tree
 #: model_terms:ir.ui.view,arch_db:hr_recruitment.view_crm_case_jobs_filter
 msgid "Degree"
-msgstr "Grado"
+msgstr "Titolo di studio"
 
 #. module: hr_recruitment
 #: model:ir.ui.menu,name:hr_recruitment.menu_hr_recruitment_degree
 msgid "Degrees"
-msgstr "Gradi"
+msgstr "Titoli di studio"
 
 #. module: hr_recruitment
 #: model:ir.model.fields,field_description:hr_recruitment.field_hr_applicant__delay_close
 msgid "Delay to Close"
-msgstr "Ritardare Chiusura"
+msgstr "Ritardo chiusura"
 
 #. module: hr_recruitment
 #: model_terms:ir.ui.view,arch_db:hr_recruitment.hr_kanban_view_applicant
@@ -800,7 +797,9 @@ msgstr "Nome visualizzato"
 #: code:addons/hr_recruitment/models/digest.py:16
 #, python-format
 msgid "Do not have access, skip this data for user's digest email"
-msgstr "Non hai accesso, salta questi dati per l'e-mail digest dell'utente"
+msgstr ""
+"Accesso non consentito, non utilizzare questi dati nell'e-mail di riepilogo "
+"dell'utente"
 
 #. module: hr_recruitment
 #: model:hr.recruitment.degree,name:hr_recruitment.degree_bac5
@@ -935,12 +934,12 @@ msgstr "Primo colloquio"
 #. module: hr_recruitment
 #: model:ir.model.fields,field_description:hr_recruitment.field_hr_recruitment_stage__fold
 msgid "Folded in Recruitment Pipe"
-msgstr "Minimizzata nel flusso di selezione del personale"
+msgstr "Minimizzata nel flusso di selezione"
 
 #. module: hr_recruitment
 #: model:ir.model.fields,field_description:hr_recruitment.field_hr_applicant__message_follower_ids
 msgid "Followers"
-msgstr "Follower"
+msgstr "Chi sta seguendo"
 
 #. module: hr_recruitment
 #: model:ir.model.fields,field_description:hr_recruitment.field_hr_applicant__message_channel_ids
@@ -960,7 +959,8 @@ msgstr "Attività future"
 #. module: hr_recruitment
 #: model:ir.model.fields,help:hr_recruitment.field_hr_recruitment_degree__sequence
 msgid "Gives the sequence order when displaying a list of degrees."
-msgstr "Fornisce l'ordinamento quando viene visualizzata una lista di gradi."
+msgstr ""
+"Stabilisce l'ordine con cui visualizzare un elenco di titoli di studio."
 
 #. module: hr_recruitment
 #: model:ir.model.fields,help:hr_recruitment.field_hr_recruitment_stage__sequence
@@ -975,7 +975,7 @@ msgstr "Buona"
 #. module: hr_recruitment
 #: model:hr.recruitment.degree,name:hr_recruitment.degree_graduate
 msgid "Graduate"
-msgstr "Laureato"
+msgstr "Diploma"
 
 #. module: hr_recruitment
 #: selection:hr.applicant,kanban_state:0
@@ -1584,7 +1584,7 @@ msgstr "Selezione del personale completata"
 #. module: hr_recruitment
 #: model_terms:ir.ui.view,arch_db:hr_recruitment.res_config_settings_view_form
 msgid "Recruitment Process"
-msgstr "Processo di assunzione"
+msgstr "Processo di selezione"
 
 #. module: hr_recruitment
 #: model:ir.model.fields,field_description:hr_recruitment.field_hr_job__user_id
@@ -1614,17 +1614,17 @@ msgstr "Etichetta kanban - Rosso"
 #. module: hr_recruitment
 #: model:ir.model.fields,field_description:hr_recruitment.field_hr_applicant__reference
 msgid "Referred By"
-msgstr "Riferito da"
+msgstr "Segnalato da"
 
 #. module: hr_recruitment
 #: model_terms:ir.ui.view,arch_db:hr_recruitment.crm_case_form_view_job
 msgid "Refuse"
-msgstr "Rifiuta"
+msgstr "Declina"
 
 #. module: hr_recruitment
 #: model_terms:ir.ui.view,arch_db:hr_recruitment.hr_applicant_view_search
 msgid "Refused"
-msgstr "Rifiutato"
+msgstr "Declinato"
 
 #. module: hr_recruitment
 #: model_terms:ir.ui.view,arch_db:hr_recruitment.crm_case_form_view_job
@@ -1634,7 +1634,7 @@ msgstr "Riapri candidatura"
 #. module: hr_recruitment
 #: model:ir.ui.menu,name:hr_recruitment.report_hr_recruitment
 msgid "Reports"
-msgstr "Report"
+msgstr "Resoconti"
 
 #. module: hr_recruitment
 #: model:ir.model.fields,field_description:hr_recruitment.field_hr_recruitment_stage__requirements
@@ -1658,7 +1658,7 @@ msgstr "Utente responsabile"
 #: model:ir.actions.act_window,name:hr_recruitment.hr_applicant_resumes
 #: model:ir.ui.menu,name:hr_recruitment.menu_crm_case_categ0_act_job02
 msgid "Resumes and Letters"
-msgstr "Curricula e Lettere"
+msgstr "Curriculum e lettere"
 
 #. module: hr_recruitment
 #: model:ir.model.fields,help:hr_recruitment.field_hr_applicant__salary_expected
@@ -1744,7 +1744,7 @@ msgstr "Origine dei candidati"
 #: model:ir.ui.menu,name:hr_recruitment.menu_hr_recruitment_source
 #: model_terms:ir.ui.view,arch_db:hr_recruitment.hr_recruitment_source_tree
 msgid "Sources of Applicants"
-msgstr "Origini dei candidati"
+msgstr "Provenienze dei candidati"
 
 #. module: hr_recruitment
 #: model:ir.model.fields,help:hr_recruitment.field_hr_recruitment_stage__job_id
@@ -1796,7 +1796,7 @@ msgstr "Fasi"
 #. module: hr_recruitment
 #: model_terms:ir.ui.view,arch_db:hr_recruitment.view_hr_job_kanban
 msgid "Start Recruitment"
-msgstr "Avvia selezione del personale"
+msgstr "Avvia selezione"
 
 #. module: hr_recruitment
 #: model_terms:ir.ui.view,arch_db:hr_recruitment.view_hr_job_kanban

--- a/addons/hr_recruitment_survey/i18n/eu.po
+++ b/addons/hr_recruitment_survey/i18n/eu.po
@@ -7,6 +7,7 @@
 # Mikel Lizarralde <mikellizarralde@gmail.com>, 2019
 # Naomi Hidalgo <naomihid96@gmail.com>, 2019
 # Maialen Rodriguez <maialenrodriguez98@gmail.com>, 2020
+# Unai Muñoz <unaimunoz9@gmail.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -14,7 +15,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2018-09-18 09:49+0000\n"
 "PO-Revision-Date: 2018-08-24 09:19+0000\n"
-"Last-Translator: Maialen Rodriguez <maialenrodriguez98@gmail.com>, 2020\n"
+"Last-Translator: Unai Muñoz <unaimunoz9@gmail.com>, 2020\n"
 "Language-Team: Basque (https://www.transifex.com/odoo/teams/41243/eu/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -89,7 +90,7 @@ msgstr ""
 #. module: hr_recruitment_survey
 #: model:ir.model,name:hr_recruitment_survey.model_hr_applicant
 msgid "Applicant"
-msgstr ""
+msgstr "Eskatzailea"
 
 #. module: hr_recruitment_survey
 #: model:survey.page,title:hr_recruitment_survey.recruitment_1

--- a/addons/hr_timesheet/i18n/ar.po
+++ b/addons/hr_timesheet/i18n/ar.po
@@ -619,6 +619,14 @@ msgstr ""
 "                للعملاء إذا تطلب الأمر."
 
 #. module: hr_timesheet
+#: code:addons/hr_timesheet/models/analytic_account.py:53
+#, python-format
+msgid ""
+"You cannot change the company of an analytical account if it is related to a"
+" project."
+msgstr ""
+
+#. module: hr_timesheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet.hr_employee_view_form_inherit_timesheet
 msgid "per hour"
 msgstr "في الساعة"

--- a/addons/hr_timesheet/i18n/az.po
+++ b/addons/hr_timesheet/i18n/az.po
@@ -588,6 +588,14 @@ msgid ""
 msgstr ""
 
 #. module: hr_timesheet
+#: code:addons/hr_timesheet/models/analytic_account.py:53
+#, python-format
+msgid ""
+"You cannot change the company of an analytical account if it is related to a"
+" project."
+msgstr ""
+
+#. module: hr_timesheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet.hr_employee_view_form_inherit_timesheet
 msgid "per hour"
 msgstr ""

--- a/addons/hr_timesheet/i18n/bg.po
+++ b/addons/hr_timesheet/i18n/bg.po
@@ -609,6 +609,14 @@ msgstr ""
 "                клиенти, ако е необходимо."
 
 #. module: hr_timesheet
+#: code:addons/hr_timesheet/models/analytic_account.py:53
+#, python-format
+msgid ""
+"You cannot change the company of an analytical account if it is related to a"
+" project."
+msgstr ""
+
+#. module: hr_timesheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet.hr_employee_view_form_inherit_timesheet
 msgid "per hour"
 msgstr ""

--- a/addons/hr_timesheet/i18n/bn.po
+++ b/addons/hr_timesheet/i18n/bn.po
@@ -589,6 +589,14 @@ msgid ""
 msgstr ""
 
 #. module: hr_timesheet
+#: code:addons/hr_timesheet/models/analytic_account.py:53
+#, python-format
+msgid ""
+"You cannot change the company of an analytical account if it is related to a"
+" project."
+msgstr ""
+
+#. module: hr_timesheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet.hr_employee_view_form_inherit_timesheet
 msgid "per hour"
 msgstr ""

--- a/addons/hr_timesheet/i18n/bs.po
+++ b/addons/hr_timesheet/i18n/bs.po
@@ -590,6 +590,14 @@ msgid ""
 msgstr ""
 
 #. module: hr_timesheet
+#: code:addons/hr_timesheet/models/analytic_account.py:53
+#, python-format
+msgid ""
+"You cannot change the company of an analytical account if it is related to a"
+" project."
+msgstr ""
+
+#. module: hr_timesheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet.hr_employee_view_form_inherit_timesheet
 msgid "per hour"
 msgstr "po satu"

--- a/addons/hr_timesheet/i18n/ca.po
+++ b/addons/hr_timesheet/i18n/ca.po
@@ -5,7 +5,7 @@
 # Translators:
 # Martin Trigaux, 2018
 # Quim - eccit <quim@eccit.com>, 2018
-# Manel Fernandez <manelfera@outlook.com>, 2018
+# Manel Fernandez Ramirez <manelfera@outlook.com>, 2018
 # M Palau <mpalau@tda.ad>, 2019
 # Arnau Ros, 2019
 # 
@@ -619,6 +619,14 @@ msgstr ""
 "Pots registrar i fer el seguiment de les hores treballades per projecte cada \n"
 "dia. Tot el temps dedicat en un projecte serà un cost i pot facturar-se de nou a\n"
 "clients si es requereix"
+
+#. module: hr_timesheet
+#: code:addons/hr_timesheet/models/analytic_account.py:53
+#, python-format
+msgid ""
+"You cannot change the company of an analytical account if it is related to a"
+" project."
+msgstr ""
 
 #. module: hr_timesheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet.hr_employee_view_form_inherit_timesheet

--- a/addons/hr_timesheet/i18n/cs.po
+++ b/addons/hr_timesheet/i18n/cs.po
@@ -610,6 +610,14 @@ msgid ""
 msgstr ""
 
 #. module: hr_timesheet
+#: code:addons/hr_timesheet/models/analytic_account.py:53
+#, python-format
+msgid ""
+"You cannot change the company of an analytical account if it is related to a"
+" project."
+msgstr ""
+
+#. module: hr_timesheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet.hr_employee_view_form_inherit_timesheet
 msgid "per hour"
 msgstr "za hodinu"

--- a/addons/hr_timesheet/i18n/da.po
+++ b/addons/hr_timesheet/i18n/da.po
@@ -617,6 +617,14 @@ msgstr ""
 "                kunder hvis nødvendigt."
 
 #. module: hr_timesheet
+#: code:addons/hr_timesheet/models/analytic_account.py:53
+#, python-format
+msgid ""
+"You cannot change the company of an analytical account if it is related to a"
+" project."
+msgstr ""
+
+#. module: hr_timesheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet.hr_employee_view_form_inherit_timesheet
 msgid "per hour"
 msgstr "pr. time"

--- a/addons/hr_timesheet/i18n/de.po
+++ b/addons/hr_timesheet/i18n/de.po
@@ -613,6 +613,14 @@ msgstr ""
 " Rechnung gestellt werden."
 
 #. module: hr_timesheet
+#: code:addons/hr_timesheet/models/analytic_account.py:53
+#, python-format
+msgid ""
+"You cannot change the company of an analytical account if it is related to a"
+" project."
+msgstr ""
+
+#. module: hr_timesheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet.hr_employee_view_form_inherit_timesheet
 msgid "per hour"
 msgstr "pro Stunde"

--- a/addons/hr_timesheet/i18n/el.po
+++ b/addons/hr_timesheet/i18n/el.po
@@ -598,6 +598,14 @@ msgid ""
 msgstr ""
 
 #. module: hr_timesheet
+#: code:addons/hr_timesheet/models/analytic_account.py:53
+#, python-format
+msgid ""
+"You cannot change the company of an analytical account if it is related to a"
+" project."
+msgstr ""
+
+#. module: hr_timesheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet.hr_employee_view_form_inherit_timesheet
 msgid "per hour"
 msgstr ""

--- a/addons/hr_timesheet/i18n/es.po
+++ b/addons/hr_timesheet/i18n/es.po
@@ -621,6 +621,14 @@ msgstr ""
 "Cada vez que emplea horas en un proyecto, se creará un coste que puede ser facturado al cliente si es necesario."
 
 #. module: hr_timesheet
+#: code:addons/hr_timesheet/models/analytic_account.py:53
+#, python-format
+msgid ""
+"You cannot change the company of an analytical account if it is related to a"
+" project."
+msgstr ""
+
+#. module: hr_timesheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet.hr_employee_view_form_inherit_timesheet
 msgid "per hour"
 msgstr "por hora"

--- a/addons/hr_timesheet/i18n/et.po
+++ b/addons/hr_timesheet/i18n/et.po
@@ -10,6 +10,7 @@
 # Martin Aavastik <martin@avalah.ee>, 2018
 # Arma Gedonsky <armagedonsky@hot.ee>, 2018
 # Eneli Õigus <enelioigus@gmail.com>, 2019
+# Algo Kärp <algokarp@gmail.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -17,7 +18,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-01-09 10:31+0000\n"
 "PO-Revision-Date: 2018-08-24 09:19+0000\n"
-"Last-Translator: Eneli Õigus <enelioigus@gmail.com>, 2019\n"
+"Last-Translator: Algo Kärp <algokarp@gmail.com>, 2020\n"
 "Language-Team: Estonian (https://www.transifex.com/odoo/teams/41243/et/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -40,22 +41,22 @@ msgstr ""
 #. module: hr_timesheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet.view_project_kanban_inherited
 msgid "<span class=\"o_label\">Timesheets</span>"
-msgstr "<span class=\"o_label\">Tööaja arvestuslhed</span>"
+msgstr "<span class=\"o_label\">Tööaja arvestuslehed</span>"
 
 #. module: hr_timesheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet.hr_employee_view_form_inherit_timesheet
 msgid "<span class=\"o_stat_text\">Timesheets</span>"
-msgstr "<span class=\"o_stat_text\">Ajaarvestus</span>"
+msgstr "<span class=\"o_stat_text\">Tööaja arvestuslehed</span>"
 
 #. module: hr_timesheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet.view_task_form2_inherited
 msgid "<span> planned hours</span>"
-msgstr ""
+msgstr "<span> planeeritud tunnid</span>"
 
 #. module: hr_timesheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet.report_timesheet
 msgid "<span>Date</span>"
-msgstr ""
+msgstr "<span>Kuupäev</span>"
 
 #. module: hr_timesheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet.report_timesheet
@@ -65,12 +66,12 @@ msgstr ""
 #. module: hr_timesheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet.report_timesheet
 msgid "<span>Responsible</span>"
-msgstr ""
+msgstr "<span>Vastutav</span>"
 
 #. module: hr_timesheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet.report_timesheet
 msgid "<span>Time</span>"
-msgstr ""
+msgstr "<span>Aeg</span>"
 
 #. module: hr_timesheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet.report_timesheet
@@ -80,7 +81,7 @@ msgstr "<span>Tööaja arvestuslehtede sissekanded</span>"
 #. module: hr_timesheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet.view_kanban_account_analytic_line
 msgid "<strong>Duration: </strong>"
-msgstr "<strong>Kestvus:</strong>"
+msgstr "<strong>Kestus:</strong>"
 
 #. module: hr_timesheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet.report_timesheet
@@ -103,7 +104,7 @@ msgstr "Kõik tööaja arvestulehed"
 #: model:ir.model.fields,field_description:hr_timesheet.field_project_task__allow_timesheets
 #: model_terms:ir.ui.view,arch_db:hr_timesheet.project_invoice_form
 msgid "Allow timesheets"
-msgstr "Luba ajaarvestus"
+msgstr "Luba tööaja arvestuslehed"
 
 #. module: hr_timesheet
 #: model:ir.model,name:hr_timesheet.model_account_analytic_account
@@ -204,7 +205,7 @@ msgstr "Kirjeldus"
 #. module: hr_timesheet
 #: model:ir.model.fields,help:hr_timesheet.field_project_task__progress
 msgid "Display progress of current task."
-msgstr ""
+msgstr "Näitab praeguse ülesande käiku"
 
 #. module: hr_timesheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet.portal_my_task
@@ -215,7 +216,7 @@ msgstr "Kestvus"
 #: code:addons/hr_timesheet/models/hr_timesheet.py:95
 #, python-format
 msgid "Duration (%s)"
-msgstr ""
+msgstr "Kestus (%s)"
 
 #. module: hr_timesheet
 #: model:ir.model.fields,field_description:hr_timesheet.field_report_project_task_user__hours_effective
@@ -232,7 +233,7 @@ msgstr "Töötaja"
 #. module: hr_timesheet
 #: model:ir.model.fields,field_description:hr_timesheet.field_res_config_settings__timesheet_encode_uom_id
 msgid "Encoding Unit"
-msgstr ""
+msgstr "Kodeerimisüksus"
 
 #. module: hr_timesheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet.res_config_settings_view_form
@@ -300,7 +301,7 @@ msgstr "Juhataja"
 #: model:ir.ui.menu,name:hr_timesheet.timesheet_menu_activity_mine
 #: model_terms:ir.ui.view,arch_db:hr_timesheet.hr_timesheet_line_search
 msgid "My Timesheets"
-msgstr "Minu ajaarvestus"
+msgstr "Minu tööaja arvestuslehed"
 
 #. module: hr_timesheet
 #: model:ir.model.fields,field_description:hr_timesheet.field_report_project_task_user__hours_planned
@@ -364,7 +365,7 @@ msgstr "Projektid"
 #: model_terms:ir.actions.act_window,help:hr_timesheet.timesheet_action_report_by_project
 #: model_terms:ir.actions.act_window,help:hr_timesheet.timesheet_action_report_by_task
 msgid "Record a new activity"
-msgstr ""
+msgstr "Salvestage uus tegevus"
 
 #. module: hr_timesheet
 #: model:ir.model.fields,field_description:hr_timesheet.field_project_task__remaining_hours
@@ -391,7 +392,7 @@ msgstr "Vastutaja"
 #. module: hr_timesheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet.res_config_settings_view_form
 msgid "Set time unit used to record your timesheets"
-msgstr ""
+msgstr "Määrake ajagraafikute salvestamiseks kasutatav ajaühik"
 
 #. module: hr_timesheet
 #: model:ir.actions.act_window,name:hr_timesheet.hr_timesheet_config_settings_action
@@ -407,12 +408,12 @@ msgstr "Kulutatud tunnid"
 #. module: hr_timesheet
 #: model:ir.model.fields,field_description:hr_timesheet.field_project_task__subtask_effective_hours
 msgid "Sub-tasks Hours Spent"
-msgstr ""
+msgstr "Alamülesannetele kulunud tunnid"
 
 #. module: hr_timesheet
 #: model:ir.model.fields,help:hr_timesheet.field_project_task__subtask_effective_hours
 msgid "Sum of actually spent hours on the subtask(s)"
-msgstr ""
+msgstr "Alamülesanne(te) le tegelikult kulutatud tundide summa"
 
 #. module: hr_timesheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet.res_config_settings_view_form
@@ -470,7 +471,7 @@ msgstr ""
 #. module: hr_timesheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet.res_config_settings_view_form
 msgid "Time Encoding"
-msgstr ""
+msgstr "Aja kodeerimine"
 
 #. module: hr_timesheet
 #: model:ir.ui.menu,name:hr_timesheet.menu_hr_time_tracking
@@ -484,7 +485,7 @@ msgstr "Ajaarvestus"
 #: model_terms:ir.ui.view,arch_db:hr_timesheet.hr_timesheet_line_tree
 #: model_terms:ir.ui.view,arch_db:hr_timesheet.view_task_form2_inherited
 msgid "Timesheet Activities"
-msgstr "Ajaarvestuse tegevused"
+msgstr "Tööaja arvestuslehe tegevused"
 
 #. module: hr_timesheet
 #: model:ir.model.fields,field_description:hr_timesheet.field_hr_employee__timesheet_cost
@@ -494,23 +495,23 @@ msgstr "Tunnihind (kulu)"
 #. module: hr_timesheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet.hr_timesheet_line_search
 msgid "Timesheet Date"
-msgstr ""
+msgstr "Ajaarvestuse kuupäev"
 
 #. module: hr_timesheet
 #: model:ir.model.fields,field_description:hr_timesheet.field_res_company__timesheet_encode_uom_id
 msgid "Timesheet Encoding Unit"
-msgstr ""
+msgstr "Ajaarvestuse kodeerimise üksus"
 
 #. module: hr_timesheet
 #: model:ir.actions.act_window,name:hr_timesheet.project_task_action_view_timesheet
 #: model:ir.actions.report,name:hr_timesheet.timesheet_report
 msgid "Timesheet Entries"
-msgstr "Ajaarvestuse sissekanded"
+msgstr "Tööaja arvestuslehtede sissekanded"
 
 #. module: hr_timesheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet.hr_timesheet_line_search
 msgid "Timesheet by Date"
-msgstr ""
+msgstr "Ajaarvestus kuupäeva järgi"
 
 #. module: hr_timesheet
 #: model:ir.actions.act_window,name:hr_timesheet.timesheet_action_from_employee
@@ -528,7 +529,7 @@ msgstr "Ajaarvestus"
 #. module: hr_timesheet
 #: model:ir.model.fields,help:hr_timesheet.field_project_task__allow_timesheets
 msgid "Timesheets can be logged on this task."
-msgstr ""
+msgstr "Selle ülesande jaoks saab ajaarvestust logida"
 
 #. module: hr_timesheet
 #: code:addons/hr_timesheet/models/project.py:32

--- a/addons/hr_timesheet/i18n/et.po
+++ b/addons/hr_timesheet/i18n/et.po
@@ -608,6 +608,14 @@ msgstr ""
 "Projektile kulutatud ajast saab kulu ning selle kohta on vajadusel võimalik kliendile arve esitada."
 
 #. module: hr_timesheet
+#: code:addons/hr_timesheet/models/analytic_account.py:53
+#, python-format
+msgid ""
+"You cannot change the company of an analytical account if it is related to a"
+" project."
+msgstr ""
+
+#. module: hr_timesheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet.hr_employee_view_form_inherit_timesheet
 msgid "per hour"
 msgstr "tunnis"

--- a/addons/hr_timesheet/i18n/eu.po
+++ b/addons/hr_timesheet/i18n/eu.po
@@ -13,6 +13,7 @@
 # Victor Laskurain <blaskurain@binovo.es>, 2019
 # Maialen Rodriguez <maialenrodriguez98@gmail.com>, 2020
 # Miren Maiz <mirenmaizz@gmail.com>, 2020
+# Mikel Galarza <mikelgalarza99@gmail.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -20,7 +21,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-01-09 10:31+0000\n"
 "PO-Revision-Date: 2018-08-24 09:19+0000\n"
-"Last-Translator: Miren Maiz <mirenmaizz@gmail.com>, 2020\n"
+"Last-Translator: Mikel Galarza <mikelgalarza99@gmail.com>, 2020\n"
 "Language-Team: Basque (https://www.transifex.com/odoo/teams/41243/eu/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -39,6 +40,8 @@ msgid ""
 "<span class=\"fa fa-lg fa-building-o\" title=\"Values set here are company-"
 "specific.\" groups=\"base.group_multi_company\"/>"
 msgstr ""
+"<span class=\"fa fa-lg fa-building-o\" title=\"Values set here are company-"
+"specific.\" groups=\"base.group_multi_company\"/>"
 
 #. module: hr_timesheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet.view_project_kanban_inherited

--- a/addons/hr_timesheet/i18n/eu.po
+++ b/addons/hr_timesheet/i18n/eu.po
@@ -13,7 +13,7 @@
 # Victor Laskurain <blaskurain@binovo.es>, 2019
 # Maialen Rodriguez <maialenrodriguez98@gmail.com>, 2020
 # Miren Maiz <mirenmaizz@gmail.com>, 2020
-# Mikel Galarza <mikelgalarza99@gmail.com>, 2020
+# mgalarza005 <mikelgalarza99@gmail.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -21,7 +21,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-01-09 10:31+0000\n"
 "PO-Revision-Date: 2018-08-24 09:19+0000\n"
-"Last-Translator: Mikel Galarza <mikelgalarza99@gmail.com>, 2020\n"
+"Last-Translator: mgalarza005 <mikelgalarza99@gmail.com>, 2020\n"
 "Language-Team: Basque (https://www.transifex.com/odoo/teams/41243/eu/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -601,6 +601,14 @@ msgid ""
 "You can register and track your workings hours by project every\n"
 "                day. Every time spent on a project will become a cost and can be re-invoiced to\n"
 "                customers if required."
+msgstr ""
+
+#. module: hr_timesheet
+#: code:addons/hr_timesheet/models/analytic_account.py:53
+#, python-format
+msgid ""
+"You cannot change the company of an analytical account if it is related to a"
+" project."
 msgstr ""
 
 #. module: hr_timesheet

--- a/addons/hr_timesheet/i18n/fa.po
+++ b/addons/hr_timesheet/i18n/fa.po
@@ -596,6 +596,14 @@ msgid ""
 msgstr ""
 
 #. module: hr_timesheet
+#: code:addons/hr_timesheet/models/analytic_account.py:53
+#, python-format
+msgid ""
+"You cannot change the company of an analytical account if it is related to a"
+" project."
+msgstr ""
+
+#. module: hr_timesheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet.hr_employee_view_form_inherit_timesheet
 msgid "per hour"
 msgstr ""

--- a/addons/hr_timesheet/i18n/fi.po
+++ b/addons/hr_timesheet/i18n/fi.po
@@ -614,6 +614,14 @@ msgid ""
 msgstr ""
 
 #. module: hr_timesheet
+#: code:addons/hr_timesheet/models/analytic_account.py:53
+#, python-format
+msgid ""
+"You cannot change the company of an analytical account if it is related to a"
+" project."
+msgstr ""
+
+#. module: hr_timesheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet.hr_employee_view_form_inherit_timesheet
 msgid "per hour"
 msgstr "per tunti"

--- a/addons/hr_timesheet/i18n/fil.po
+++ b/addons/hr_timesheet/i18n/fil.po
@@ -584,6 +584,14 @@ msgid ""
 msgstr ""
 
 #. module: hr_timesheet
+#: code:addons/hr_timesheet/models/analytic_account.py:53
+#, python-format
+msgid ""
+"You cannot change the company of an analytical account if it is related to a"
+" project."
+msgstr ""
+
+#. module: hr_timesheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet.hr_employee_view_form_inherit_timesheet
 msgid "per hour"
 msgstr ""

--- a/addons/hr_timesheet/i18n/fr.po
+++ b/addons/hr_timesheet/i18n/fr.po
@@ -11,6 +11,7 @@
 # William Olhasque <william.olhasque@scopea.fr>, 2019
 # Mohamed BENKIRANE <benkirane.med.ali@gmail.com>, 2019
 # Cécile Collart <cco@odoo.com>, 2019
+# Priscilla Sanchez <prs@odoo.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -18,7 +19,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-01-09 10:31+0000\n"
 "PO-Revision-Date: 2018-08-24 09:19+0000\n"
-"Last-Translator: Cécile Collart <cco@odoo.com>, 2019\n"
+"Last-Translator: Priscilla Sanchez <prs@odoo.com>, 2020\n"
 "Language-Team: French (https://www.transifex.com/odoo/teams/41243/fr/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -624,6 +625,16 @@ msgstr ""
 "et par jour. Chaque temps passé sur un projet deviendra un coût dans\n"
 "le compte analytique/contrat et pourra être re-facturé au client\n"
 "si nécessaire."
+
+#. module: hr_timesheet
+#: code:addons/hr_timesheet/models/analytic_account.py:53
+#, python-format
+msgid ""
+"You cannot change the company of an analytical account if it is related to a"
+" project."
+msgstr ""
+"Vous ne pouvez pas modifier la société d'un compte analytique s'il est lié à"
+" un projet."
 
 #. module: hr_timesheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet.hr_employee_view_form_inherit_timesheet

--- a/addons/hr_timesheet/i18n/gu.po
+++ b/addons/hr_timesheet/i18n/gu.po
@@ -589,6 +589,14 @@ msgid ""
 msgstr ""
 
 #. module: hr_timesheet
+#: code:addons/hr_timesheet/models/analytic_account.py:53
+#, python-format
+msgid ""
+"You cannot change the company of an analytical account if it is related to a"
+" project."
+msgstr ""
+
+#. module: hr_timesheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet.hr_employee_view_form_inherit_timesheet
 msgid "per hour"
 msgstr ""

--- a/addons/hr_timesheet/i18n/he.po
+++ b/addons/hr_timesheet/i18n/he.po
@@ -166,7 +166,7 @@ msgstr ""
 #. module: hr_timesheet
 #: model:ir.model.fields,help:hr_timesheet.field_project_task__total_hours_spent
 msgid "Computed as: Time Spent + Sub-tasks Hours."
-msgstr ""
+msgstr "מחושב כ: זמן עבודה + זמן עבודה של תתי משימות"
 
 #. module: hr_timesheet
 #: model:ir.model.fields,help:hr_timesheet.field_project_task__effective_hours
@@ -404,12 +404,12 @@ msgstr "שעות שבוצעו"
 #. module: hr_timesheet
 #: model:ir.model.fields,field_description:hr_timesheet.field_project_task__subtask_effective_hours
 msgid "Sub-tasks Hours Spent"
-msgstr ""
+msgstr "זמן עבודה של תתי משימות"
 
 #. module: hr_timesheet
 #: model:ir.model.fields,help:hr_timesheet.field_project_task__subtask_effective_hours
 msgid "Sum of actually spent hours on the subtask(s)"
-msgstr ""
+msgstr "סכום של זמן עבודה בפועל בתתי משימות"
 
 #. module: hr_timesheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet.res_config_settings_view_form

--- a/addons/hr_timesheet/i18n/he.po
+++ b/addons/hr_timesheet/i18n/he.po
@@ -601,6 +601,14 @@ msgstr ""
 "                  עבור הלקוחות במידת הצורך."
 
 #. module: hr_timesheet
+#: code:addons/hr_timesheet/models/analytic_account.py:53
+#, python-format
+msgid ""
+"You cannot change the company of an analytical account if it is related to a"
+" project."
+msgstr ""
+
+#. module: hr_timesheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet.hr_employee_view_form_inherit_timesheet
 msgid "per hour"
 msgstr "לשעה"

--- a/addons/hr_timesheet/i18n/hr.po
+++ b/addons/hr_timesheet/i18n/hr.po
@@ -605,6 +605,14 @@ msgid ""
 msgstr ""
 
 #. module: hr_timesheet
+#: code:addons/hr_timesheet/models/analytic_account.py:53
+#, python-format
+msgid ""
+"You cannot change the company of an analytical account if it is related to a"
+" project."
+msgstr ""
+
+#. module: hr_timesheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet.hr_employee_view_form_inherit_timesheet
 msgid "per hour"
 msgstr "po satu"

--- a/addons/hr_timesheet/i18n/hr_timesheet.pot
+++ b/addons/hr_timesheet/i18n/hr_timesheet.pot
@@ -560,6 +560,12 @@ msgid "You can register and track your workings hours by project every\n"
 msgstr ""
 
 #. module: hr_timesheet
+#: code:addons/hr_timesheet/models/analytic_account.py:53
+#, python-format
+msgid "You cannot change the company of an analytical account if it is related to a project."
+msgstr ""
+
+#. module: hr_timesheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet.hr_employee_view_form_inherit_timesheet
 msgid "per hour"
 msgstr ""

--- a/addons/hr_timesheet/i18n/hu.po
+++ b/addons/hr_timesheet/i18n/hu.po
@@ -612,6 +612,14 @@ msgstr ""
 "továbbszámlázható az ügyfélnek."
 
 #. module: hr_timesheet
+#: code:addons/hr_timesheet/models/analytic_account.py:53
+#, python-format
+msgid ""
+"You cannot change the company of an analytical account if it is related to a"
+" project."
+msgstr ""
+
+#. module: hr_timesheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet.hr_employee_view_form_inherit_timesheet
 msgid "per hour"
 msgstr "óránként"

--- a/addons/hr_timesheet/i18n/id.po
+++ b/addons/hr_timesheet/i18n/id.po
@@ -612,6 +612,14 @@ msgstr ""
 "                Pelanggan jika diperlukan."
 
 #. module: hr_timesheet
+#: code:addons/hr_timesheet/models/analytic_account.py:53
+#, python-format
+msgid ""
+"You cannot change the company of an analytical account if it is related to a"
+" project."
+msgstr ""
+
+#. module: hr_timesheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet.hr_employee_view_form_inherit_timesheet
 msgid "per hour"
 msgstr ""

--- a/addons/hr_timesheet/i18n/is.po
+++ b/addons/hr_timesheet/i18n/is.po
@@ -599,6 +599,14 @@ msgid ""
 msgstr ""
 
 #. module: hr_timesheet
+#: code:addons/hr_timesheet/models/analytic_account.py:53
+#, python-format
+msgid ""
+"You cannot change the company of an analytical account if it is related to a"
+" project."
+msgstr ""
+
+#. module: hr_timesheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet.hr_employee_view_form_inherit_timesheet
 msgid "per hour"
 msgstr ""

--- a/addons/hr_timesheet/i18n/it.po
+++ b/addons/hr_timesheet/i18n/it.po
@@ -9,7 +9,7 @@
 # David Minneci <david@numeko.it>, 2018
 # Léonie Bouchat <lbo@odoo.com>, 2018
 # Martin Trigaux, 2018
-# Sergio Zanchetta <primes2h@gmail.com>, 2019
+# Sergio Zanchetta <primes2h@gmail.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -17,7 +17,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-01-09 10:31+0000\n"
 "PO-Revision-Date: 2018-08-24 09:19+0000\n"
-"Last-Translator: Sergio Zanchetta <primes2h@gmail.com>, 2019\n"
+"Last-Translator: Sergio Zanchetta <primes2h@gmail.com>, 2020\n"
 "Language-Team: Italian (https://www.transifex.com/odoo/teams/41243/it/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -196,7 +196,7 @@ msgstr "Data"
 #. module: hr_timesheet
 #: model:ir.model.fields,field_description:hr_timesheet.field_account_analytic_line__department_id
 msgid "Department"
-msgstr "Dipartimento"
+msgstr "Ufficio"
 
 #. module: hr_timesheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet.portal_my_task
@@ -620,6 +620,14 @@ msgstr ""
 "È possibile registrare e tenere traccia giornalmente delle ore di lavoro\n"
 "                per progetto. I tempi impiegati  diventano costi che, se necessario, possono\n"
 "                essere rifatturati al cliente."
+
+#. module: hr_timesheet
+#: code:addons/hr_timesheet/models/analytic_account.py:53
+#, python-format
+msgid ""
+"You cannot change the company of an analytical account if it is related to a"
+" project."
+msgstr ""
 
 #. module: hr_timesheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet.hr_employee_view_form_inherit_timesheet

--- a/addons/hr_timesheet/i18n/ja.po
+++ b/addons/hr_timesheet/i18n/ja.po
@@ -600,6 +600,14 @@ msgstr ""
 "再請求することができます。"
 
 #. module: hr_timesheet
+#: code:addons/hr_timesheet/models/analytic_account.py:53
+#, python-format
+msgid ""
+"You cannot change the company of an analytical account if it is related to a"
+" project."
+msgstr ""
+
+#. module: hr_timesheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet.hr_employee_view_form_inherit_timesheet
 msgid "per hour"
 msgstr "毎時"

--- a/addons/hr_timesheet/i18n/ka.po
+++ b/addons/hr_timesheet/i18n/ka.po
@@ -594,6 +594,14 @@ msgid ""
 msgstr ""
 
 #. module: hr_timesheet
+#: code:addons/hr_timesheet/models/analytic_account.py:53
+#, python-format
+msgid ""
+"You cannot change the company of an analytical account if it is related to a"
+" project."
+msgstr ""
+
+#. module: hr_timesheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet.hr_employee_view_form_inherit_timesheet
 msgid "per hour"
 msgstr ""

--- a/addons/hr_timesheet/i18n/kab.po
+++ b/addons/hr_timesheet/i18n/kab.po
@@ -591,6 +591,14 @@ msgid ""
 msgstr ""
 
 #. module: hr_timesheet
+#: code:addons/hr_timesheet/models/analytic_account.py:53
+#, python-format
+msgid ""
+"You cannot change the company of an analytical account if it is related to a"
+" project."
+msgstr ""
+
+#. module: hr_timesheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet.hr_employee_view_form_inherit_timesheet
 msgid "per hour"
 msgstr ""

--- a/addons/hr_timesheet/i18n/km.po
+++ b/addons/hr_timesheet/i18n/km.po
@@ -617,6 +617,14 @@ msgstr ""
 "                 អតិថិជនប្រសិនបើចាំបាច់។"
 
 #. module: hr_timesheet
+#: code:addons/hr_timesheet/models/analytic_account.py:53
+#, python-format
+msgid ""
+"You cannot change the company of an analytical account if it is related to a"
+" project."
+msgstr ""
+
+#. module: hr_timesheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet.hr_employee_view_form_inherit_timesheet
 msgid "per hour"
 msgstr "ក្នុងរយៈពេល"

--- a/addons/hr_timesheet/i18n/ko.po
+++ b/addons/hr_timesheet/i18n/ko.po
@@ -6,7 +6,7 @@
 # Martin Trigaux, 2018
 # Link Up링크업 <linkup.way@gmail.com>, 2018
 # Linkup <link-up@naver.com>, 2018
-# JH CHOI <hwangtog@gmail.com>, 2019
+# JH CHOI <hwangtog@gmail.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -14,7 +14,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-01-09 10:31+0000\n"
 "PO-Revision-Date: 2018-08-24 09:19+0000\n"
-"Last-Translator: JH CHOI <hwangtog@gmail.com>, 2019\n"
+"Last-Translator: JH CHOI <hwangtog@gmail.com>, 2020\n"
 "Language-Team: Korean (https://www.transifex.com/odoo/teams/41243/ko/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -602,6 +602,14 @@ msgstr ""
 "매일 프로젝트별 작업시간을 입력하거나 추적할 수 있습니다.\n"
 "                    프로젝트에서 모든 시간 사용은 비용으로 변경되며 \n"
 "                    필요시 청구서 재발행이 가능합니다."
+
+#. module: hr_timesheet
+#: code:addons/hr_timesheet/models/analytic_account.py:53
+#, python-format
+msgid ""
+"You cannot change the company of an analytical account if it is related to a"
+" project."
+msgstr "프로젝트와 관련된 분석 계정의 회사는 변경할 수 없습니다."
 
 #. module: hr_timesheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet.hr_employee_view_form_inherit_timesheet

--- a/addons/hr_timesheet/i18n/lt.po
+++ b/addons/hr_timesheet/i18n/lt.po
@@ -624,6 +624,14 @@ msgstr ""
 "sąskaitą klientams, jei to reikia."
 
 #. module: hr_timesheet
+#: code:addons/hr_timesheet/models/analytic_account.py:53
+#, python-format
+msgid ""
+"You cannot change the company of an analytical account if it is related to a"
+" project."
+msgstr ""
+
+#. module: hr_timesheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet.hr_employee_view_form_inherit_timesheet
 msgid "per hour"
 msgstr "per valandą"

--- a/addons/hr_timesheet/i18n/lv.po
+++ b/addons/hr_timesheet/i18n/lv.po
@@ -601,6 +601,14 @@ msgstr ""
 "                customers if required."
 
 #. module: hr_timesheet
+#: code:addons/hr_timesheet/models/analytic_account.py:53
+#, python-format
+msgid ""
+"You cannot change the company of an analytical account if it is related to a"
+" project."
+msgstr ""
+
+#. module: hr_timesheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet.hr_employee_view_form_inherit_timesheet
 msgid "per hour"
 msgstr ""

--- a/addons/hr_timesheet/i18n/mn.po
+++ b/addons/hr_timesheet/i18n/mn.po
@@ -616,6 +616,14 @@ msgstr ""
 "            "
 
 #. module: hr_timesheet
+#: code:addons/hr_timesheet/models/analytic_account.py:53
+#, python-format
+msgid ""
+"You cannot change the company of an analytical account if it is related to a"
+" project."
+msgstr ""
+
+#. module: hr_timesheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet.hr_employee_view_form_inherit_timesheet
 msgid "per hour"
 msgstr "цаг тутамд"

--- a/addons/hr_timesheet/i18n/nb.po
+++ b/addons/hr_timesheet/i18n/nb.po
@@ -599,6 +599,14 @@ msgid ""
 msgstr ""
 
 #. module: hr_timesheet
+#: code:addons/hr_timesheet/models/analytic_account.py:53
+#, python-format
+msgid ""
+"You cannot change the company of an analytical account if it is related to a"
+" project."
+msgstr ""
+
+#. module: hr_timesheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet.hr_employee_view_form_inherit_timesheet
 msgid "per hour"
 msgstr "per time"

--- a/addons/hr_timesheet/i18n/nl.po
+++ b/addons/hr_timesheet/i18n/nl.po
@@ -9,6 +9,7 @@
 # Cas Vissers <casvissers@brahoo.nl>, 2018
 # Martin Trigaux, 2018
 # Erwin van der Ploeg <erwin@odooexperts.nl>, 2020
+# Antoine Gilard <ang@odoo.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -16,7 +17,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-01-09 10:31+0000\n"
 "PO-Revision-Date: 2018-08-24 09:19+0000\n"
-"Last-Translator: Erwin van der Ploeg <erwin@odooexperts.nl>, 2020\n"
+"Last-Translator: Antoine Gilard <ang@odoo.com>, 2020\n"
 "Language-Team: Dutch (https://www.transifex.com/odoo/teams/41243/nl/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -620,6 +621,16 @@ msgid ""
 msgstr ""
 "U kan elke dag uw werkuren registeren en opvolgen per project.\n"
 "Alle tijd die gespendeerd wordt op een project wordt als kosten geboekt en kan opnieuw gefactureerd worden aan klanten indien nodig"
+
+#. module: hr_timesheet
+#: code:addons/hr_timesheet/models/analytic_account.py:53
+#, python-format
+msgid ""
+"You cannot change the company of an analytical account if it is related to a"
+" project."
+msgstr ""
+"U kunt het bedrijf van een analytische rekening niet wijzigen als deze "
+"gerelateerd is aan een project."
 
 #. module: hr_timesheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet.hr_employee_view_form_inherit_timesheet

--- a/addons/hr_timesheet/i18n/pl.po
+++ b/addons/hr_timesheet/i18n/pl.po
@@ -619,6 +619,14 @@ msgstr ""
 "                 do klienta w razie potrzeby."
 
 #. module: hr_timesheet
+#: code:addons/hr_timesheet/models/analytic_account.py:53
+#, python-format
+msgid ""
+"You cannot change the company of an analytical account if it is related to a"
+" project."
+msgstr ""
+
+#. module: hr_timesheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet.hr_employee_view_form_inherit_timesheet
 msgid "per hour"
 msgstr "na godzinę"

--- a/addons/hr_timesheet/i18n/pt.po
+++ b/addons/hr_timesheet/i18n/pt.po
@@ -4,7 +4,7 @@
 # 
 # Translators:
 # Manuela Silva <inactive+h_manuela_rodsilva@transifex.com>, 2018
-# MS <manuelarodsilva@gmail.com>, 2018
+# Manuela Silva <manuelarodsilva@gmail.com>, 2018
 # Nuno Silva <nuno.silva@arxi.pt>, 2018
 # Diogo Fonseca <dsf@thinkopensolutions.pt>, 2018
 # Martin Trigaux, 2018
@@ -600,6 +600,14 @@ msgid ""
 "You can register and track your workings hours by project every\n"
 "                day. Every time spent on a project will become a cost and can be re-invoiced to\n"
 "                customers if required."
+msgstr ""
+
+#. module: hr_timesheet
+#: code:addons/hr_timesheet/models/analytic_account.py:53
+#, python-format
+msgid ""
+"You cannot change the company of an analytical account if it is related to a"
+" project."
 msgstr ""
 
 #. module: hr_timesheet

--- a/addons/hr_timesheet/i18n/pt_BR.po
+++ b/addons/hr_timesheet/i18n/pt_BR.po
@@ -14,7 +14,7 @@
 # Mateus Lopes <mateus1@gmail.com>, 2018
 # Lauro de Lima <lauro@ciclix.com>, 2019
 # Marcel Savegnago <marcel.savegnago@gmail.com>, 2020
-# Luiz Fernando Gondin <lfpsgs@outlook.com>, 2020
+# Luiz Fernando <lfpsgs@outlook.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -22,7 +22,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-01-09 10:31+0000\n"
 "PO-Revision-Date: 2018-08-24 09:19+0000\n"
-"Last-Translator: Luiz Fernando Gondin <lfpsgs@outlook.com>, 2020\n"
+"Last-Translator: Luiz Fernando <lfpsgs@outlook.com>, 2020\n"
 "Language-Team: Portuguese (Brazil) (https://www.transifex.com/odoo/teams/41243/pt_BR/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -609,6 +609,14 @@ msgid ""
 "You can register and track your workings hours by project every\n"
 "                day. Every time spent on a project will become a cost and can be re-invoiced to\n"
 "                customers if required."
+msgstr ""
+
+#. module: hr_timesheet
+#: code:addons/hr_timesheet/models/analytic_account.py:53
+#, python-format
+msgid ""
+"You cannot change the company of an analytical account if it is related to a"
+" project."
 msgstr ""
 
 #. module: hr_timesheet

--- a/addons/hr_timesheet/i18n/ro.po
+++ b/addons/hr_timesheet/i18n/ro.po
@@ -606,6 +606,14 @@ msgstr ""
 "poate fi re-facturat clienților, dacă este necesar."
 
 #. module: hr_timesheet
+#: code:addons/hr_timesheet/models/analytic_account.py:53
+#, python-format
+msgid ""
+"You cannot change the company of an analytical account if it is related to a"
+" project."
+msgstr ""
+
+#. module: hr_timesheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet.hr_employee_view_form_inherit_timesheet
 msgid "per hour"
 msgstr ""

--- a/addons/hr_timesheet/i18n/ru.po
+++ b/addons/hr_timesheet/i18n/ru.po
@@ -621,6 +621,14 @@ msgstr ""
 "анализа клиентам будут выставлены дополнительные счета."
 
 #. module: hr_timesheet
+#: code:addons/hr_timesheet/models/analytic_account.py:53
+#, python-format
+msgid ""
+"You cannot change the company of an analytical account if it is related to a"
+" project."
+msgstr ""
+
+#. module: hr_timesheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet.hr_employee_view_form_inherit_timesheet
 msgid "per hour"
 msgstr "на час"

--- a/addons/hr_timesheet/i18n/sk.po
+++ b/addons/hr_timesheet/i18n/sk.po
@@ -619,6 +619,14 @@ msgstr ""
 " zákazníkovi v prípade potreby."
 
 #. module: hr_timesheet
+#: code:addons/hr_timesheet/models/analytic_account.py:53
+#, python-format
+msgid ""
+"You cannot change the company of an analytical account if it is related to a"
+" project."
+msgstr ""
+
+#. module: hr_timesheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet.hr_employee_view_form_inherit_timesheet
 msgid "per hour"
 msgstr "za hodinu"

--- a/addons/hr_timesheet/i18n/sl.po
+++ b/addons/hr_timesheet/i18n/sl.po
@@ -602,6 +602,14 @@ msgstr ""
 "                po potrebi zaračuna kupcu."
 
 #. module: hr_timesheet
+#: code:addons/hr_timesheet/models/analytic_account.py:53
+#, python-format
+msgid ""
+"You cannot change the company of an analytical account if it is related to a"
+" project."
+msgstr ""
+
+#. module: hr_timesheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet.hr_employee_view_form_inherit_timesheet
 msgid "per hour"
 msgstr "na uro"

--- a/addons/hr_timesheet/i18n/so.po
+++ b/addons/hr_timesheet/i18n/so.po
@@ -584,6 +584,14 @@ msgid ""
 msgstr ""
 
 #. module: hr_timesheet
+#: code:addons/hr_timesheet/models/analytic_account.py:53
+#, python-format
+msgid ""
+"You cannot change the company of an analytical account if it is related to a"
+" project."
+msgstr ""
+
+#. module: hr_timesheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet.hr_employee_view_form_inherit_timesheet
 msgid "per hour"
 msgstr ""

--- a/addons/hr_timesheet/i18n/sr.po
+++ b/addons/hr_timesheet/i18n/sr.po
@@ -591,6 +591,14 @@ msgid ""
 msgstr ""
 
 #. module: hr_timesheet
+#: code:addons/hr_timesheet/models/analytic_account.py:53
+#, python-format
+msgid ""
+"You cannot change the company of an analytical account if it is related to a"
+" project."
+msgstr ""
+
+#. module: hr_timesheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet.hr_employee_view_form_inherit_timesheet
 msgid "per hour"
 msgstr ""

--- a/addons/hr_timesheet/i18n/sv.po
+++ b/addons/hr_timesheet/i18n/sv.po
@@ -3,7 +3,7 @@
 # * hr_timesheet
 # 
 # Translators:
-# Kristoffer Grundström <hamnisdude@gmail.com>, 2019
+# Kristoffer Grundström <lovaren@gmail.com>, 2019
 # Martin Trigaux, 2019
 # Anders Wallenquist <anders.wallenquist@vertel.se>, 2019
 # Christelle Wehbe <libanon_cristelle@hotmail.com>, 2019
@@ -596,6 +596,14 @@ msgid ""
 "You can register and track your workings hours by project every\n"
 "                day. Every time spent on a project will become a cost and can be re-invoiced to\n"
 "                customers if required."
+msgstr ""
+
+#. module: hr_timesheet
+#: code:addons/hr_timesheet/models/analytic_account.py:53
+#, python-format
+msgid ""
+"You cannot change the company of an analytical account if it is related to a"
+" project."
 msgstr ""
 
 #. module: hr_timesheet

--- a/addons/hr_timesheet/i18n/ta.po
+++ b/addons/hr_timesheet/i18n/ta.po
@@ -590,6 +590,14 @@ msgid ""
 msgstr ""
 
 #. module: hr_timesheet
+#: code:addons/hr_timesheet/models/analytic_account.py:53
+#, python-format
+msgid ""
+"You cannot change the company of an analytical account if it is related to a"
+" project."
+msgstr ""
+
+#. module: hr_timesheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet.hr_employee_view_form_inherit_timesheet
 msgid "per hour"
 msgstr ""

--- a/addons/hr_timesheet/i18n/th.po
+++ b/addons/hr_timesheet/i18n/th.po
@@ -590,6 +590,14 @@ msgid ""
 msgstr ""
 
 #. module: hr_timesheet
+#: code:addons/hr_timesheet/models/analytic_account.py:53
+#, python-format
+msgid ""
+"You cannot change the company of an analytical account if it is related to a"
+" project."
+msgstr ""
+
+#. module: hr_timesheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet.hr_employee_view_form_inherit_timesheet
 msgid "per hour"
 msgstr ""

--- a/addons/hr_timesheet/i18n/tr.po
+++ b/addons/hr_timesheet/i18n/tr.po
@@ -625,6 +625,14 @@ msgstr ""
 "eğer müşteri arzu ederse yeniden faturalanacaktır."
 
 #. module: hr_timesheet
+#: code:addons/hr_timesheet/models/analytic_account.py:53
+#, python-format
+msgid ""
+"You cannot change the company of an analytical account if it is related to a"
+" project."
+msgstr ""
+
+#. module: hr_timesheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet.hr_employee_view_form_inherit_timesheet
 msgid "per hour"
 msgstr "saat başına"

--- a/addons/hr_timesheet/i18n/uk.po
+++ b/addons/hr_timesheet/i18n/uk.po
@@ -619,6 +619,14 @@ msgstr ""
 "                 клієнтів, якщо це необхідно."
 
 #. module: hr_timesheet
+#: code:addons/hr_timesheet/models/analytic_account.py:53
+#, python-format
+msgid ""
+"You cannot change the company of an analytical account if it is related to a"
+" project."
+msgstr ""
+
+#. module: hr_timesheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet.hr_employee_view_form_inherit_timesheet
 msgid "per hour"
 msgstr "на годину"

--- a/addons/hr_timesheet/i18n/vi.po
+++ b/addons/hr_timesheet/i18n/vi.po
@@ -625,6 +625,14 @@ msgstr ""
 "                Thời gian được sử dụng cho dự án có thể trở thành chi phí                 và có thể xuất hoá đơn cho khách hàng theo đó nếu cần thiết."
 
 #. module: hr_timesheet
+#: code:addons/hr_timesheet/models/analytic_account.py:53
+#, python-format
+msgid ""
+"You cannot change the company of an analytical account if it is related to a"
+" project."
+msgstr ""
+
+#. module: hr_timesheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet.hr_employee_view_form_inherit_timesheet
 msgid "per hour"
 msgstr "mỗi giờ"

--- a/addons/hr_timesheet/i18n/zh_CN.po
+++ b/addons/hr_timesheet/i18n/zh_CN.po
@@ -604,6 +604,14 @@ msgstr ""
 " 天可以按项目登记并跟踪工作时间。在项目上花费的每段时间都将产生费用"
 
 #. module: hr_timesheet
+#: code:addons/hr_timesheet/models/analytic_account.py:53
+#, python-format
+msgid ""
+"You cannot change the company of an analytical account if it is related to a"
+" project."
+msgstr ""
+
+#. module: hr_timesheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet.hr_employee_view_form_inherit_timesheet
 msgid "per hour"
 msgstr "每小时"

--- a/addons/hr_timesheet/i18n/zh_TW.po
+++ b/addons/hr_timesheet/i18n/zh_TW.po
@@ -599,6 +599,14 @@ msgstr ""
 " 客戶重新開具發票。"
 
 #. module: hr_timesheet
+#: code:addons/hr_timesheet/models/analytic_account.py:53
+#, python-format
+msgid ""
+"You cannot change the company of an analytical account if it is related to a"
+" project."
+msgstr ""
+
+#. module: hr_timesheet
 #: model_terms:ir.ui.view,arch_db:hr_timesheet.hr_employee_view_form_inherit_timesheet
 msgid "per hour"
 msgstr "每小時"

--- a/addons/hr_timesheet/models/analytic_account.py
+++ b/addons/hr_timesheet/models/analytic_account.py
@@ -44,3 +44,9 @@ class AccountAnalyticAccount(models.Model):
             result['views'] = [(False, "form")]
             result['res_id'] = self.project_ids.id
         return result
+
+    @api.constrains('company_id')
+    def _check_company_id(self):
+        for record in self:
+            if record.project_ids:
+                raise UserError(_('You cannot change the company of an analytical account if it is related to a project.'))

--- a/addons/hw_drivers/controllers/driver.py
+++ b/addons/hw_drivers/controllers/driver.py
@@ -331,15 +331,17 @@ class Manager(Thread):
         x_screen = 0
         for match in finditer('Display Number (\d), type HDMI (\d)', displays):
             display_id, hdmi_id = match.groups()
-            display_name = subprocess.check_output(['tvservice', '-nv', display_id]).decode().rstrip().split('=')[1]
-            display_identifier = sub('[^a-zA-Z0-9 ]+', '', display_name).replace(' ', '_') + "_" + str(hdmi_id)
-            iot_device = IoTDevice({
-                'identifier': display_identifier,
-                'name': display_name,
-                'x_screen': str(x_screen),
-            }, 'display')
-            display_devices[display_identifier] = iot_device
-            x_screen += 1
+            tvservice_output = subprocess.check_output(['tvservice', '-nv', display_id]).decode().rstrip()
+            if tvservice_output:
+                display_name = tvservice_output.split('=')[1]
+                display_identifier = sub('[^a-zA-Z0-9 ]+', '', display_name).replace(' ', '_') + "_" + str(hdmi_id)
+                iot_device = IoTDevice({
+                    'identifier': display_identifier,
+                    'name': display_name,
+                    'x_screen': str(x_screen),
+                }, 'display')
+                display_devices[display_identifier] = iot_device
+                x_screen += 1
 
         if not len(display_devices):
             # No display connected, create "fake" device to be accessed from another computer

--- a/addons/im_livechat/i18n/et.po
+++ b/addons/im_livechat/i18n/et.po
@@ -583,6 +583,9 @@ msgid ""
 "image, with aspect ratio preserved. Use this field in form views or some "
 "kanban views."
 msgstr ""
+"Grupi keskmise suurusega foto. Selle suurust muudetakse automaatselt 128x128"
+" pikslise suurusega pildiks, kuvasuhe säilitatakse. Kasutage seda välja "
+"vormivaate või mõne kanbani vaatena."
 
 #. module: im_livechat
 #: model_terms:ir.ui.view,arch_db:im_livechat.im_livechat_report_channel_view_search

--- a/addons/im_livechat/i18n/eu.po
+++ b/addons/im_livechat/i18n/eu.po
@@ -13,6 +13,7 @@
 # Victor Laskurain <blaskurain@binovo.es>, 2019
 # Iñaki Ibarrola <inakiibarrola@yahoo.es>, 2020
 # Maialen Rodriguez <maialenrodriguez98@gmail.com>, 2020
+# Mikel Galarza <mikelgalarza99@gmail.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -20,7 +21,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-01-09 10:32+0000\n"
 "PO-Revision-Date: 2018-08-24 09:19+0000\n"
-"Last-Translator: Maialen Rodriguez <maialenrodriguez98@gmail.com>, 2020\n"
+"Last-Translator: Mikel Galarza <mikelgalarza99@gmail.com>, 2020\n"
 "Language-Team: Basque (https://www.transifex.com/odoo/teams/41243/eu/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -80,7 +81,7 @@ msgstr "Ekintza"
 #. module: im_livechat
 #: model_terms:ir.ui.view,arch_db:im_livechat.mail_channel_view_form
 msgid "Anonymous"
-msgstr ""
+msgstr "Anonimoa"
 
 #. module: im_livechat
 #: model:ir.model.fields,field_description:im_livechat.field_mail_channel__anonymous_name
@@ -204,7 +205,7 @@ msgstr "Kanalak "
 #. module: im_livechat
 #: selection:mail.channel,channel_type:0
 msgid "Chat Discussion"
-msgstr ""
+msgstr "Txat Eztabaida "
 
 #. module: im_livechat
 #: model:ir.model.fields,field_description:im_livechat.field_im_livechat_channel__input_placeholder

--- a/addons/im_livechat/i18n/eu.po
+++ b/addons/im_livechat/i18n/eu.po
@@ -13,7 +13,8 @@
 # Victor Laskurain <blaskurain@binovo.es>, 2019
 # Iñaki Ibarrola <inakiibarrola@yahoo.es>, 2020
 # Maialen Rodriguez <maialenrodriguez98@gmail.com>, 2020
-# Mikel Galarza <mikelgalarza99@gmail.com>, 2020
+# mgalarza005 <mikelgalarza99@gmail.com>, 2020
+# Unai Muñoz <unaimunoz9@gmail.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -21,7 +22,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-01-09 10:32+0000\n"
 "PO-Revision-Date: 2018-08-24 09:19+0000\n"
-"Last-Translator: Mikel Galarza <mikelgalarza99@gmail.com>, 2020\n"
+"Last-Translator: Unai Muñoz <unaimunoz9@gmail.com>, 2020\n"
 "Language-Team: Basque (https://www.transifex.com/odoo/teams/41243/eu/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -48,7 +49,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:im_livechat.field_im_livechat_channel__rating_percentage_satisfaction
 #: model_terms:ir.ui.view,arch_db:im_livechat.im_livechat_channel_view_form
 msgid "% Happy"
-msgstr ""
+msgstr "% Pozik"
 
 #. module: im_livechat
 #: model:ir.model.fields,help:im_livechat.field_im_livechat_channel_rule__action
@@ -381,7 +382,7 @@ msgstr ""
 #: code:addons/im_livechat/static/src/xml/im_livechat.xml:11
 #, python-format
 msgid "Good"
-msgstr ""
+msgstr "Ondo"
 
 #. module: im_livechat
 #: model_terms:ir.ui.view,arch_db:im_livechat.im_livechat_report_channel_view_search

--- a/addons/im_livechat/i18n/fr.po
+++ b/addons/im_livechat/i18n/fr.po
@@ -9,6 +9,7 @@
 # thomas quertinmont <tqu@odoo.com>, 2019
 # Eloïse Stilmant <est@odoo.com>, 2020
 # Cécile Collart <cco@odoo.com>, 2020
+# Jonathan Quique <jqu@odoo.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -16,7 +17,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-01-09 10:32+0000\n"
 "PO-Revision-Date: 2018-08-24 09:19+0000\n"
-"Last-Translator: Cécile Collart <cco@odoo.com>, 2020\n"
+"Last-Translator: Jonathan Quique <jqu@odoo.com>, 2020\n"
 "Language-Team: French (https://www.transifex.com/odoo/teams/41243/fr/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -534,7 +535,7 @@ msgstr "Canal de Live Chat"
 #. module: im_livechat
 #: model:ir.model,name:im_livechat.model_im_livechat_channel_rule
 msgid "Livechat Channel Rules"
-msgstr ""
+msgstr "Règles du canal de Live Chat"
 
 #. module: im_livechat
 #: selection:mail.channel,channel_type:0
@@ -544,7 +545,7 @@ msgstr "Salon de Live Chat"
 #. module: im_livechat
 #: model:ir.model,name:im_livechat.model_im_livechat_report_channel
 msgid "Livechat Support Channel Report"
-msgstr ""
+msgstr "Rapport du canal d'assistance en ligne"
 
 #. module: im_livechat
 #: model_terms:ir.actions.act_window,help:im_livechat.im_livechat_report_channel_action
@@ -562,7 +563,7 @@ msgstr ""
 #. module: im_livechat
 #: model:ir.model,name:im_livechat.model_im_livechat_report_operator
 msgid "Livechat Support Operator Report"
-msgstr ""
+msgstr "Rapport de l'opérateur d'assistance en ligne"
 
 #. module: im_livechat
 #: model:ir.actions.act_window,name:im_livechat.im_livechat_report_channel_action
@@ -987,7 +988,7 @@ msgstr "Widget"
 #. module: im_livechat
 #: model_terms:ir.ui.view,arch_db:im_livechat.mail_channel_view_search
 msgid "With Messages"
-msgstr ""
+msgstr "Avec les messages"
 
 #. module: im_livechat
 #: model_terms:ir.actions.act_window,help:im_livechat.im_livechat_channel_action

--- a/addons/im_livechat/i18n/he.po
+++ b/addons/im_livechat/i18n/he.po
@@ -709,7 +709,7 @@ msgstr ""
 #. module: im_livechat
 #: model_terms:ir.ui.view,arch_db:im_livechat.im_livechat_channel_view_kanban
 msgid "Rating: Okay"
-msgstr ""
+msgstr "דירוג: בסדר"
 
 #. module: im_livechat
 #: model:ir.actions.act_window,name:im_livechat.rating_rating_action_view_livechat_rating

--- a/addons/im_livechat_mail_bot/i18n/fr.po
+++ b/addons/im_livechat_mail_bot/i18n/fr.po
@@ -3,15 +3,17 @@
 # * im_livechat_mail_bot
 # 
 # Translators:
-# Eloïse Stilmant <est@odoo.com>, 2018
 # Martin Trigaux, 2018
+# Eloïse Stilmant <est@odoo.com>, 2018
+# Priscilla Sanchez <prs@odoo.com>, 2020
+# 
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server saas~11.5\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2018-10-02 10:05+0000\n"
-"PO-Revision-Date: 2018-10-02 10:05+0000\n"
-"Last-Translator: Martin Trigaux, 2018\n"
+"PO-Revision-Date: 2018-08-24 09:20+0000\n"
+"Last-Translator: Priscilla Sanchez <prs@odoo.com>, 2020\n"
 "Language-Team: French (https://www.transifex.com/odoo/teams/41243/fr/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -44,7 +46,7 @@ msgstr "Inactif"
 #. module: im_livechat_mail_bot
 #: model:ir.model,name:im_livechat_mail_bot.model_mail_bot
 msgid "Mail Bot"
-msgstr ""
+msgstr "Mail Bot"
 
 #. module: im_livechat_mail_bot
 #: selection:res.users,odoobot_state:0
@@ -69,17 +71,17 @@ msgstr "Statut OdooBot"
 #. module: im_livechat_mail_bot
 #: selection:res.users,odoobot_state:0
 msgid "Onboarding attachement"
-msgstr ""
+msgstr "Accessoire d'intégration"
 
 #. module: im_livechat_mail_bot
 #: selection:res.users,odoobot_state:0
 msgid "Onboarding canned"
-msgstr ""
+msgstr "Onboarding canned"
 
 #. module: im_livechat_mail_bot
 #: selection:res.users,odoobot_state:0
 msgid "Onboarding command"
-msgstr ""
+msgstr "Commande d'intégration"
 
 #. module: im_livechat_mail_bot
 #: selection:res.users,odoobot_state:0
@@ -89,7 +91,7 @@ msgstr "Emoji Onboarding"
 #. module: im_livechat_mail_bot
 #: selection:res.users,odoobot_state:0
 msgid "Onboarding ping"
-msgstr ""
+msgstr "Ping d'intégration"
 
 #. module: im_livechat_mail_bot
 #: code:addons/im_livechat_mail_bot/models/mail_bot.py:15

--- a/addons/im_livechat_mail_bot/i18n/ro.po
+++ b/addons/im_livechat_mail_bot/i18n/ro.po
@@ -4,13 +4,15 @@
 # 
 # Translators:
 # Martin Trigaux, 2018
+# Dorin Hongu <dhongu@gmail.com>, 2020
+# 
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server saas~11.5\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2018-10-02 10:05+0000\n"
-"PO-Revision-Date: 2018-10-02 10:05+0000\n"
-"Last-Translator: Martin Trigaux, 2018\n"
+"PO-Revision-Date: 2018-08-24 09:20+0000\n"
+"Last-Translator: Dorin Hongu <dhongu@gmail.com>, 2020\n"
 "Language-Team: Romanian (https://www.transifex.com/odoo/teams/41243/ro/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -21,7 +23,7 @@ msgstr ""
 #. module: im_livechat_mail_bot
 #: selection:res.users,odoobot_state:0
 msgid "Disabled"
-msgstr ""
+msgstr "Dezactivat"
 
 #. module: im_livechat_mail_bot
 #: code:addons/im_livechat_mail_bot/models/mail_bot.py:18

--- a/addons/l10n_ch/__manifest__.py
+++ b/addons/l10n_ch/__manifest__.py
@@ -25,7 +25,7 @@ Here is how it works:
     - Printing the invoice will trigger the download of two files: the invoice, and its ISR
     - Clicking the 'Send by mail' button will attach two files to your draft mail : the invoice, and the corresponding ISR.
     """,
-    'version': '10.0',
+    'version': '11.0',
     'author': 'Odoo S.A',
     'category': 'Localization',
 

--- a/addons/l10n_ch/migrations/0.0.0/pre-migrate-qr-template.py
+++ b/addons/l10n_ch/migrations/0.0.0/pre-migrate-qr-template.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+
+
+def migrate(cr, version):
+    """ From 12.0, to saas-13.3, l10n_ch_swissqr_template
+    used to inherit from another template. This isn't the case
+    anymore since https://github.com/odoo/odoo/commit/719f087b1b5be5f1f276a0f87670830d073f6ef4
+    (made in 12.0, and forward-ported). The module will not be updatable if we
+    don't manually clean inherit_id.
+    """
+    cr.execute("""
+        update ir_ui_view v
+        set inherit_id = NULL, mode='primary'
+        from ir_model_data mdata
+        where
+        v.id = mdata.res_id
+        and mdata.model= 'ir.ui.view'
+        and mdata.name = 'l10n_ch_swissqr_template'
+        and mdata.module='l10n_ch';
+    """)

--- a/addons/l10n_ch/models/account_invoice.py
+++ b/addons/l10n_ch/models/account_invoice.py
@@ -170,12 +170,25 @@ class AccountInvoice(models.Model):
                                    - associate this bank with a postal reference for the currency used in this invoice\n
                                    - fill the 'bank account' field of the invoice with the postal to be used to receive the related payment. A default account will be automatically set for all invoices created after you defined a postal account for your company."""))
 
+    def can_generate_qr_bill(self):
+        """ Returns True iff the invoice can be used to generate a QR-bill.
+        """
+        self.ensure_one()
+
+        # First part of this condition is due to fix commit https://github.com/odoo/odoo/commit/719f087b1b5be5f1f276a0f87670830d073f6ef4
+        # We do that to ensure not to try generating QR-bills for modules that haven't been
+        # updated yet. Not doing that could crash when trying to send an invoice by mail,
+        # as the QR report data haven't been loaded.
+        # TODO: remove this in master
+        return not self.env.ref('l10n_ch.l10n_ch_swissqr_template').inherit_id \
+               and self.partner_bank_id.validate_swiss_code_arguments(self.partner_bank_id.currency_id, self.partner_id, self.reference)
+
     def print_ch_qr_bill(self):
         """ Triggered by the 'Print QR-bill' button.
         """
         self.ensure_one()
 
-        if not self.partner_bank_id.validate_swiss_code_arguments(self.partner_bank_id.currency_id, self.partner_id, self.reference):
+        if not self.can_generate_qr_bill():
             raise UserError(_("Cannot generate the QR-bill. Please check you have configured the address of your company and debtor. If you are using a QR-IBAN, also check the invoice's payment reference is a QR reference."))
 
         self.l10n_ch_isr_sent = True

--- a/addons/l10n_ch/models/mail_template.py
+++ b/addons/l10n_ch/models/mail_template.py
@@ -29,21 +29,26 @@ class MailTemplate(models.Model):
         for res_id in res_ids:
             related_model = self.env[self.model_id.model].browse(res_id)
 
-            if related_model._name == 'account.invoice' and related_model.l10n_ch_isr_valid:
-                #We add an attachment containing the ISR
+            if related_model._name == 'account.invoice':
+
                 template = res_ids_to_templates[res_id]
                 inv_print_name = self._render_template(template.report_name, template.model, res_id)
+                new_attachments = []
 
-                isr_report_name = 'ISR-' + inv_print_name + '.pdf'
-                qr_report_name = 'QR-bill-' + inv_print_name + '.pdf'
+                if related_model.l10n_ch_isr_valid:
+                    # We add an attachment containing the ISR
+                    isr_report_name = 'ISR-' + inv_print_name + '.pdf'
+                    isr_pdf = self.env.ref('l10n_ch.l10n_ch_isr_report').render_qweb_pdf([res_id])[0]
+                    isr_pdf = base64.b64encode(isr_pdf)
+                    new_attachments.append((isr_report_name, isr_pdf))
 
-                isr_pdf = self.env.ref('l10n_ch.l10n_ch_isr_report').render_qweb_pdf([res_id])[0]
-                isr_pdf = base64.b64encode(isr_pdf)
+                if related_model.can_generate_qr_bill():
+                    # We add an attachment containing the QR-bill
+                    qr_report_name = 'QR-bill-' + inv_print_name + '.pdf'
+                    qr_pdf = self.env.ref('l10n_ch.l10n_ch_qr_report').render_qweb_pdf([res_id])[0]
+                    qr_pdf = base64.b64encode(qr_pdf)
+                    new_attachments.append((qr_report_name, qr_pdf))
 
-                qr_pdf = self.env.ref('l10n_ch.l10n_ch_qr_report').render_qweb_pdf([res_id])[0]
-                qr_pdf = base64.b64encode(qr_pdf)
-
-                new_attachments = [(isr_report_name, isr_pdf), (qr_report_name, qr_pdf)]
                 attachments_list = multi_mode and rslt[res_id].get('attachments', False) or rslt.get('attachments', False)
                 if attachments_list:
                     attachments_list.extend(new_attachments)

--- a/addons/link_tracker/i18n/fr.po
+++ b/addons/link_tracker/i18n/fr.po
@@ -5,13 +5,15 @@
 # Translators:
 # Martin Trigaux, 2018
 # Eloïse Stilmant <est@odoo.com>, 2018
+# Priscilla Sanchez <prs@odoo.com>, 2020
+# 
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server saas~11.5\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2018-09-21 13:17+0000\n"
-"PO-Revision-Date: 2018-09-21 13:17+0000\n"
-"Last-Translator: Eloïse Stilmant <est@odoo.com>, 2018\n"
+"PO-Revision-Date: 2018-08-24 09:20+0000\n"
+"Last-Translator: Priscilla Sanchez <prs@odoo.com>, 2020\n"
 "Language-Team: French (https://www.transifex.com/odoo/teams/41243/fr/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -140,12 +142,12 @@ msgstr "Surveillance de liens"
 #. module: link_tracker
 #: model:ir.model,name:link_tracker.model_link_tracker_click
 msgid "Link Tracker Click"
-msgstr ""
+msgstr "Lien Tracker Click"
 
 #. module: link_tracker
 #: model:ir.model,name:link_tracker.model_link_tracker_code
 msgid "Link Tracker Code"
-msgstr ""
+msgstr "Code de suivi des liens"
 
 #. module: link_tracker
 #: model:ir.model.fields,field_description:link_tracker.field_link_tracker__medium_id

--- a/addons/lunch/i18n/hu.po
+++ b/addons/lunch/i18n/hu.po
@@ -7,7 +7,7 @@
 # krnkris, 2018
 # gezza <geza.nagy@oregional.hu>, 2018
 # Ákos Nagy <akos.nagy@oregional.hu>, 2018
-# Tamás Németh <ntomasz81@gmail.com>, 2019
+# Tamás Németh <ntomasz81@gmail.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -15,7 +15,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-01-09 10:32+0000\n"
 "PO-Revision-Date: 2018-08-24 09:20+0000\n"
-"Last-Translator: Tamás Németh <ntomasz81@gmail.com>, 2019\n"
+"Last-Translator: Tamás Németh <ntomasz81@gmail.com>, 2020\n"
 "Language-Team: Hungarian (https://www.transifex.com/odoo/teams/41243/hu/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -769,7 +769,7 @@ msgstr "Megjegyzés"
 #. module: lunch
 #: model_terms:ir.actions.act_window,help:lunch.lunch_order_line_action_by_supplier
 msgid "Nothing to order today"
-msgstr ""
+msgstr "Ma nincs rendelés"
 
 #. module: lunch
 #: code:addons/lunch/models/lunch.py:318

--- a/addons/mail/i18n/et.po
+++ b/addons/mail/i18n/et.po
@@ -251,7 +251,7 @@ msgstr ""
 #: code:addons/mail/static/src/js/models/threads/create_mode_document_thread.js:65
 #, python-format
 msgid "<p>Creating a new record...</p>"
-msgstr ""
+msgstr "​<p>Loo uus kirje...</p>"
 
 #. module: mail
 #: model_terms:ir.ui.view,arch_db:mail.email_compose_message_wizard_form
@@ -315,7 +315,7 @@ msgstr ""
 #. module: mail
 #: model_terms:ir.ui.view,arch_db:mail.message_activity_done
 msgid "<strong> Feedback</strong>"
-msgstr ""
+msgstr "<strong> Tagasiside</strong>"
 
 #. module: mail
 #: model_terms:ir.ui.view,arch_db:mail.message_notification_email
@@ -523,7 +523,7 @@ msgstr "Lisa kanaleid"
 #. module: mail
 #: model_terms:ir.ui.view,arch_db:mail.mail_blacklist_view_form
 msgid "Add Email Blacklist"
-msgstr ""
+msgstr "Lisage must nimekiri"
 
 #. module: mail
 #. openerp-web
@@ -546,7 +546,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:mail.field_mail_mail__add_sign
 #: model:ir.model.fields,field_description:mail.field_mail_message__add_sign
 msgid "Add Sign"
-msgstr ""
+msgstr "Lisa märk"
 
 #. module: mail
 #: model:ir.model.fields,field_description:mail.field_email_template_preview__user_signature
@@ -578,7 +578,7 @@ msgstr "Lisa privaatne kanal"
 #. module: mail
 #: model_terms:ir.actions.act_window,help:mail.mail_blacklist_action
 msgid "Add an email address in the blacklist"
-msgstr ""
+msgstr "Lisage e-posti aadress musta nimekirja"
 
 #. module: mail
 #. openerp-web
@@ -596,7 +596,7 @@ msgstr "Lisa kanaleid, mida teavitada ..."
 #: model_terms:ir.ui.view,arch_db:mail.email_compose_message_wizard_form
 #: model_terms:ir.ui.view,arch_db:mail.mail_wizard_invite_form
 msgid "Add contacts to notify..."
-msgstr "Lis akontaktid, keda teavitada ..."
+msgstr "Lisa kontaktid, keda teavitada ..."
 
 #. module: mail
 #. openerp-web
@@ -692,7 +692,7 @@ msgstr "Aliased"
 #: code:addons/mail/static/src/xml/systray.xml:31
 #, python-format
 msgid "All"
-msgstr "All"
+msgstr "Kõik"
 
 #. module: mail
 #. openerp-web
@@ -887,7 +887,7 @@ msgstr "Automaane kustutamine"
 #: model:ir.model.fields,field_description:mail.field_mail_activity__force_next
 #: model:ir.model.fields,field_description:mail.field_mail_activity_type__force_next
 msgid "Auto Schedule Next Activity"
-msgstr ""
+msgstr "Järgmise tegevuse automaatne ajakava"
 
 #. module: mail
 #: model_terms:ir.ui.view,arch_db:mail.mail_channel_view_form
@@ -917,7 +917,7 @@ msgstr ""
 #. module: mail
 #: model:ir.model.fields,field_description:mail.field_mail_channel__moderation_notify
 msgid "Automatic notification"
-msgstr ""
+msgstr "Automaatteavitus"
 
 #. module: mail
 #. openerp-web
@@ -970,12 +970,12 @@ msgstr "Parimate tervitustega,"
 #: model:ir.model.fields,field_description:mail.field_res_partner__is_blacklisted
 #: model:ir.model.fields,field_description:mail.field_res_users__is_blacklisted
 msgid "Blacklist"
-msgstr ""
+msgstr "Must nimekiri"
 
 #. module: mail
 #: model_terms:ir.ui.view,arch_db:mail.mail_blacklist_view_tree
 msgid "Blacklist Date"
-msgstr ""
+msgstr "Must nimekiri"
 
 #. module: mail
 #: model:ir.model.fields,field_description:mail.field_email_template_preview__body_html
@@ -1124,7 +1124,7 @@ msgstr "Allikas"
 #. module: mail
 #: model:ir.model.fields,field_description:mail.field_mail_channel__channel_message_ids
 msgid "Channel Message"
-msgstr ""
+msgstr "Kanali sõnum"
 
 #. module: mail
 #: model:ir.ui.menu,name:mail.mail_moderation_menu
@@ -1269,7 +1269,7 @@ msgstr "Ettevõtted"
 #: model_terms:ir.ui.view,arch_db:mail.email_compose_message_wizard_form
 #, python-format
 msgid "Compose Email"
-msgstr "Koosta e-maili"
+msgstr "Koosta e-kiri"
 
 #. module: mail
 #: model:ir.model.fields,field_description:mail.field_mail_compose_message__composition_mode
@@ -1303,7 +1303,7 @@ msgstr "Õnnitleme! Sinu postkast on tühi!"
 #. module: mail
 #: selection:mail.notification,failure_type:0
 msgid "Connection failed (outgoing mail server problem)"
-msgstr ""
+msgstr "Ühenduse loomine ebaõnnestus (väljamineva e-posti serveri probleem)"
 
 #. module: mail
 #: model:ir.model,name:mail.model_res_partner
@@ -1356,13 +1356,13 @@ msgstr "Loo %s"
 #. module: mail
 #: selection:ir.actions.server,state:0
 msgid "Create Next Activity"
-msgstr ""
+msgstr "Looge järgmine tegevus"
 
 #. module: mail
 #: code:addons/mail/models/mail_thread.py:400
 #, python-format
 msgid "Create a new %(document)s"
-msgstr ""
+msgstr "Loo uus %(document)s"
 
 #. module: mail
 #: code:addons/mail/models/mail_thread.py:392
@@ -1452,7 +1452,7 @@ msgstr ""
 #. module: mail
 #: model:ir.model.fields,help:mail.field_mail_channel__is_moderator
 msgid "Current user is a moderator of the channel"
-msgstr ""
+msgstr "Praegune kasutaja on kanali moderaator"
 
 #. module: mail
 #: model:ir.model.fields,field_description:mail.field_mail_compose_message__date
@@ -1539,7 +1539,7 @@ msgstr ""
 #. module: mail
 #: model:ir.model.fields,field_description:mail.field_mail_activity_type__delay_from
 msgid "Delay Type"
-msgstr "Delay Type"
+msgstr "Viivituse tüüp"
 
 #. module: mail
 #: model:ir.model.fields,field_description:mail.field_mail_activity_type__delay_unit
@@ -1835,7 +1835,7 @@ msgstr "Muuda tellimust"
 #: selection:mail.compose.message,message_type:0
 #: selection:mail.message,message_type:0
 msgid "Email"
-msgstr "E-mail"
+msgstr "E-post"
 
 #. module: mail
 #: model:ir.model.fields,field_description:mail.field_mail_blacklist__email
@@ -1860,7 +1860,7 @@ msgstr ""
 #. module: mail
 #: model_terms:ir.ui.view,arch_db:mail.mail_blacklist_view_tree
 msgid "Email Blacklist"
-msgstr ""
+msgstr "E-posti must nimekiri"
 
 #. module: mail
 #: model_terms:ir.ui.view,arch_db:mail.email_template_form
@@ -1880,7 +1880,7 @@ msgstr "E-posti otsing"
 #. module: mail
 #: model:ir.model.fields,field_description:mail.field_mail_notification__email_status
 msgid "Email Status"
-msgstr ""
+msgstr "E-posti olek"
 
 #. module: mail
 #: model:ir.model.fields,field_description:mail.field_ir_actions_server__template_id
@@ -1939,6 +1939,7 @@ msgid ""
 "Email addresses that are blacklisted means that the recipient won't receive "
 "any mass mailing anymore."
 msgstr ""
+"Musta nimekirja kantud aadressid ei saa enam masspostitustega e-kirju. "
 
 #. module: mail
 #: model:ir.model,name:mail.model_mail_compose_message
@@ -1949,7 +1950,7 @@ msgstr "E-maili koostamise viisard"
 #: model_terms:ir.ui.view,arch_db:mail.view_mail_form
 #: model_terms:ir.ui.view,arch_db:mail.view_mail_message_subtype_form
 msgid "Email message"
-msgstr "Emaili sõnum"
+msgstr "E-posti sõnum"
 
 #. module: mail
 #: model:ir.model,name:mail.model_mail_resend_message
@@ -2098,7 +2099,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:mail.field_mail_mail__starred_partner_ids
 #: model:ir.model.fields,field_description:mail.field_mail_message__starred_partner_ids
 msgid "Favorited By"
-msgstr ""
+msgstr "Soositud"
 
 #. module: mail
 #. openerp-web
@@ -2154,7 +2155,7 @@ msgstr ""
 #. module: mail
 #: selection:mail.channel.partner,fold_state:0
 msgid "Folded"
-msgstr "Folded"
+msgstr "Volditud"
 
 #. module: mail
 #. openerp-web
@@ -2306,7 +2307,7 @@ msgstr "Grupid"
 #. module: mail
 #: model:ir.model.fields,field_description:mail.field_mail_channel__moderation_guidelines_msg
 msgid "Guidelines"
-msgstr ""
+msgstr "Juhised"
 
 #. module: mail
 #: code:addons/mail/models/mail_channel.py:448
@@ -2332,7 +2333,7 @@ msgstr ""
 #. module: mail
 #: model_terms:ir.ui.view,arch_db:mail.view_message_search
 msgid "Has Mentions"
-msgstr ""
+msgstr "Kas mainib"
 
 #. module: mail
 #: model_terms:ir.ui.view,arch_db:mail.view_message_search
@@ -2347,7 +2348,7 @@ msgstr "Failiga"
 #: model:ir.model.fields,help:mail.field_mail_mail__has_error
 #: model:ir.model.fields,help:mail.field_mail_message__has_error
 msgid "Has error"
-msgstr ""
+msgstr "On viga"
 
 #. module: mail
 #: model:ir.model.fields,field_description:mail.field_mail_mail__headers
@@ -2561,7 +2562,7 @@ msgstr "Saabuvad"
 #: model:ir.model.fields,help:mail.field_mail_activity__automated
 msgid ""
 "Indicates this activity has been created automatically and not by any user."
-msgstr ""
+msgstr "Näitab, et see tegevus on loodud automaatselt, mitte kasutaja poolt."
 
 #. module: mail
 #. openerp-web
@@ -2639,13 +2640,13 @@ msgstr ""
 #: code:addons/mail/static/src/js/services/mail_notification_manager.js:197
 #, python-format
 msgid "Invitation"
-msgstr "Invitation"
+msgstr "Kutse"
 
 #. module: mail
 #: code:addons/mail/wizard/invite.py:53
 #, python-format
 msgid "Invitation to follow %s: %s"
-msgstr ""
+msgstr "Kutse jälgida %s: %s"
 
 #. module: mail
 #. openerp-web
@@ -2685,7 +2686,7 @@ msgstr "Invite wizard"
 #. module: mail
 #: selection:mail.channel,public:0
 msgid "Invited people only"
-msgstr ""
+msgstr "Ainult kutsutud inimesed"
 
 #. module: mail
 #: model_terms:ir.ui.view,arch_db:mail.mail_moderation_view_search
@@ -2724,7 +2725,7 @@ msgstr "Tellitud"
 #. module: mail
 #: model:ir.model.fields,field_description:mail.field_mail_channel__is_chat
 msgid "Is a chat"
-msgstr ""
+msgstr "On vestlus"
 
 #. module: mail
 #: model:ir.model.fields,field_description:mail.field_mail_channel__is_member
@@ -2734,7 +2735,7 @@ msgstr "On liige"
 #. module: mail
 #: model:ir.model.fields,field_description:mail.field_res_users__is_moderator
 msgid "Is moderator"
-msgstr ""
+msgstr "On moderaator"
 
 #. module: mail
 #: model:ir.model.fields,field_description:mail.field_mail_channel_partner__is_pinned
@@ -3004,7 +3005,7 @@ msgstr "Postiteenuste tüüp"
 #. module: mail
 #: model:ir.model,name:mail.model_mail_blacklist
 msgid "Mail Blacklist"
-msgstr ""
+msgstr "E-posti must nimekiri"
 
 #. module: mail
 #: model:ir.model,name:mail.model_mail_blacklist_mixin
@@ -3038,7 +3039,7 @@ msgstr ""
 #. module: mail
 #: model:ir.model,name:mail.model_mail_tracking_value
 msgid "Mail Tracking Value"
-msgstr ""
+msgstr "E-kirjade jälgimisväärtus"
 
 #. module: mail
 #: model:ir.model.fields,help:mail.field_mail_mail__notification
@@ -3057,7 +3058,7 @@ msgstr ""
 #: model:ir.cron,cron_name:mail.ir_cron_mail_notify_channel_moderators
 #: model:ir.cron,name:mail.ir_cron_mail_notify_channel_moderators
 msgid "Mail: Notify channel moderators"
-msgstr ""
+msgstr "Post: teavitage kanali moderaatoreid"
 
 #. module: mail
 #: code:addons/mail/models/mail_thread.py:939
@@ -3140,7 +3141,7 @@ msgstr "Märgi tehtuks"
 #. module: mail
 #: model:ir.ui.menu,name:mail.mail_blacklist_menu
 msgid "Mass Mail Blacklist"
-msgstr ""
+msgstr "Masspostituse must nimekiri"
 
 #. module: mail
 #: model:ir.model.fields,field_description:mail.field_mail_channel__image_medium
@@ -3154,6 +3155,9 @@ msgid ""
 "image, with aspect ratio preserved. Use this field in form views or some "
 "kanban views."
 msgstr ""
+"Grupi keskmise suurusega foto. Selle suurust muudetakse automaatselt 128x128"
+" pikslise suurusega pildiks, kuvasuhe säilitatakse. Kasutage seda välja "
+"vormivaate või mõne kanbani vaatena."
 
 #. module: mail
 #: selection:mail.activity.type,category:0
@@ -3211,7 +3215,7 @@ msgstr "Sõnumi ID"
 #. module: mail
 #: model:ir.model,name:mail.model_mail_notification
 msgid "Message Notifications"
-msgstr ""
+msgstr "Sõnumi teavitused"
 
 #. module: mail
 #: model:ir.model.fields,field_description:mail.field_mail_compose_message__record_name
@@ -3372,24 +3376,24 @@ msgstr ""
 #. module: mail
 #: model:ir.model.fields,field_description:mail.field_mail_channel__moderation
 msgid "Moderate this channel"
-msgstr ""
+msgstr "Modereerige seda kanalit"
 
 #. module: mail
 #: model:ir.model.fields,field_description:mail.field_mail_compose_message__moderator_id
 #: model:ir.model.fields,field_description:mail.field_mail_mail__moderator_id
 #: model:ir.model.fields,field_description:mail.field_mail_message__moderator_id
 msgid "Moderated By"
-msgstr ""
+msgstr "Modereerib"
 
 #. module: mail
 #: model:ir.model.fields,field_description:mail.field_mail_channel__moderation_ids
 msgid "Moderated Emails"
-msgstr ""
+msgstr "Modereeritud e-kirjad"
 
 #. module: mail
 #: model:ir.model.fields,field_description:mail.field_res_users__moderation_channel_ids
 msgid "Moderated channels"
-msgstr ""
+msgstr "Modereeritud kanalid"
 
 #. module: mail
 #: code:addons/mail/models/mail_channel.py:170
@@ -3425,7 +3429,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:mail.field_mail_mail__moderation_status
 #: model:ir.model.fields,field_description:mail.field_mail_message__moderation_status
 msgid "Moderation Status"
-msgstr ""
+msgstr "Modereerimise olek"
 
 #. module: mail
 #: model:ir.model.fields,field_description:mail.field_res_users__moderation_counter
@@ -3435,12 +3439,12 @@ msgstr ""
 #. module: mail
 #: model:ir.model.fields,field_description:mail.field_mail_channel__is_moderator
 msgid "Moderator"
-msgstr ""
+msgstr "Moderaator"
 
 #. module: mail
 #: model:ir.model.fields,field_description:mail.field_mail_channel__moderator_ids
 msgid "Moderators"
-msgstr ""
+msgstr "Moderaatorid"
 
 #. module: mail
 #: code:addons/mail/models/mail_channel.py:154
@@ -3518,7 +3522,7 @@ msgstr "Vajab tegevust"
 #: model:ir.model.fields,field_description:mail.field_mail_mail__need_moderation
 #: model:ir.model.fields,field_description:mail.field_mail_message__need_moderation
 msgid "Need moderation"
-msgstr ""
+msgstr "Vajab modereerimist"
 
 #. module: mail
 #: model:ir.model.fields,field_description:mail.field_mail_notification__res_partner_id
@@ -3743,12 +3747,12 @@ msgstr "Märge"
 #. module: mail
 #: model:ir.model.fields,field_description:mail.field_res_users__notification_type
 msgid "Notification Management"
-msgstr "Teavitused"
+msgstr "Teavituste haldamine"
 
 #. module: mail
 #: model:ir.model.fields,field_description:mail.field_mail_channel__moderation_notify_msg
 msgid "Notification message"
-msgstr ""
+msgstr "Teavitussõnum"
 
 #. module: mail
 #: model:ir.model.fields,field_description:mail.field_mail_compose_message__notification_ids
@@ -3756,7 +3760,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:mail.field_mail_message__notification_ids
 #: model:ir.model.fields,field_description:mail.field_mail_resend_message__notification_ids
 msgid "Notifications"
-msgstr "Notifications"
+msgstr "Teavitused"
 
 #. module: mail
 #: model:ir.model.fields,field_description:mail.field_mail_compose_message__notify
@@ -3878,6 +3882,8 @@ msgid ""
 "Once a message has been starred, you can come back and review it at any time"
 " here."
 msgstr ""
+"Kui sõnum on märgistatud tähega, võite iga hetk siia tagasi tulla ja seda "
+"vaadata."
 
 #. module: mail
 #. openerp-web
@@ -4026,7 +4032,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:mail.field_mail_mail__mail_server_id
 #: model:ir.model.fields,field_description:mail.field_mail_message__mail_server_id
 msgid "Outgoing mail server"
-msgstr ""
+msgstr "Väljuvate kirjade server"
 
 #. module: mail
 #. openerp-web
@@ -4129,7 +4135,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:mail.field_mail_mail__needaction_partner_ids
 #: model:ir.model.fields,field_description:mail.field_mail_message__needaction_partner_ids
 msgid "Partners with Need Action"
-msgstr ""
+msgstr "Partnerid, kellel on vaja tegutseda"
 
 #. module: mail
 #: selection:mail.compose.message,moderation_status:0
@@ -4195,19 +4201,19 @@ msgstr ""
 #: selection:res.partner,activity_state:0
 #, python-format
 msgid "Planned"
-msgstr "Planned"
+msgstr "Planeeritud"
 
 #. module: mail
 #. openerp-web
 #: code:addons/mail/static/src/xml/activity.xml:6
 #, python-format
 msgid "Planned activities"
-msgstr ""
+msgstr "Planeeritud tegevus"
 
 #. module: mail
 #: model_terms:ir.ui.view,arch_db:mail.mail_activity_type_view_tree
 msgid "Planned in"
-msgstr ""
+msgstr "Planeeritud"
 
 #. module: mail
 #. openerp-web
@@ -4238,7 +4244,7 @@ msgstr ""
 #: code:addons/mail/static/src/js/composers/basic_composer.js:242
 #, python-format
 msgid "Please, wait while the file is uploading."
-msgstr ""
+msgstr "Oodake, kuni fail üles laaditakse."
 
 #. module: mail
 #: model:ir.model.fields,help:mail.field_res_users__notification_type
@@ -4477,7 +4483,7 @@ msgstr "Tagasi lükatud"
 #: model:ir.model.fields,field_description:mail.field_mail_message__res_id
 #: model:ir.model.fields,field_description:mail.field_mail_wizard_invite__res_id
 msgid "Related Document ID"
-msgstr ""
+msgstr "Seotud dokumendi ID"
 
 #. module: mail
 #: model:ir.model.fields,field_description:mail.field_email_template_preview__model
@@ -4488,12 +4494,12 @@ msgstr ""
 #: model:ir.model.fields,field_description:mail.field_mail_template__model
 #: model:ir.model.fields,field_description:mail.field_mail_wizard_invite__res_model
 msgid "Related Document Model"
-msgstr ""
+msgstr "Seotud dokumendi mudel"
 
 #. module: mail
 #: model:ir.model.fields,field_description:mail.field_mail_followers__res_model
 msgid "Related Document Model Name"
-msgstr ""
+msgstr "Seotud dokumendi mudel"
 
 #. module: mail
 #: model_terms:ir.ui.view,arch_db:mail.view_mail_tracking_value_form
@@ -4692,7 +4698,7 @@ msgstr "Planeeritud kuupäev"
 #: model:ir.model.fields,field_description:mail.field_mail_mail__scheduled_date
 #: model_terms:ir.ui.view,arch_db:mail.email_template_form
 msgid "Scheduled Send Date"
-msgstr ""
+msgstr "Ajastatud saatmiskuupäev"
 
 #. module: mail
 #: selection:ir.ui.view,type:0
@@ -4726,7 +4732,7 @@ msgstr ""
 #: code:addons/mail/static/src/xml/discuss.xml:183
 #, python-format
 msgid "Select all messages to moderate"
-msgstr ""
+msgstr "Valige kõik modereeritavad kirjad"
 
 #. module: mail
 #: model:ir.model.fields,help:mail.field_email_template_preview__model_object_field
@@ -4735,6 +4741,8 @@ msgid ""
 "Select target field from the related document model.\n"
 "If it is a relationship field you will be able to select a target field at the destination of the relationship."
 msgstr ""
+"Valige dokumendimudelist sihtväli. Kui see on seotud väli, saate seotud "
+"välja sihtkohas valida sihtvälja. "
 
 #. module: mail
 #: model_terms:ir.ui.view,arch_db:mail.mail_resend_message_view_form
@@ -4746,7 +4754,7 @@ msgstr ""
 #. module: mail
 #: selection:mail.channel,public:0
 msgid "Selected group of users"
-msgstr ""
+msgstr "Valitud kasutajarühm"
 
 #. module: mail
 #. openerp-web
@@ -4774,7 +4782,7 @@ msgstr "Saada kiri"
 #: code:addons/mail/models/mail_template.py:265
 #, python-format
 msgid "Send Mail (%s)"
-msgstr ""
+msgstr "Saada kiri (%s)"
 
 #. module: mail
 #. openerp-web
@@ -4820,7 +4828,7 @@ msgstr "Saada sõnum"
 #. module: mail
 #: model:ir.model.fields,field_description:mail.field_mail_channel__email_send
 msgid "Send messages by email"
-msgstr ""
+msgstr "Saatke sõnumid e-kirjaga"
 
 #. module: mail
 #: model:ir.model.fields,help:mail.field_email_template_preview__email_from
@@ -4908,6 +4916,8 @@ msgid ""
 "Sidebar action to make this template available on records of the related "
 "document model"
 msgstr ""
+"Külgriba toiming selle malli kättesaadavaks tegemiseks seotud "
+"dokumendimudeli kirjetel."
 
 #. module: mail
 #: model:ir.model.fields,help:mail.field_mail_compose_message__author_avatar
@@ -5298,6 +5308,8 @@ msgid ""
 "Tracked values are stored in a separate model. This field allow to "
 "reconstruct the tracking and to generate statistics on the model."
 msgstr ""
+"Jälgitavad väärtused salvestatakse eraldi mudelis. See väli võimaldab "
+"taastada jälgimist ja  mudeli kohta statistikat genereerida."
 
 #. module: mail
 #: model:ir.model.fields,field_description:mail.field_ir_model_fields__track_visibility
@@ -5315,19 +5327,19 @@ msgstr "Jälgitav väärtus"
 #: model:ir.actions.act_window,name:mail.action_view_mail_tracking_value
 #: model:ir.ui.menu,name:mail.menu_mail_tracking_value
 msgid "Tracking Values"
-msgstr ""
+msgstr "Jälgimisväärtused"
 
 #. module: mail
 #: model:ir.model.fields,field_description:mail.field_mail_tracking_value__track_sequence
 msgid "Tracking field sequence"
-msgstr ""
+msgstr "Jälgimisvälja järjestus"
 
 #. module: mail
 #: model:ir.model.fields,field_description:mail.field_mail_compose_message__tracking_value_ids
 #: model:ir.model.fields,field_description:mail.field_mail_mail__tracking_value_ids
 #: model:ir.model.fields,field_description:mail.field_mail_message__tracking_value_ids
 msgid "Tracking values"
-msgstr ""
+msgstr "Jälgimisväärtused"
 
 #. module: mail
 #: selection:ir.actions.act_window.view,view_mode:0
@@ -5343,6 +5355,7 @@ msgid ""
 "Try to add some activity on records, or make sure that\n"
 "                there is no active filter in the search bar."
 msgstr ""
+"Proovige lisada uus kirje, või veenduge, et otsinguribal poleks filter sees."
 
 #. module: mail
 #: model:ir.model.fields,field_description:mail.field_mail_compose_message__message_type
@@ -5385,19 +5398,19 @@ msgstr ""
 #: code:addons/mail/models/mail_thread.py:2207
 #, python-format
 msgid "Unable to log message, please configure the sender's email address."
-msgstr ""
+msgstr "Sõnumist ei saa teatada, konfigureerige saatja e-posti aadress."
 
 #. module: mail
 #: code:addons/mail/models/mail_thread.py:2172
 #, python-format
 msgid "Unable to notify message, please configure the sender's email address."
-msgstr ""
+msgstr "Sõnumist ei saa teatada, konfigureerige saatja e-posti aadress."
 
 #. module: mail
 #: code:addons/mail/models/mail_message.py:34
 #, python-format
 msgid "Unable to post message, please configure the sender's email address."
-msgstr ""
+msgstr "Sõnumit ei saa postitada, looge saatja e-posti aadress."
 
 #. module: mail
 #. openerp-web
@@ -5526,7 +5539,7 @@ msgstr ""
 #: code:addons/mail/static/src/xml/thread.xml:531
 #, python-format
 msgid "Uploaded"
-msgstr ""
+msgstr "Üles laaditud"
 
 #. module: mail
 #. openerp-web
@@ -5540,7 +5553,7 @@ msgstr "Üleslaadimine"
 #: code:addons/mail/static/src/js/composers/basic_composer.js:242
 #, python-format
 msgid "Uploading error"
-msgstr ""
+msgstr "Üleslaadimise viga"
 
 #. module: mail
 #: model:ir.model.fields,help:mail.field_ir_actions_server__activity_user_type
@@ -5710,6 +5723,8 @@ msgid ""
 "When a relationship field is selected as first field, this field lets you "
 "select the target field within the destination document model (sub-model)."
 msgstr ""
+"Kui esimese väljana valitakse suhteväli(seotud väli), võimaldab see väli "
+"valida sihtdokumendi mudelis(alammudelis) sihtvälja."
 
 #. module: mail
 #: model:ir.model.fields,help:mail.field_email_template_preview__sub_object
@@ -5718,6 +5733,8 @@ msgid ""
 "When a relationship field is selected as first field, this field shows the "
 "document model the relationship goes to."
 msgstr ""
+"Kui seotud väli(suhteväli) on valitud esimesena, näitab see väli "
+"dokumendimudelit, kuhu suhe läheb."
 
 #. module: mail
 #: model:ir.model.fields,help:mail.field_ir_model_fields__track_visibility
@@ -5733,7 +5750,7 @@ msgstr ""
 #. module: mail
 #: model:ir.model.fields,help:mail.field_ir_model__is_mail_thread
 msgid "Whether this model supports messages and notifications."
-msgstr ""
+msgstr "Kas see mudel toetab sõnumeid ja teatisi."
 
 #. module: mail
 #: model_terms:ir.ui.view,arch_db:mail.mail_channel_view_form
@@ -5745,7 +5762,7 @@ msgstr ""
 #: code:addons/mail/static/src/xml/activity.xml:96
 #, python-format
 msgid "Write Feedback"
-msgstr ""
+msgstr "Kirjuta tagasiside"
 
 #. module: mail
 #. openerp-web
@@ -5823,6 +5840,8 @@ msgid ""
 "You are the administrator of this channel. Are you sure you want to "
 "unsubscribe?"
 msgstr ""
+"\n"
+"Olete selle kanali administraator. Kas soovite kindlasti tellimuse tühistada?"
 
 #. module: mail
 #. openerp-web
@@ -5865,7 +5884,7 @@ msgstr ""
 #. module: mail
 #: model_terms:ir.ui.view,arch_db:mail.message_user_assigned
 msgid "You have been assigned to the"
-msgstr ""
+msgstr "Sulle on määratud"
 
 #. module: mail
 #. openerp-web
@@ -5884,7 +5903,7 @@ msgstr ""
 #: code:addons/mail/static/src/xml/thread.xml:138
 #, python-format
 msgid "You have no message to moderate"
-msgstr ""
+msgstr "Teil pole sõnumit modereerimiseks"
 
 #. module: mail
 #: model:ir.model.fields,help:mail.field_email_template_preview__attachment_ids
@@ -5940,7 +5959,7 @@ msgstr ""
 #: code:addons/mail/static/src/xml/discuss.xml:198
 #, python-format
 msgid "Your message was rejected by moderator."
-msgstr ""
+msgstr "Moderaator lükkas teie sõnumi tagasi."
 
 #. module: mail
 #: code:addons/mail/models/ir_actions.py:57
@@ -6017,7 +6036,7 @@ msgstr "loodud"
 #. module: mail
 #: selection:mail.activity.type,delay_unit:0
 msgid "days"
-msgstr "päeva pärast"
+msgstr "päev(a)"
 
 #. module: mail
 #: code:addons/mail/models/mail_thread.py:357
@@ -6074,19 +6093,19 @@ msgstr "üldine"
 #. module: mail
 #: model_terms:ir.ui.view,arch_db:mail.message_origin_link
 msgid "has been"
-msgstr ""
+msgstr "on olnud"
 
 #. module: mail
 #: code:addons/mail/models/mail_alias.py:272
 #, python-format
 msgid "incorrectly configured alias"
-msgstr ""
+msgstr "Valesti loodud alias."
 
 #. module: mail
 #: code:addons/mail/models/mail_alias.py:268
 #, python-format
 msgid "incorrectly configured alias (unknown reference record)"
-msgstr ""
+msgstr "Valesti loodud alias."
 
 #. module: mail
 #: code:addons/mail/models/mail_thread.py:1051

--- a/addons/mail/i18n/eu.po
+++ b/addons/mail/i18n/eu.po
@@ -16,7 +16,7 @@
 # Iñaki Ibarrola <inakiibarrola@yahoo.es>, 2020
 # Maialen Rodriguez <maialenrodriguez98@gmail.com>, 2020
 # Miren Maiz <mirenmaizz@gmail.com>, 2020
-# Mikel Galarza <mikelgalarza99@gmail.com>, 2020
+# mgalarza005 <mikelgalarza99@gmail.com>, 2020
 # Unai Muñoz <unaimunoz9@gmail.com>, 2020
 # 
 msgid ""
@@ -635,7 +635,7 @@ msgstr "Aurreratutako ezarpenak"
 #. module: mail
 #: model:ir.model.fields,field_description:mail.field_mail_activity_type__delay_count
 msgid "After"
-msgstr ""
+msgstr "Ondoren"
 
 #. module: mail
 #. openerp-web
@@ -1338,7 +1338,7 @@ msgstr "Edukiak"
 #. module: mail
 #: model:ir.model.fields,field_description:mail.field_mail_channel_partner__fold_state
 msgid "Conversation Fold State"
-msgstr ""
+msgstr "Konbertsio akzioa"
 
 #. module: mail
 #: model:ir.model.fields,field_description:mail.field_mail_channel_partner__is_minimized
@@ -1350,7 +1350,7 @@ msgstr ""
 #: code:addons/mail/static/src/xml/systray.xml:9
 #, python-format
 msgid "Conversations"
-msgstr ""
+msgstr "Konbertsioak"
 
 #. module: mail
 #: model:ir.model.fields,help:mail.field_res_partner__message_bounce
@@ -1497,7 +1497,7 @@ msgstr "Epemuga "
 #. module: mail
 #: model_terms:ir.ui.view,arch_db:mail.message_user_assigned
 msgid "Dear"
-msgstr ""
+msgstr "Maitea"
 
 #. module: mail
 #: model:ir.model.fields,field_description:mail.field_mail_activity__activity_decoration
@@ -1508,7 +1508,7 @@ msgstr ""
 #. module: mail
 #: model:ir.model.fields,field_description:mail.field_mail_message_subtype__default
 msgid "Default"
-msgstr ""
+msgstr "Lehenetsia"
 
 #. module: mail
 #: model:ir.model.fields,field_description:mail.field_mail_activity_type__default_next_type_id
@@ -1519,7 +1519,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:mail.field_email_template_preview__null_value
 #: model:ir.model.fields,field_description:mail.field_mail_template__null_value
 msgid "Default Value"
-msgstr ""
+msgstr "Balio lehenetsia"
 
 #. module: mail
 #: model:ir.model.fields,field_description:mail.field_mail_alias__alias_defaults
@@ -1532,7 +1532,7 @@ msgstr "Balio lehenetsiak "
 #: model:ir.model.fields,field_description:mail.field_email_template_preview__use_default_to
 #: model:ir.model.fields,field_description:mail.field_mail_template__use_default_to
 msgid "Default recipients"
-msgstr ""
+msgstr "Lehenetsitako hartzailea"
 
 #. module: mail
 #: model:ir.model.fields,help:mail.field_email_template_preview__use_default_to
@@ -1584,7 +1584,7 @@ msgstr ""
 #. module: mail
 #: selection:mail.mail,state:0
 msgid "Delivery Failed"
-msgstr ""
+msgstr "Banaketa akatsa"
 
 #. module: mail
 #: model:ir.model.fields,field_description:mail.field_mail_channel__description
@@ -1611,7 +1611,7 @@ msgstr "Diagrama"
 #: code:addons/mail/static/src/xml/discuss.xml:57
 #, python-format
 msgid "Direct Messages"
-msgstr ""
+msgstr "Mezu zuzenak"
 
 #. module: mail
 #. openerp-web
@@ -1744,7 +1744,7 @@ msgstr ""
 #. module: mail
 #: model:ir.model.fields,field_description:mail.field_mail_activity__res_name
 msgid "Document Name"
-msgstr ""
+msgstr "Dokumentu izena"
 
 #. module: mail
 #. openerp-web
@@ -1828,14 +1828,14 @@ msgstr ""
 #: code:addons/mail/static/src/js/followers.js:354
 #, python-format
 msgid "Edit Subscription of "
-msgstr ""
+msgstr "Editatu harpidetza"
 
 #. module: mail
 #. openerp-web
 #: code:addons/mail/static/src/xml/followers.xml:50
 #, python-format
 msgid "Edit subscription"
-msgstr ""
+msgstr "Editatu harpidetza"
 
 #. module: mail
 #: model:ir.model.fields,field_description:mail.field_mail_channel_partner__partner_email
@@ -1877,22 +1877,22 @@ msgstr ""
 #. module: mail
 #: model_terms:ir.ui.view,arch_db:mail.email_template_form
 msgid "Email Configuration"
-msgstr ""
+msgstr "Email konfigurazioa"
 
 #. module: mail
 #: model_terms:ir.ui.view,arch_db:mail.email_template_preview_form
 msgid "Email Preview"
-msgstr ""
+msgstr "Email aurreikuspena"
 
 #. module: mail
 #: model_terms:ir.ui.view,arch_db:mail.view_mail_search
 msgid "Email Search"
-msgstr ""
+msgstr "Email bilaketa"
 
 #. module: mail
 #: model:ir.model.fields,field_description:mail.field_mail_notification__email_status
 msgid "Email Status"
-msgstr ""
+msgstr "Email egoera"
 
 #. module: mail
 #: model:ir.model.fields,field_description:mail.field_ir_actions_server__template_id
@@ -1961,7 +1961,7 @@ msgstr "E-posta sortzeko laguntzailea"
 #: model_terms:ir.ui.view,arch_db:mail.view_mail_form
 #: model_terms:ir.ui.view,arch_db:mail.view_mail_message_subtype_form
 msgid "Email message"
-msgstr ""
+msgstr "eposta mezua"
 
 #. module: mail
 #: model:ir.model,name:mail.model_mail_resend_message
@@ -2069,7 +2069,7 @@ msgstr ""
 #. module: mail
 #: model:ir.model.fields,field_description:mail.field_res_config_settings__fail_counter
 msgid "Fail Mail"
-msgstr ""
+msgstr "Mezu galdua"
 
 #. module: mail
 #: model_terms:ir.ui.view,arch_db:mail.view_mail_search
@@ -2086,7 +2086,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:mail.field_mail_mail__failure_reason
 #: model_terms:ir.ui.view,arch_db:mail.view_mail_form
 msgid "Failure Reason"
-msgstr ""
+msgstr "Akats arrazoia"
 
 #. module: mail
 #: model:ir.model.fields,field_description:mail.field_mail_notification__failure_reason
@@ -2166,7 +2166,7 @@ msgstr ""
 #. module: mail
 #: selection:mail.channel.partner,fold_state:0
 msgid "Folded"
-msgstr ""
+msgstr "Tolestu"
 
 #. module: mail
 #. openerp-web
@@ -2434,6 +2434,8 @@ msgid ""
 "ID of the parent record holding the alias (example: project holding the task"
 " creation alias)"
 msgstr ""
+"Ezizena duen erregistro gurasoaren ID (adibidez: atazak sortzeko ezizena "
+"duen proiektua)"
 
 #. module: mail
 #: model:ir.model.fields,field_description:mail.field_mail_activity__icon
@@ -4421,7 +4423,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:mail.field_mail_alias_mixin__alias_force_thread_id
 #: model:ir.model.fields,field_description:mail.field_mail_channel__alias_force_thread_id
 msgid "Record Thread ID"
-msgstr ""
+msgstr "Record Thread-en ID"
 
 #. module: mail
 #: code:addons/mail/models/mail_activity.py:244

--- a/addons/mail/i18n/eu.po
+++ b/addons/mail/i18n/eu.po
@@ -16,6 +16,8 @@
 # Iñaki Ibarrola <inakiibarrola@yahoo.es>, 2020
 # Maialen Rodriguez <maialenrodriguez98@gmail.com>, 2020
 # Miren Maiz <mirenmaizz@gmail.com>, 2020
+# Mikel Galarza <mikelgalarza99@gmail.com>, 2020
+# Unai Muñoz <unaimunoz9@gmail.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -23,7 +25,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-11-14 07:34+0000\n"
 "PO-Revision-Date: 2018-08-24 09:20+0000\n"
-"Last-Translator: Miren Maiz <mirenmaizz@gmail.com>, 2020\n"
+"Last-Translator: Unai Muñoz <unaimunoz9@gmail.com>, 2020\n"
 "Language-Team: Basque (https://www.transifex.com/odoo/teams/41243/eu/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -54,14 +56,14 @@ msgstr ""
 #: code:addons/mail/static/src/js/services/mail_manager.js:945
 #, python-format
 msgid "%d Messages"
-msgstr ""
+msgstr "%dMezuak"
 
 #. module: mail
 #. openerp-web
 #: code:addons/mail/static/src/js/activity.js:89
 #, python-format
 msgid "%d days overdue"
-msgstr ""
+msgstr "%dAtzeratze egunak "
 
 #. module: mail
 #: code:addons/mail/models/mail_template.py:249
@@ -80,7 +82,7 @@ msgstr ""
 #: code:addons/mail/models/mail_thread.py:278
 #, python-format
 msgid "%s created"
-msgstr ""
+msgstr "%s Sortu"
 
 #. module: mail
 #. openerp-web
@@ -112,49 +114,49 @@ msgstr ""
 #: code:addons/mail/static/src/xml/discuss.xml:285
 #, python-format
 msgid "&nbsp;("
-msgstr ""
+msgstr "&nbsp;"
 
 #. module: mail
 #. openerp-web
 #: code:addons/mail/static/src/xml/thread.xml:326
 #, python-format
 msgid "(from"
-msgstr ""
+msgstr "-tik"
 
 #. module: mail
 #. openerp-web
 #: code:addons/mail/static/src/xml/activity.xml:56
 #, python-format
 msgid ", due on"
-msgstr ""
+msgstr "ez dagoelako"
 
 #. module: mail
 #. openerp-web
 #: code:addons/mail/static/src/xml/thread.xml:547
 #, python-format
 msgid "-------- Show older messages --------"
-msgstr ""
+msgstr "Erakutsi mezu zaharragoak"
 
 #. module: mail
 #. openerp-web
 #: code:addons/mail/static/src/xml/systray.xml:99
 #, python-format
 msgid "0 Future"
-msgstr ""
+msgstr "0 Etorkizuna"
 
 #. module: mail
 #. openerp-web
 #: code:addons/mail/static/src/xml/systray.xml:95
 #, python-format
 msgid "0 Late"
-msgstr ""
+msgstr "0 Berandu"
 
 #. module: mail
 #. openerp-web
 #: code:addons/mail/static/src/xml/systray.xml:97
 #, python-format
 msgid "0 Today"
-msgstr ""
+msgstr "0 Gaur"
 
 #. module: mail
 #: code:addons/mail/models/mail_channel.py:926
@@ -183,6 +185,8 @@ msgid ""
 "<div class=\"o_mail_notification\">created <a href=\"#\" "
 "class=\"o_channel_redirect\" data-oe-id=\"%s\">#%s</a></div>"
 msgstr ""
+"<div class=\"o_mail_notification\"> sortua<a href=\"#\" "
+"class=\"o_channel_redirect\" data-oe-id=\"%s\">#%s</a></div>"
 
 #. module: mail
 #: code:addons/mail/models/mail_channel.py:729
@@ -192,6 +196,8 @@ msgid ""
 "<div class=\"o_mail_notification\">joined <a href=\"#\" "
 "class=\"o_channel_redirect\" data-oe-id=\"%s\">#%s</a></div>"
 msgstr ""
+"<div class=\"o_mail_notification\">batua <a href=\"#\" "
+"class=\"o_channel_redirect\" data-oe-id=\"%s\">#%s</a></div>"
 
 #. module: mail
 #: code:addons/mail/models/mail_channel.py:295
@@ -200,6 +206,8 @@ msgid ""
 "<div class=\"o_mail_notification\">left <a href=\"#\" "
 "class=\"o_channel_redirect\" data-oe-id=\"%s\">#%s</a></div>"
 msgstr ""
+"<div class=\"o_mail_notification\">ezkerra<a href=\"#\" "
+"class=\"o_channel_redirect\" data-oe-id=\"%s\">#%s</a></div>"
 
 #. module: mail
 #: model_terms:ir.ui.view,arch_db:mail.res_partner_view_form_inherit_mail
@@ -302,6 +310,8 @@ msgid ""
 "<span class=\"o_stat_text\">Remove</span>\n"
 "                                    <span class=\"o_stat_text\">Context Action</span>"
 msgstr ""
+"<span class=\"o_stat_text\">Borratu</span>\n"
+"<span class=\"o_stat_text\">Kontextuko akzioa </span>"
 
 #. module: mail
 #: model_terms:ir.ui.view,arch_db:mail.email_compose_message_wizard_form
@@ -317,7 +327,7 @@ msgstr ""
 #. module: mail
 #: model_terms:ir.ui.view,arch_db:mail.message_activity_done
 msgid "<strong> Feedback</strong>"
-msgstr ""
+msgstr "<strong>Feedback-a</strong>"
 
 #. module: mail
 #: model_terms:ir.ui.view,arch_db:mail.message_notification_email
@@ -346,6 +356,8 @@ msgid ""
 "A Python dictionary that will be evaluated to provide default values when "
 "creating new records for this alias."
 msgstr ""
+"Python hiztegi bat, ezizen horrentzat erregistro berriak sortzen direnean "
+"lehenetsitako balioak emateko ebaluatuko dena."
 
 #. module: mail
 #: code:addons/mail/models/ir_actions.py:69
@@ -415,7 +427,7 @@ msgstr ""
 #. module: mail
 #: model:ir.model.fields,help:mail.field_mail_message_subtype__default
 msgid "Activated by default when subscribing."
-msgstr ""
+msgstr "Lehenespenez aktibatzen da harpidetzean."
 
 #. module: mail
 #: model:ir.model.fields,field_description:mail.field_mail_activity_type__active
@@ -464,7 +476,7 @@ msgstr "Jarduera"
 #. module: mail
 #: model:ir.model,name:mail.model_mail_activity_mixin
 msgid "Activity Mixin"
-msgstr ""
+msgstr "Jarduera nahasketa"
 
 #. module: mail
 #: model:ir.model.fields,field_description:mail.field_mail_activity_mixin__activity_state
@@ -496,7 +508,7 @@ msgstr ""
 #: code:addons/mail/static/src/xml/activity.xml:37
 #, python-format
 msgid "Activity type"
-msgstr ""
+msgstr "Jarduera mota"
 
 #. module: mail
 #. openerp-web
@@ -518,7 +530,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:mail.field_ir_actions_server__channel_ids
 #, python-format
 msgid "Add Channels"
-msgstr ""
+msgstr "Kanalak gehitu"
 
 #. module: mail
 #: model_terms:ir.ui.view,arch_db:mail.mail_blacklist_view_form
@@ -533,7 +545,7 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:mail.mail_wizard_invite_form
 #, python-format
 msgid "Add Followers"
-msgstr ""
+msgstr "Jarraitzaileak gehitu"
 
 #. module: mail
 #: code:addons/mail/models/ir_actions.py:63
@@ -552,7 +564,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:mail.field_email_template_preview__user_signature
 #: model:ir.model.fields,field_description:mail.field_mail_template__user_signature
 msgid "Add Signature"
-msgstr ""
+msgstr "Sinadura gehitu"
 
 #. module: mail
 #. openerp-web
@@ -560,7 +572,7 @@ msgstr ""
 #: code:addons/mail/static/src/xml/discuss.xml:242
 #, python-format
 msgid "Add a channel"
-msgstr ""
+msgstr "Kanalak gehitu"
 
 #. module: mail
 #: code:addons/mail/models/mail_thread.py:383
@@ -573,7 +585,7 @@ msgstr ""
 #: code:addons/mail/static/src/xml/discuss.xml:71
 #, python-format
 msgid "Add a private channel"
-msgstr ""
+msgstr "Kanal pribatua gehitu"
 
 #. module: mail
 #: model_terms:ir.actions.act_window,help:mail.mail_blacklist_action
@@ -590,7 +602,7 @@ msgstr ""
 #. module: mail
 #: model_terms:ir.ui.view,arch_db:mail.mail_wizard_invite_form
 msgid "Add channels to notify..."
-msgstr ""
+msgstr "Gehitu kontaktuak jakinarazteko..."
 
 #. module: mail
 #: model_terms:ir.ui.view,arch_db:mail.email_compose_message_wizard_form
@@ -608,7 +620,7 @@ msgstr ""
 #. module: mail
 #: model:ir.model.fields,field_description:mail.field_mail_compose_message__partner_ids
 msgid "Additional Contacts"
-msgstr ""
+msgstr "Kontatu gehigarriak"
 
 #. module: mail
 #: model_terms:ir.ui.view,arch_db:mail.view_mail_form
@@ -652,7 +664,7 @@ msgstr "Alias"
 #: model:ir.model.fields,field_description:mail.field_mail_channel__alias_contact
 #: model:ir.model.fields,field_description:mail.field_res_users__alias_contact
 msgid "Alias Contact Security"
-msgstr ""
+msgstr "Segurtasun Kontaktu Ezizena"
 
 #. module: mail
 #: model:ir.model.fields,field_description:mail.field_res_config_settings__alias_domain
@@ -678,13 +690,13 @@ msgstr "Alias domeinua "
 #: model:ir.model.fields,field_description:mail.field_mail_alias_mixin__alias_model_id
 #: model:ir.model.fields,field_description:mail.field_mail_channel__alias_model_id
 msgid "Aliased Model"
-msgstr ""
+msgstr "Ezizenaren eredua"
 
 #. module: mail
 #: model:ir.actions.act_window,name:mail.action_view_mail_alias
 #: model:ir.ui.menu,name:mail.mail_alias_menu
 msgid "Aliases"
-msgstr ""
+msgstr "Ezizenak"
 
 #. module: mail
 #. openerp-web
@@ -736,7 +748,7 @@ msgstr ""
 #: code:addons/mail/static/src/js/models/messages/message.js:148
 #, python-format
 msgid "Anonymous"
-msgstr ""
+msgstr "Anonimoa"
 
 #. module: mail
 #: model:ir.model.fields,help:mail.field_mail_compose_message__no_auto_thread
@@ -751,7 +763,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:mail.field_email_template_preview__model_id
 #: model:ir.model.fields,field_description:mail.field_mail_template__model_id
 msgid "Applies to"
-msgstr ""
+msgstr "Honi aplikatzen zaio:"
 
 #. module: mail
 #. openerp-web
@@ -794,7 +806,7 @@ msgstr ""
 #. module: mail
 #: model_terms:ir.ui.view,arch_db:mail.email_compose_message_wizard_form
 msgid "Attach a file"
-msgstr ""
+msgstr "Fitxategia eranskin "
 
 #. module: mail
 #: model:ir.model,name:mail.model_ir_attachment
@@ -835,12 +847,12 @@ msgstr ""
 #. module: mail
 #: selection:mail.alias,alias_contact:0
 msgid "Authenticated Employees"
-msgstr ""
+msgstr "Kautotu langileak"
 
 #. module: mail
 #: selection:mail.alias,alias_contact:0
 msgid "Authenticated Partners"
-msgstr ""
+msgstr "Kautotutako kideak"
 
 #. module: mail
 #: model:ir.model.fields,field_description:mail.field_mail_compose_message__author_id
@@ -853,7 +865,7 @@ msgstr "Egilea"
 #. module: mail
 #: model_terms:ir.ui.view,arch_db:mail.email_template_form
 msgid "Author Signature (mass mail only)"
-msgstr ""
+msgstr "Egileraren sinadura (mezu masiboak soilik)"
 
 #. module: mail
 #: model:ir.model.fields,help:mail.field_mail_compose_message__author_id
@@ -869,19 +881,19 @@ msgstr ""
 #: model:ir.model.fields,field_description:mail.field_mail_mail__author_avatar
 #: model:ir.model.fields,field_description:mail.field_mail_message__author_avatar
 msgid "Author's avatar"
-msgstr ""
+msgstr "Egilearen izena"
 
 #. module: mail
 #: model:ir.model.fields,field_description:mail.field_mail_channel__group_public_id
 msgid "Authorized Group"
-msgstr ""
+msgstr "Talde baimendua"
 
 #. module: mail
 #: model:ir.model.fields,field_description:mail.field_email_template_preview__auto_delete
 #: model:ir.model.fields,field_description:mail.field_mail_mail__auto_delete
 #: model:ir.model.fields,field_description:mail.field_mail_template__auto_delete
 msgid "Auto Delete"
-msgstr ""
+msgstr "Automatikoki ezabatu"
 
 #. module: mail
 #: model:ir.model.fields,field_description:mail.field_mail_activity__force_next
@@ -897,12 +909,12 @@ msgstr ""
 #. module: mail
 #: model:ir.model.fields,field_description:mail.field_mail_channel__group_ids
 msgid "Auto Subscription"
-msgstr ""
+msgstr "Harpidetza automatikoa"
 
 #. module: mail
 #: model_terms:ir.ui.view,arch_db:mail.view_mail_message_subtype_form
 msgid "Auto subscription"
-msgstr ""
+msgstr "Harpidetza automatikoa"
 
 #. module: mail
 #: model:ir.model.fields,field_description:mail.field_mail_activity__automated
@@ -956,7 +968,7 @@ msgstr ""
 #: code:addons/mail/static/src/xml/followers.xml:90
 #, python-format
 msgid "Be careful with channels following internal notifications"
-msgstr ""
+msgstr "Kontuz ibili barne-jakinarazpenen ondorengo kanalekin"
 
 #. module: mail
 #: model_terms:ir.ui.view,arch_db:mail.mail_notification_paynow
@@ -997,7 +1009,7 @@ msgstr "Berreskuratze"
 #: selection:mail.notification,email_status:0
 #, python-format
 msgid "Bounced"
-msgstr ""
+msgstr "Berreskuratze"
 
 #. module: mail
 #: selection:ir.actions.act_window.view,view_mode:0
@@ -1008,7 +1020,7 @@ msgstr "Egutegia"
 #. module: mail
 #: model:mail.activity.type,name:mail.mail_activity_data_call
 msgid "Call"
-msgstr ""
+msgstr "Deia"
 
 #. module: mail
 #. openerp-web
@@ -1049,7 +1061,7 @@ msgstr "Ezeztatua"
 #. module: mail
 #: model:ir.model,name:mail.model_mail_shortcode
 msgid "Canned Response / Shortcode"
-msgstr ""
+msgstr "Arduraduna / Bidezidor"
 
 #. module: mail
 #: model:ir.model.fields,help:mail.field_mail_mail__email_cc
@@ -1084,7 +1096,7 @@ msgstr "Kategoria"
 #: model:ir.model.fields,field_description:mail.field_mail_mail__email_cc
 #: model:ir.model.fields,field_description:mail.field_mail_template__email_cc
 msgid "Cc"
-msgstr ""
+msgstr "Cc"
 
 #. module: mail
 #: model_terms:ir.ui.view,arch_db:mail.view_mail_tracking_value_form
@@ -1107,7 +1119,7 @@ msgstr ""
 #. module: mail
 #: model:ir.model.fields,field_description:mail.field_mail_tracking_value__field
 msgid "Changed Field"
-msgstr ""
+msgstr "Aldatu eremua"
 
 #. module: mail
 #. openerp-web
@@ -1124,7 +1136,7 @@ msgstr "Kanala"
 #. module: mail
 #: model:ir.model.fields,field_description:mail.field_mail_channel__channel_message_ids
 msgid "Channel Message"
-msgstr ""
+msgstr "Mezu Kanalak "
 
 #. module: mail
 #: model:ir.ui.menu,name:mail.mail_moderation_menu
@@ -1170,7 +1182,7 @@ msgstr "Kanalak "
 #: model:ir.actions.act_window,name:mail.mail_channel_partner_action
 #: model:ir.ui.menu,name:mail.mail_channel_partner_menu
 msgid "Channels/Partner"
-msgstr ""
+msgstr "Kanal/Kidea"
 
 #. module: mail
 #. openerp-web
@@ -1179,29 +1191,29 @@ msgstr ""
 #: code:addons/mail/static/src/xml/systray.xml:35
 #, python-format
 msgid "Chat"
-msgstr ""
+msgstr "Txat"
 
 #. module: mail
 #: selection:mail.channel,channel_type:0
 msgid "Chat Discussion"
-msgstr ""
+msgstr "Txat Eztabaida "
 
 #. module: mail
 #: model:ir.actions.act_window,name:mail.mail_shortcode_action
 msgid "Chat Shortcode"
-msgstr ""
+msgstr "txat bidezidorra"
 
 #. module: mail
 #: model:ir.model.fields,field_description:mail.field_mail_compose_message__child_ids
 #: model:ir.model.fields,field_description:mail.field_mail_mail__child_ids
 #: model:ir.model.fields,field_description:mail.field_mail_message__child_ids
 msgid "Child Messages"
-msgstr ""
+msgstr "Haurrentzako menuak"
 
 #. module: mail
 #: model_terms:ir.ui.view,arch_db:mail.email_template_preview_form
 msgid "Choose an example"
-msgstr ""
+msgstr "Hautatu eredua"
 
 #. module: mail
 #. openerp-web
@@ -1274,7 +1286,7 @@ msgstr "Eposta idatzi"
 #. module: mail
 #: model:ir.model.fields,field_description:mail.field_mail_compose_message__composition_mode
 msgid "Composition mode"
-msgstr ""
+msgstr "Konposaketa modua"
 
 #. module: mail
 #: model:ir.model,name:mail.model_res_config_settings
@@ -1298,7 +1310,7 @@ msgstr ""
 #: code:addons/mail/static/src/js/discuss.js:944
 #, python-format
 msgid "Congratulations, your inbox is empty!"
-msgstr ""
+msgstr "Zorionak, kaxa hutsik duzu!"
 
 #. module: mail
 #: selection:mail.notification,failure_type:0
@@ -1351,7 +1363,7 @@ msgstr "Kontaktu honek izan dituen errebote e-posten kontagailua"
 #: code:addons/mail/static/src/js/discuss.js:566
 #, python-format
 msgid "Create %s"
-msgstr ""
+msgstr "%s sortu"
 
 #. module: mail
 #: selection:ir.actions.server,state:0
@@ -1447,7 +1459,7 @@ msgstr ""
 #: model:ir.model.fields,help:mail.field_mail_mail__starred
 #: model:ir.model.fields,help:mail.field_mail_message__starred
 msgid "Current user has a starred notification linked to this message"
-msgstr ""
+msgstr "Uneko erabiltzaileak mezu honi lotutako izar-jakinarazpena du"
 
 #. module: mail
 #: model:ir.model.fields,help:mail.field_mail_channel__is_moderator
@@ -2045,7 +2057,7 @@ msgstr "Hainbat ekintza exekutatu"
 #. module: mail
 #: model_terms:ir.ui.view,arch_db:mail.view_mail_search
 msgid "Extended Filters..."
-msgstr ""
+msgstr "Iragazki hedatuak ..."
 
 #. module: mail
 #. openerp-web
@@ -4592,7 +4604,7 @@ msgstr "Arduraduna"
 #: model:ir.model.fields,field_description:mail.field_res_partner__activity_user_id
 #: model:ir.model.fields,field_description:mail.field_res_users__activity_user_id
 msgid "Responsible User"
-msgstr ""
+msgstr "Erabiltzaile arduraduna"
 
 #. module: mail
 #: model_terms:ir.ui.view,arch_db:mail.view_mail_form
@@ -5009,7 +5021,7 @@ msgstr ""
 #. module: mail
 #: model_terms:ir.ui.view,arch_db:mail.email_compose_message_wizard_form
 msgid "Subject..."
-msgstr ""
+msgstr "Gai..."
 
 #. module: mail
 #. openerp-web
@@ -5305,7 +5317,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:mail.field_mail_mail__tracking_value_ids
 #: model:ir.model.fields,field_description:mail.field_mail_message__tracking_value_ids
 msgid "Tracking values"
-msgstr ""
+msgstr "Jarraipen balioak"
 
 #. module: mail
 #: selection:ir.actions.act_window.view,view_mode:0
@@ -5536,7 +5548,7 @@ msgstr "Erabili domeinu aktiboa"
 #. module: mail
 #: model:ir.model.fields,field_description:mail.field_mail_compose_message__template_id
 msgid "Use template"
-msgstr ""
+msgstr "Txantiloia erabili"
 
 #. module: mail
 #: model_terms:ir.ui.view,arch_db:mail.res_config_settings_view_form

--- a/addons/mail/i18n/fi.po
+++ b/addons/mail/i18n/fi.po
@@ -440,7 +440,7 @@ msgstr "Tehtävät"
 #. module: mail
 #: model:ir.model,name:mail.model_ir_actions_act_window_view
 msgid "Action Window View"
-msgstr ""
+msgstr "Action Window View"
 
 #. module: mail
 #: model:ir.model.fields,help:mail.field_mail_message_subtype__default

--- a/addons/mail/i18n/fi.po
+++ b/addons/mail/i18n/fi.po
@@ -615,7 +615,7 @@ msgstr ""
 #: code:addons/mail/static/src/xml/composer.xml:15
 #, python-format
 msgid "Add attachment"
-msgstr ""
+msgstr "Lisää liite"
 
 #. module: mail
 #: model_terms:ir.ui.view,arch_db:mail.mail_wizard_invite_form

--- a/addons/mail/i18n/fr.po
+++ b/addons/mail/i18n/fr.po
@@ -30,6 +30,8 @@
 # Pauline Thiry <pth@odoo.com>, 2020
 # Julien Goergen <jgo@odoo.com>, 2020
 # Priscilla Sanchez <prs@odoo.com>, 2020
+# Vallen Delobel <edv@odoo.com>, 2020
+# Jonathan Quique <jqu@odoo.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -37,7 +39,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-11-14 07:34+0000\n"
 "PO-Revision-Date: 2018-08-24 09:20+0000\n"
-"Last-Translator: Priscilla Sanchez <prs@odoo.com>, 2020\n"
+"Last-Translator: Jonathan Quique <jqu@odoo.com>, 2020\n"
 "Language-Team: French (https://www.transifex.com/odoo/teams/41243/fr/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -981,7 +983,7 @@ msgstr "Planifier automatiquement l'activité suivante"
 #. module: mail
 #: model_terms:ir.ui.view,arch_db:mail.mail_channel_view_form
 msgid "Auto Subscribe Groups"
-msgstr ""
+msgstr "Abonner automatiquement les groupes"
 
 #. module: mail
 #: model:ir.model.fields,field_description:mail.field_mail_channel__group_ids
@@ -1729,7 +1731,7 @@ msgstr "Annuler les échecs d'envoi d'email"
 #: code:addons/mail/static/src/xml/discuss.xml:187
 #, python-format
 msgid "Discard selected messages"
-msgstr ""
+msgstr "Jeter les messages sélectionnés"
 
 #. module: mail
 #. openerp-web
@@ -1961,7 +1963,7 @@ msgstr "Alias courriel"
 #. module: mail
 #: model:ir.model,name:mail.model_mail_alias_mixin
 msgid "Email Aliases Mixin"
-msgstr ""
+msgstr "Incorporer les alias courriel"
 
 #. module: mail
 #: model_terms:ir.ui.view,arch_db:mail.mail_blacklist_view_tree
@@ -2036,7 +2038,7 @@ msgstr ""
 #. module: mail
 #: selection:mail.notification,failure_type:0
 msgid "Email address rejected by destination"
-msgstr ""
+msgstr "Adresse rejetée par le destinataire"
 
 #. module: mail
 #: model_terms:ir.ui.view,arch_db:mail.email_compose_message_wizard_form
@@ -2109,6 +2111,8 @@ msgid ""
 "Error without exception. Probably due do concurrent access update of "
 "notification records. Please see with an administrator."
 msgstr ""
+"Erreur sans exception. Probablement due à un accès simultané à la mise à "
+"jour des enregistrements de notification. Adressez-vous à un administrateur."
 
 #. module: mail
 #: code:addons/mail/models/mail_mail.py:329
@@ -2398,7 +2402,7 @@ msgstr "Passerelle"
 #. module: mail
 #: selection:ir.actions.server,activity_user_type:0
 msgid "Generic User From Record"
-msgstr ""
+msgstr "Utilisateur générique de l'enregistrement"
 
 #. module: mail
 #: code:addons/mail/models/res_users.py:88
@@ -2438,7 +2442,7 @@ msgstr "Directives"
 #: code:addons/mail/models/mail_channel.py:448
 #, python-format
 msgid "Guidelines of channel %s"
-msgstr ""
+msgstr "Règles du canal %s"
 
 #. module: mail
 #: selection:res.users,notification_type:0
@@ -2667,6 +2671,9 @@ msgid ""
 "notification and review them one by one by clicking on the red envelope next"
 " to each message."
 msgstr ""
+"Si vous voulez les renvoyer, cliquez sur Annuler maintenant, puis cliquez "
+"sur la notification et passez-les en revue un par un en cliquant sur l'icône"
+" rouge à côté de chaque message."
 
 #. module: mail
 #: model_terms:ir.ui.view,arch_db:mail.mail_resend_message_view_form
@@ -2714,7 +2721,7 @@ msgstr "Info"
 #. module: mail
 #: model:ir.model.fields,field_description:mail.field_mail_activity_type__initial_res_model_id
 msgid "Initial model"
-msgstr ""
+msgstr "Modèle initial"
 
 #. module: mail
 #: model:ir.model.fields,help:mail.field_mail_compose_message__parent_id
@@ -2743,7 +2750,7 @@ msgstr "Adresse e-mail non-valide"
 #: code:addons/mail/models/mail_blacklist.py:35
 #, python-format
 msgid "Invalid email address %r"
-msgstr ""
+msgstr "Adresse email invalide %r"
 
 #. module: mail
 #: code:addons/mail/models/mail_alias.py:88
@@ -2760,7 +2767,7 @@ msgstr ""
 #: code:addons/mail/models/mail_blacklist.py:129
 #, python-format
 msgid "Invalid primary email field on model %s"
-msgstr ""
+msgstr "Champ email principal invalide sur le modèle %s"
 
 #. module: mail
 #: code:addons/mail/models/mail_thread.py:1968
@@ -2869,7 +2876,7 @@ msgstr "Est abonné"
 #. module: mail
 #: model:ir.model.fields,field_description:mail.field_mail_channel__is_chat
 msgid "Is a chat"
-msgstr ""
+msgstr "Est un chat"
 
 #. module: mail
 #: model:ir.model.fields,field_description:mail.field_mail_channel__is_member
@@ -3158,7 +3165,7 @@ msgstr "Blacklist Email"
 #. module: mail
 #: model:ir.model,name:mail.model_mail_blacklist_mixin
 msgid "Mail Blacklist mixin"
-msgstr ""
+msgstr "Incorporer la blacklist"
 
 #. module: mail
 #. openerp-web
@@ -3237,7 +3244,7 @@ msgstr "Pièce jointe principale"
 #: code:addons/mail/static/src/xml/thread.xml:9
 #, python-format
 msgid "Manage Messages"
-msgstr ""
+msgstr "Gérer les Messages"
 
 #. module: mail
 #. openerp-web
@@ -3569,7 +3576,7 @@ msgstr "Canaux modérés"
 #: code:addons/mail/models/mail_channel.py:170
 #, python-format
 msgid "Moderated channels must have moderators."
-msgstr ""
+msgstr "Les canaux modérés doivent avoir des modérateurs."
 
 #. module: mail
 #: model:ir.model.fields,field_description:mail.field_mail_channel__moderation_count
@@ -4086,6 +4093,8 @@ msgstr "En ligne"
 msgid ""
 "Only an administrator or a moderator can send guidelines to channel members!"
 msgstr ""
+"Seul un administrateur ou un modérateur peut envoyer les règles aux membres "
+"du canal !"
 
 #. module: mail
 #: code:addons/mail/models/ir_model.py:53
@@ -4097,7 +4106,7 @@ msgstr "Seul les modèles personnalisés peuvent être modifiés."
 #: code:addons/mail/models/mail_channel.py:165
 #, python-format
 msgid "Only mailing lists can be moderated."
-msgstr ""
+msgstr "Seules les mailing lists peuvent être modérées."
 
 #. module: mail
 #: selection:mail.channel.partner,fold_state:0
@@ -4109,7 +4118,7 @@ msgstr "Ouvertes"
 #: code:addons/mail/static/src/xml/thread.xml:409
 #, python-format
 msgid "Open Channel in Discuss to moderate"
-msgstr ""
+msgstr "Ouvrir le canal dans Discuss pour le modérer"
 
 #. module: mail
 #: model_terms:ir.ui.view,arch_db:mail.view_mail_alias_form
@@ -4422,7 +4431,7 @@ msgstr "Merci de nous contacter plutôt que d'utiliser"
 #. module: mail
 #: model_terms:ir.ui.view,arch_db:mail.mail_channel_send_guidelines
 msgid "Please find below the guidelines of the"
-msgstr ""
+msgstr "Prière de trouver ci-dessous les règles de"
 
 #. module: mail
 #. openerp-web
@@ -4470,7 +4479,7 @@ msgstr ""
 #: code:addons/mail/static/src/js/tour.js:48
 #, python-format
 msgid "Post your message on the thread"
-msgstr ""
+msgstr "Publier votre message dans le fil"
 
 #. module: mail
 #: model_terms:ir.ui.view,arch_db:mail.mail_notification_borders
@@ -4918,7 +4927,7 @@ msgstr "Chercher dans les groupes"
 #. module: mail
 #: model_terms:ir.ui.view,arch_db:mail.mail_moderation_view_search
 msgid "Search Moderation List"
-msgstr ""
+msgstr "Recherche une liste de Modération"
 
 #. module: mail
 #. openerp-web
@@ -4950,6 +4959,8 @@ msgid ""
 "Select the action to do on each mail and correct the email address if "
 "needed. The modified address will be saved on the corresponding contact."
 msgstr ""
+"Sélectionnez l'action à effectuer sur chaque email et corrigez l'adresse si "
+"nécessaire. L'adresse modifiée sera sauvegarder sur le contat correspondant."
 
 #. module: mail
 #: selection:mail.channel,public:0
@@ -5305,6 +5316,8 @@ msgid ""
 "Technical field to keep trace of the model at the beginning of the edition "
 "for UX related behaviour"
 msgstr ""
+"Champ technique pour garder la trace du modèlle au début de l'édition des "
+"comportements liés à l'expérience utilisateur."
 
 #. module: mail
 #: model:ir.model.fields,help:mail.field_ir_actions_server__activity_user_field_name
@@ -5339,7 +5352,7 @@ msgstr "Le"
 #: code:addons/mail/models/ir_actions.py:51
 #, python-format
 msgid "The 'Due Date In' value can't be negative."
-msgstr ""
+msgstr "La valeur de 'date d'échéance dans' ne peut être négative."
 
 #. module: mail
 #: sql_constraint:mail.moderation:0
@@ -5557,7 +5570,7 @@ msgstr "Valeurs du suivi"
 #. module: mail
 #: model:ir.model.fields,field_description:mail.field_mail_tracking_value__track_sequence
 msgid "Tracking field sequence"
-msgstr ""
+msgstr "Séquence du champ de suivi"
 
 #. module: mail
 #: model:ir.model.fields,field_description:mail.field_mail_compose_message__tracking_value_ids
@@ -5631,6 +5644,8 @@ msgstr "Impossible de se connecter au serveur SMTP"
 #, python-format
 msgid "Unable to log message, please configure the sender's email address."
 msgstr ""
+"Impossible d'enregistrer le message, veuillez configurer l'adresse e-mail de"
+" l'expéditeur."
 
 #. module: mail
 #: code:addons/mail/models/mail_thread.py:2172
@@ -5763,7 +5778,7 @@ msgstr "Type de rapport non pris en charge détecté (%s)."
 #: code:addons/mail/models/mail_message.py:188
 #, python-format
 msgid "Unsupported search filter on moderation status"
-msgstr ""
+msgstr "Filtre de recherche incompatible sur le statut de modération"
 
 #. module: mail
 #: selection:ir.actions.server,state:0
@@ -5901,6 +5916,8 @@ msgid ""
 "View \"mail.mail_channel_send_guidelines\" was not found. No email has been "
 "sent. Please contact an administrator to fix this issue."
 msgstr ""
+"La vue \"mail.mail_channel_send_guidelines\" est introuvable. Il n'y a pas "
+"eu d'email envoyé. Contactez votre administrateur pour résoudre ce problème."
 
 #. module: mail
 #: code:addons/mail/models/mail_thread.py:752
@@ -5919,7 +5936,7 @@ msgstr "Type de Vue"
 #: code:addons/mail/static/src/xml/chatter.xml:99
 #, python-format
 msgid "View all the attachments of the current record"
-msgstr ""
+msgstr "Voir toutes les pièces jointes de l'enregistrement courant."
 
 #. module: mail
 #. openerp-web
@@ -6283,11 +6300,13 @@ msgid ""
 "cannot be processed. This address\n"
 "    is used to collect replies and should not be used to directly contact"
 msgstr ""
+"ne peut pas être traité. Cette adresse\n"
+"    est utilisée pour recevoir les réponses et ne doit pas être utilisée pour contacter directement"
 
 #. module: mail
 #: model_terms:ir.ui.view,arch_db:mail.mail_channel_send_guidelines
 msgid "channel."
-msgstr ""
+msgstr "canal."
 
 #. module: mail
 #: model_terms:ir.ui.view,arch_db:mail.message_origin_link
@@ -6539,7 +6558,7 @@ msgstr "ce document"
 #. module: mail
 #: model_terms:ir.ui.view,arch_db:mail.message_activity_assigned
 msgid "to close for"
-msgstr ""
+msgstr "à fermer pour"
 
 #. module: mail
 #: code:addons/mail/models/mail_thread.py:1081
@@ -6564,7 +6583,7 @@ msgstr "sans nom"
 #. module: mail
 #: model_terms:ir.ui.view,arch_db:mail.message_notification_email
 msgid "using"
-msgstr ""
+msgstr "utilisant"
 
 #. module: mail
 #: selection:mail.activity.type,delay_unit:0

--- a/addons/mail/i18n/he.po
+++ b/addons/mail/i18n/he.po
@@ -2699,7 +2699,7 @@ msgstr "אשף הזמנה"
 #. module: mail
 #: selection:mail.channel,public:0
 msgid "Invited people only"
-msgstr ""
+msgstr "אנשים שהוזמנו בלבד"
 
 #. module: mail
 #: model_terms:ir.ui.view,arch_db:mail.mail_moderation_view_search

--- a/addons/mail/i18n/id.po
+++ b/addons/mail/i18n/id.po
@@ -10,7 +10,6 @@
 # William Surya Permana <zarambie_game@yahoo.com>, 2019
 # Dedi Santoso <dedisantoso@yahoo.com>, 2019
 # Febrasari Almania <febrasari.almania@gmail.com>, 2019
-# Muhammad Syarif <mhdsyarif.ms@gmail.com>, 2019
 # Gusti Rini <gustirini@gmail.com>, 2019
 # Martin Trigaux, 2019
 # oon arfiandwi <oon.arfiandwi@gmail.com>, 2019
@@ -19,6 +18,7 @@
 # Ryanto The <ry.the77@gmail.com>, 2019
 # Wahyu Setiawan <wahyusetiaaa@gmail.com>, 2019
 # PAS IRVANUS <ipankbiz@gmail.com>, 2019
+# Muhammad Syarif <mhdsyarif.ms@gmail.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -26,7 +26,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-11-14 07:34+0000\n"
 "PO-Revision-Date: 2018-08-24 09:20+0000\n"
-"Last-Translator: PAS IRVANUS <ipankbiz@gmail.com>, 2019\n"
+"Last-Translator: Muhammad Syarif <mhdsyarif.ms@gmail.com>, 2020\n"
 "Language-Team: Indonesian (https://www.transifex.com/odoo/teams/41243/id/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -2424,7 +2424,7 @@ msgstr "Memiliki lampiran"
 #: model:ir.model.fields,help:mail.field_mail_mail__has_error
 #: model:ir.model.fields,help:mail.field_mail_message__has_error
 msgid "Has error"
-msgstr ""
+msgstr "Ada kesalahan"
 
 #. module: mail
 #: model:ir.model.fields,field_description:mail.field_mail_mail__headers

--- a/addons/mail/i18n/it.po
+++ b/addons/mail/i18n/it.po
@@ -3349,7 +3349,7 @@ msgstr "Errore di consegna messaggio"
 #. module: mail
 #: model:ir.model.fields,field_description:mail.field_mail_tracking_value__mail_message_id
 msgid "Message ID"
-msgstr "ID Messaggio"
+msgstr "ID messaggio"
 
 #. module: mail
 #: model:ir.model,name:mail.model_mail_notification
@@ -3444,7 +3444,7 @@ msgstr "Identificativo univoco del messaggio"
 #: model:ir.model.fields,field_description:mail.field_mail_mail__message_id
 #: model:ir.model.fields,field_description:mail.field_mail_message__message_id
 msgid "Message-Id"
-msgstr "ID Messaggio"
+msgstr "ID messaggio"
 
 #. module: mail
 #: model:ir.actions.act_window,name:mail.action_view_mail_message
@@ -5697,7 +5697,7 @@ msgstr "Messaggi non letti"
 #: model:ir.model.fields,field_description:mail.field_res_partner__message_unread_counter
 #: model:ir.model.fields,field_description:mail.field_res_users__message_unread_counter
 msgid "Unread Messages Counter"
-msgstr "Contatore messaggi non letti"
+msgstr "Numero messaggi non letti"
 
 #. module: mail
 #. openerp-web
@@ -6433,8 +6433,8 @@ msgid ""
 "posting a message without model should be with a null res_id (private "
 "message), received %s"
 msgstr ""
-"Per pubblicare un messaggio senza modello, usi un ID res_id nullo (messaggio"
-" privato), ricevuto %s"
+"un messaggio senza modello deve essere spedito con res_id nullo (messaggio "
+"privato), ricevuto %s"
 
 #. module: mail
 #: code:addons/mail/models/mail_thread.py:1025
@@ -6442,7 +6442,7 @@ msgstr ""
 msgid ""
 "posting a message without model should be with a parent_id (private message)"
 msgstr ""
-"Per pubblicare un messaggio senza modello, usare un ID parent_id (messaggio "
+"un messaggio senza modello deve essere spedito con un parent_id (messaggio "
 "privato)"
 
 #. module: mail

--- a/addons/mail/i18n/ja.po
+++ b/addons/mail/i18n/ja.po
@@ -16,8 +16,8 @@
 # Tim Siu Lai <tl@roomsfor.hk>, 2019
 # 江口 和志 <k_eguchi@enzantrades.co.jp>, 2020
 # Konno Takatsugu <konno@token-express.com>, 2020
-# Yoshi Tashiro <tashiro@roomsfor.hk>, 2020
 # Hau Dao <hau@quartile.co>, 2020
+# Yoshi Tashiro <tashiro@roomsfor.hk>, 2020
 # 
 msgid ""
 msgstr ""
@@ -25,7 +25,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-11-14 07:34+0000\n"
 "PO-Revision-Date: 2018-08-24 09:20+0000\n"
-"Last-Translator: Hau Dao <hau@quartile.co>, 2020\n"
+"Last-Translator: Yoshi Tashiro <tashiro@roomsfor.hk>, 2020\n"
 "Language-Team: Japanese (https://www.transifex.com/odoo/teams/41243/ja/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -5685,7 +5685,7 @@ msgstr ""
 #: code:addons/mail/models/mail_thread.py:752
 #, python-format
 msgid "View %s"
-msgstr ""
+msgstr "%sを見る"
 
 #. module: mail
 #: model:ir.model.fields,field_description:mail.field_ir_actions_act_window_view__view_mode

--- a/addons/mail/i18n/pt_BR.po
+++ b/addons/mail/i18n/pt_BR.po
@@ -28,6 +28,7 @@
 # Fernanda Marques <fem@odoo.com>, 2020
 # Marcel Savegnago <marcel.savegnago@gmail.com>, 2020
 # Kevin Harrings <kha@odoo.com>, 2020
+# Guilherme Libardi <guilherme.libardig@gmail.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -35,7 +36,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-11-14 07:34+0000\n"
 "PO-Revision-Date: 2018-08-24 09:20+0000\n"
-"Last-Translator: Kevin Harrings <kha@odoo.com>, 2020\n"
+"Last-Translator: Guilherme Libardi <guilherme.libardig@gmail.com>, 2020\n"
 "Language-Team: Portuguese (Brazil) (https://www.transifex.com/odoo/teams/41243/pt_BR/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -3618,7 +3619,7 @@ msgstr "Necessita ação"
 #: model:ir.model.fields,field_description:mail.field_mail_mail__need_moderation
 #: model:ir.model.fields,field_description:mail.field_mail_message__need_moderation
 msgid "Need moderation"
-msgstr ""
+msgstr "Precisa de moderação"
 
 #. module: mail
 #: model:ir.model.fields,field_description:mail.field_mail_notification__res_partner_id

--- a/addons/mail/models/ir_actions.py
+++ b/addons/mail/models/ir_actions.py
@@ -130,6 +130,7 @@ class ServerActions(models.Model):
         if action.activity_date_deadline_range > 0:
             vals['date_deadline'] = fields.Date.context_today(action) + relativedelta(**{action.activity_date_deadline_range_type: action.activity_date_deadline_range})
         for record in records:
+            user = False
             if action.activity_user_type == 'specific':
                 user = action.activity_user_id
             elif action.activity_user_type == 'generic' and action.activity_user_field_name in record:

--- a/addons/mail/models/res_partner.py
+++ b/addons/mail/models/res_partner.py
@@ -133,7 +133,7 @@ class Partner(models.Model):
         for group_tpl_values in [group for group in recipients.values() if group['recipients']]:
             # generate notification email content
             template_ctx = {**base_template_ctx, **group_tpl_values}
-            mail_body = base_template.render(template_ctx, engine='ir.qweb', minimal_qcontext=True)
+            mail_body = base_template.render(template_ctx, engine='ir.qweb', minimal_qcontext=True) if base_template else message.body
             mail_body = self.env['mail.thread']._replace_local_links(mail_body)
             mail_subject = message.subject or (message.record_name and 'Re: %s' % message.record_name)
 

--- a/addons/mail/wizard/mail_compose_message_view.xml
+++ b/addons/mail/wizard/mail_compose_message_view.xml
@@ -60,7 +60,7 @@
                         <field name="subject" placeholder="Subject..." required="True"/>
                         <!-- mass post -->
                         <field name="notify"
-                            attrs="{'invisible':['|', ('composition_mode', '!=', 'mass_post')]}"/>
+                            attrs="{'invisible':[('composition_mode', '!=', 'mass_post')]}"/>
                         <!-- mass mailing -->
                         <field name="no_auto_thread" attrs="{'invisible':[('composition_mode', '!=', 'mass_mail')]}"/>
                         <field name="reply_to" placeholder="Email address to redirect replies..."

--- a/addons/mail_bot/i18n/fr.po
+++ b/addons/mail_bot/i18n/fr.po
@@ -7,6 +7,7 @@
 # Eloïse Stilmant <est@odoo.com>, 2018
 # William Olhasque <william.olhasque@scopea.fr>, 2019
 # Nicolas Roussey <nro@odoo.com>, 2019
+# Priscilla Sanchez <prs@odoo.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -14,7 +15,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2018-10-02 10:05+0000\n"
 "PO-Revision-Date: 2018-08-24 09:20+0000\n"
-"Last-Translator: Nicolas Roussey <nro@odoo.com>, 2019\n"
+"Last-Translator: Priscilla Sanchez <prs@odoo.com>, 2020\n"
 "Language-Team: French (https://www.transifex.com/odoo/teams/41243/fr/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -141,7 +142,7 @@ msgstr "Dernière modification le"
 #. module: mail_bot
 #: model:ir.model,name:mail_bot.model_mail_bot
 msgid "Mail Bot"
-msgstr ""
+msgstr "Mail Bot"
 
 #. module: mail_bot
 #: code:addons/mail_bot/models/mail_bot.py:45
@@ -215,17 +216,17 @@ msgstr "OdooBot a une demande"
 #. module: mail_bot
 #: selection:res.users,odoobot_state:0
 msgid "Onboarding attachement"
-msgstr ""
+msgstr "Accessoire d'intégration"
 
 #. module: mail_bot
 #: selection:res.users,odoobot_state:0
 msgid "Onboarding canned"
-msgstr ""
+msgstr "Onboarding canned"
 
 #. module: mail_bot
 #: selection:res.users,odoobot_state:0
 msgid "Onboarding command"
-msgstr ""
+msgstr "Commande d'intégration"
 
 #. module: mail_bot
 #: selection:res.users,odoobot_state:0
@@ -235,7 +236,7 @@ msgstr "Emoji Onboarding"
 #. module: mail_bot
 #: selection:res.users,odoobot_state:0
 msgid "Onboarding ping"
-msgstr ""
+msgstr "Ping d'intégration"
 
 #. module: mail_bot
 #. openerp-web

--- a/addons/mail_bot/i18n/ro.po
+++ b/addons/mail_bot/i18n/ro.po
@@ -5,7 +5,7 @@
 # Translators:
 # Martin Trigaux, 2018
 # sharkutz <sharkutz4life@yahoo.com>, 2019
-# Dorin Hongu <dhongu@gmail.com>, 2019
+# Dorin Hongu <dhongu@gmail.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -13,7 +13,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2018-10-02 10:05+0000\n"
 "PO-Revision-Date: 2018-08-24 09:20+0000\n"
-"Last-Translator: Dorin Hongu <dhongu@gmail.com>, 2019\n"
+"Last-Translator: Dorin Hongu <dhongu@gmail.com>, 2020\n"
 "Language-Team: Romanian (https://www.transifex.com/odoo/teams/41243/ro/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -37,7 +37,7 @@ msgstr "Contact"
 #. module: mail_bot
 #: selection:res.users,odoobot_state:0
 msgid "Disabled"
-msgstr ""
+msgstr "Dezactivat"
 
 #. module: mail_bot
 #: model:ir.model,name:mail_bot.model_mail_channel

--- a/addons/maintenance/i18n/et.po
+++ b/addons/maintenance/i18n/et.po
@@ -30,7 +30,7 @@ msgstr ""
 #. module: maintenance
 #: model_terms:ir.ui.view,arch_db:maintenance.hr_equipment_request_view_kanban
 msgid "<b>Category:</b>"
-msgstr "<b>Category:</b>"
+msgstr "<b>Kategooria:</b>"
 
 #. module: maintenance
 #: model_terms:ir.ui.view,arch_db:maintenance.hr_equipment_view_kanban
@@ -40,12 +40,12 @@ msgstr "<b>Model Number:</b>"
 #. module: maintenance
 #: model_terms:ir.ui.view,arch_db:maintenance.hr_equipment_request_view_kanban
 msgid "<b>Request to:</b>"
-msgstr "<b>Request to:</b>"
+msgstr "<b>Taotlus:</b>"
 
 #. module: maintenance
 #: model_terms:ir.ui.view,arch_db:maintenance.hr_equipment_view_kanban
 msgid "<b>Serial Number:</b>"
-msgstr "<b>Serial Number:</b>"
+msgstr "<b>Seerianumber:</b>"
 
 #. module: maintenance
 #: model_terms:ir.ui.view,arch_db:maintenance.hr_equipment_request_view_kanban
@@ -65,7 +65,7 @@ msgstr ""
 #. module: maintenance
 #: model_terms:ir.ui.view,arch_db:maintenance.hr_equipment_request_view_form
 msgid "<span class=\"ml8\">hours</span>"
-msgstr ""
+msgstr "<span class=\"ml8\">tundi</span>"
 
 #. module: maintenance
 #: model_terms:ir.ui.view,arch_db:maintenance.maintenance_team_kanban
@@ -80,12 +80,12 @@ msgstr "<span>Vaata</span>"
 #. module: maintenance
 #: model_terms:ir.ui.view,arch_db:maintenance.view_maintenance_equipment_category_kanban
 msgid "<strong>Equipments:</strong>"
-msgstr "<strong>Equipments:</strong>"
+msgstr "<strong>Seadmed:</strong>"
 
 #. module: maintenance
 #: model_terms:ir.ui.view,arch_db:maintenance.view_maintenance_equipment_category_kanban
 msgid "<strong>Maintenance:</strong>"
-msgstr "<strong>Maintenance:</strong>"
+msgstr "<strong>Hooldus:</strong>"
 
 #. module: maintenance
 #: model:ir.model.fields,help:maintenance.field_maintenance_equipment_category__alias_defaults
@@ -137,12 +137,12 @@ msgstr "Tegevuste tüübid"
 #: model_terms:ir.actions.act_window,help:maintenance.hr_equipment_action
 #: model_terms:ir.actions.act_window,help:maintenance.hr_equipment_action_from_category_form
 msgid "Add a new equipment"
-msgstr ""
+msgstr "Lisage uus varustus"
 
 #. module: maintenance
 #: model_terms:ir.actions.act_window,help:maintenance.hr_equipment_category_action
 msgid "Add a new equipment category"
-msgstr ""
+msgstr "Lisa uus masinate kategooria"
 
 #. module: maintenance
 #: model_terms:ir.actions.act_window,help:maintenance.hr_equipment_request_action
@@ -152,13 +152,13 @@ msgstr ""
 #: model_terms:ir.actions.act_window,help:maintenance.hr_equipment_todo_request_action_from_dashboard
 #: model_terms:ir.actions.act_window,help:maintenance.maintenance_request_action_reports
 msgid "Add a new maintenance request"
-msgstr ""
+msgstr "Lisage uus hooldustaotlus"
 
 #. module: maintenance
 #: model_terms:ir.actions.act_window,help:maintenance.hr_equipment_stage_action
 #: model_terms:ir.actions.act_window,help:maintenance.maintenance_dashboard_action
 msgid "Add a new stage in the maintenance request"
-msgstr ""
+msgstr "Lisage hooldustaotlusesse uus etapp"
 
 #. module: maintenance
 #: model_terms:ir.actions.act_window,help:maintenance.maintenance_team_action_settings
@@ -193,7 +193,7 @@ msgstr "Aliase mudel"
 #. module: maintenance
 #: model_terms:ir.ui.view,arch_db:maintenance.maintenance_team_kanban
 msgid "All"
-msgstr "All"
+msgstr "Kõik"
 
 #. module: maintenance
 #: sql_constraint:maintenance.equipment:0
@@ -216,18 +216,18 @@ msgstr "Arhiveeritud"
 #: model_terms:ir.ui.view,arch_db:maintenance.hr_equipment_category_view_tree
 #: model_terms:ir.ui.view,arch_db:maintenance.hr_equipment_view_tree
 msgid "Assign To User"
-msgstr "Assign To User"
+msgstr "Määrake kasutajale"
 
 #. module: maintenance
 #: model_terms:ir.ui.view,arch_db:maintenance.hr_equipment_request_view_search
 #: model_terms:ir.ui.view,arch_db:maintenance.hr_equipment_view_search
 msgid "Assigned"
-msgstr "Loomise kuupäev"
+msgstr "Määratud"
 
 #. module: maintenance
 #: model:ir.model.fields,field_description:maintenance.field_maintenance_equipment__assign_date
 msgid "Assigned Date"
-msgstr "Assigned Date"
+msgstr "Määratud kuupäev"
 
 #. module: maintenance
 #: model:ir.model.fields,field_description:maintenance.field_maintenance_equipment__message_attachment_count
@@ -330,7 +330,7 @@ msgstr "Loonud"
 #. module: maintenance
 #: model:ir.model.fields,field_description:maintenance.field_maintenance_request__owner_user_id
 msgid "Created by User"
-msgstr ""
+msgstr "Loodud kasutaja poolt"
 
 #. module: maintenance
 #: model:ir.model.fields,field_description:maintenance.field_maintenance_equipment__create_date
@@ -344,7 +344,7 @@ msgstr "Loomise kuupäev"
 #. module: maintenance
 #: model:ir.model.fields,field_description:maintenance.field_maintenance_equipment__maintenance_open_count
 msgid "Current Maintenance"
-msgstr "Current Maintenance"
+msgstr "Praegune hooldus"
 
 #. module: maintenance
 #: model:ir.ui.menu,name:maintenance.menu_m_dashboard
@@ -361,7 +361,7 @@ msgstr ""
 #. module: maintenance
 #: model:ir.model.fields,field_description:maintenance.field_maintenance_equipment__next_action_date
 msgid "Date of the next preventive maintenance"
-msgstr "Date of the next preventive maintenance"
+msgstr "Järgmise ennetava hoolduse kuupäev"
 
 #. module: maintenance
 #: model:ir.model.fields,help:maintenance.field_maintenance_request__request_date
@@ -374,18 +374,18 @@ msgid ""
 "Date the maintenance team plans the maintenance.  It should not differ much "
 "from the Request Date. "
 msgstr ""
-"Date the maintenance team plans the maintenance.  It should not differ much "
-"from the Request Date. "
+"Kuupäev, mil hooldusmeeskond hooldust kavandab. See ei tohiks "
+"taotluskuupäevast palju erineda."
 
 #. module: maintenance
 #: model:ir.model.fields,help:maintenance.field_maintenance_request__close_date
 msgid "Date the maintenance was finished. "
-msgstr "Date the maintenance was finished. "
+msgstr "Hoolduse lõpetamise kuupäev."
 
 #. module: maintenance
 #: model:ir.model.fields,field_description:maintenance.field_maintenance_equipment__period
 msgid "Days between each preventive maintenance"
-msgstr "Days between each preventive maintenance"
+msgstr "Päevad iga ennetava hoolduse vahel"
 
 #. module: maintenance
 #: model:ir.model.fields,field_description:maintenance.field_maintenance_equipment_category__alias_defaults
@@ -428,7 +428,7 @@ msgstr "Rippmenüü"
 #. module: maintenance
 #: model:ir.model.fields,field_description:maintenance.field_maintenance_request__duration
 msgid "Duration"
-msgstr "Kestvus"
+msgstr "Kestus"
 
 #. module: maintenance
 #: model:ir.model.fields,help:maintenance.field_maintenance_request__duration
@@ -477,23 +477,23 @@ msgstr "Equipment Assigned"
 #: model:ir.ui.menu,name:maintenance.menu_maintenance_cat
 #: model_terms:ir.ui.view,arch_db:maintenance.hr_equipment_category_view_form
 msgid "Equipment Categories"
-msgstr "Equipment Categories"
+msgstr "Masinate kategooriad"
 
 #. module: maintenance
 #: model:ir.model.fields,field_description:maintenance.field_maintenance_equipment__category_id
 msgid "Equipment Category"
-msgstr "Equipment Category"
+msgstr "Masina kategooria"
 
 #. module: maintenance
 #: model:res.groups,name:maintenance.group_equipment_manager
 msgid "Equipment Manager"
-msgstr "Equipment Manager"
+msgstr "Masina juht"
 
 #. module: maintenance
 #: model:ir.model.fields,field_description:maintenance.field_maintenance_equipment__name
 #: model_terms:ir.ui.view,arch_db:maintenance.hr_equipment_view_form
 msgid "Equipment Name"
-msgstr "Equipment Name"
+msgstr "Masina nimi"
 
 #. module: maintenance
 #: model:ir.actions.act_window,name:maintenance.hr_equipment_action
@@ -520,8 +520,7 @@ msgstr "Folded in Maintenance Pipe"
 #: model_terms:ir.actions.act_window,help:maintenance.maintenance_request_action_reports
 msgid ""
 "Follow the process of the request and communicate with the collaborator."
-msgstr ""
-"Follow the process of the request and communicate with the collaborator."
+msgstr "Järgige päringu protsessi ja suhelge kaastöötajaga."
 
 #. module: maintenance
 #: model:ir.model.fields,field_description:maintenance.field_maintenance_equipment__message_follower_ids
@@ -710,7 +709,7 @@ msgstr "Hooldus"
 #. module: maintenance
 #: model:ir.ui.menu,name:maintenance.menu_m_request_calendar
 msgid "Maintenance Calendar"
-msgstr "Maintenance Calendar"
+msgstr "Hoolduste kalender"
 
 #. module: maintenance
 #: model:ir.model.fields,field_description:maintenance.field_maintenance_equipment__maintenance_count
@@ -722,49 +721,49 @@ msgstr ""
 #: model:ir.model.fields,field_description:maintenance.field_maintenance_equipment__maintenance_duration
 #: model_terms:ir.ui.view,arch_db:maintenance.hr_equipment_view_form
 msgid "Maintenance Duration"
-msgstr "Maintenance Duration"
+msgstr "Hoolduse kestvus"
 
 #. module: maintenance
 #: model:ir.model.fields,help:maintenance.field_maintenance_equipment__maintenance_duration
 msgid "Maintenance Duration in hours."
-msgstr "Maintenance Duration in hours."
+msgstr "Hoolduse kestvus tundides."
 
 #. module: maintenance
 #: model:ir.model,name:maintenance.model_maintenance_equipment
 msgid "Maintenance Equipment"
-msgstr "Maintenance Equipment"
+msgstr "<Hooldusseadmed"
 
 #. module: maintenance
 #: model:ir.model,name:maintenance.model_maintenance_equipment_category
 msgid "Maintenance Equipment Category"
-msgstr ""
+msgstr "Hooldusmasinate kategooria"
 
 #. module: maintenance
 #: model:ir.model,name:maintenance.model_maintenance_request
 #: model_terms:ir.ui.view,arch_db:maintenance.hr_equipment_request_view_form
 #: model:mail.activity.type,name:maintenance.mail_act_maintenance_request
 msgid "Maintenance Request"
-msgstr "Maintenance Request"
+msgstr "Hooldustaotlus"
 
 #. module: maintenance
 #: model:mail.message.subtype,name:maintenance.mt_cat_req_created
 msgid "Maintenance Request Created"
-msgstr "Maintenance Request Created"
+msgstr "Hooldustaotlus on loodud"
 
 #. module: maintenance
 #: model_terms:ir.ui.view,arch_db:maintenance.hr_equipment_stage_view_tree
 msgid "Maintenance Request Stage"
-msgstr "Maintenance Request Stage"
+msgstr "Hooldustaotluse etapp"
 
 #. module: maintenance
 #: model_terms:ir.ui.view,arch_db:maintenance.hr_equipment_stage_view_search
 msgid "Maintenance Request Stages"
-msgstr "Maintenance Request Stages"
+msgstr "Hooldustaotluse etapp"
 
 #. module: maintenance
 #: model:mail.message.subtype,description:maintenance.mt_req_created
 msgid "Maintenance Request created"
-msgstr "Maintenance Request created"
+msgstr "Hooldustaotlus on loodud"
 
 #. module: maintenance
 #: model:ir.actions.act_window,name:maintenance.hr_equipment_request_action
@@ -782,38 +781,40 @@ msgstr "Hoolduse taotlused"
 #. module: maintenance
 #: model:ir.model,name:maintenance.model_maintenance_stage
 msgid "Maintenance Stage"
-msgstr "Maintenance Stage"
+msgstr "Hoolduse etapp"
 
 #. module: maintenance
 #: model:ir.ui.menu,name:maintenance.menu_maintenance_stage_configuration
 msgid "Maintenance Stages"
-msgstr "Maintenance Stages"
+msgstr "Hoolduse etapid"
 
 #. module: maintenance
 #: model:ir.model.fields,field_description:maintenance.field_maintenance_equipment__maintenance_team_id
 #: model_terms:ir.ui.view,arch_db:maintenance.maintenance_team_view_form
 #: model_terms:ir.ui.view,arch_db:maintenance.maintenance_team_view_tree
 msgid "Maintenance Team"
-msgstr "Maintenance Team"
+msgstr "Hooldusmeeskond"
 
 #. module: maintenance
 #: model:ir.actions.act_window,name:maintenance.maintenance_dashboard_action
 #: model:ir.model,name:maintenance.model_maintenance_team
 #: model:ir.ui.menu,name:maintenance.menu_maintenance_teams
 msgid "Maintenance Teams"
-msgstr "Maintenance Teams"
+msgstr "Hooldusmeeskonnad"
 
 #. module: maintenance
 #: model:ir.model.fields,field_description:maintenance.field_maintenance_request__maintenance_type
 msgid "Maintenance Type"
-msgstr "Maintenance Type"
+msgstr "Hoolduse tüüp"
 
 #. module: maintenance
 #: model:ir.actions.server,name:maintenance.maintenance_requests_cron_ir_actions_server
 #: model:ir.cron,cron_name:maintenance.maintenance_requests_cron
 #: model:ir.cron,name:maintenance.maintenance_requests_cron
 msgid "Maintenance: generate preventive maintenance requests"
-msgstr "Maintenance: generate preventive maintenance requests"
+msgstr ""
+"\n"
+"Hooldus: genereerige ennetavaid hooldustaotlusi"
 
 #. module: maintenance
 #: model:ir.model.fields,field_description:maintenance.field_maintenance_equipment__message_has_error
@@ -853,7 +854,7 @@ msgstr "Minu tegevused"
 #. module: maintenance
 #: model_terms:ir.ui.view,arch_db:maintenance.hr_equipment_view_search
 msgid "My Equipments"
-msgstr "My Equipments"
+msgstr "Minu seadmed"
 
 #. module: maintenance
 #: model_terms:ir.ui.view,arch_db:maintenance.hr_equipment_request_view_search
@@ -872,7 +873,7 @@ msgstr "Nimi"
 #. module: maintenance
 #: model:maintenance.stage,name:maintenance.stage_0
 msgid "New Request"
-msgstr "New Request"
+msgstr "Uued taotlused"
 
 #. module: maintenance
 #: model:ir.model.fields,field_description:maintenance.field_maintenance_equipment__activity_date_deadline
@@ -895,7 +896,7 @@ msgstr "Järgmise tegevuse tüüp"
 #. module: maintenance
 #: model_terms:ir.ui.view,arch_db:maintenance.hr_equipment_view_form
 msgid "Next Preventive Maintenance"
-msgstr "Next Preventive Maintenance"
+msgstr "Järgmine ennetav hooldus"
 
 #. module: maintenance
 #: selection:maintenance.request,priority:0
@@ -917,22 +918,22 @@ msgstr "Toimingute arv"
 #. module: maintenance
 #: model:ir.model.fields,field_description:maintenance.field_maintenance_team__todo_request_count
 msgid "Number of Requests"
-msgstr "Number of Requests"
+msgstr "Taotluste arv"
 
 #. module: maintenance
 #: model:ir.model.fields,field_description:maintenance.field_maintenance_team__todo_request_count_block
 msgid "Number of Requests Blocked"
-msgstr "Number of Requests Blocked"
+msgstr "Blokeeritud taotluste arv"
 
 #. module: maintenance
 #: model:ir.model.fields,field_description:maintenance.field_maintenance_team__todo_request_count_date
 msgid "Number of Requests Scheduled"
-msgstr "Number of Requests Scheduled"
+msgstr "Planeeritud taotluste arv"
 
 #. module: maintenance
 #: model:ir.model.fields,field_description:maintenance.field_maintenance_team__todo_request_count_unscheduled
 msgid "Number of Requests Unscheduled"
-msgstr "Number of Requests Unscheduled"
+msgstr "Planeerimata hooldustaotluste arv"
 
 #. module: maintenance
 #: model:ir.model.fields,field_description:maintenance.field_maintenance_team__todo_request_count_high_priority
@@ -981,7 +982,7 @@ msgstr ""
 #. module: maintenance
 #: model:ir.ui.menu,name:maintenance.menu_m_reports_oee
 msgid "Overall Equipment Effectiveness (OEE)"
-msgstr "Overall Equipment Effectiveness (OEE)"
+msgstr "Masinate efektiivsus (OEE)"
 
 #. module: maintenance
 #: selection:maintenance.equipment,activity_state:0
@@ -1027,7 +1028,7 @@ msgstr "Telefonid"
 #: selection:maintenance.equipment,activity_state:0
 #: selection:maintenance.request,activity_state:0
 msgid "Planned"
-msgstr "Planned"
+msgstr "Planeeritud"
 
 #. module: maintenance
 #: model:ir.model.fields,help:maintenance.field_maintenance_equipment_category__alias_contact
@@ -1045,18 +1046,18 @@ msgstr ""
 #. module: maintenance
 #: selection:maintenance.request,maintenance_type:0
 msgid "Preventive"
-msgstr "Preventive"
+msgstr "Ennetav"
 
 #. module: maintenance
 #: code:addons/maintenance/models/maintenance.py:231
 #, python-format
 msgid "Preventive Maintenance - %s"
-msgstr "Preventive Maintenance - %s"
+msgstr "Ennetav hooldus - %s"
 
 #. module: maintenance
 #: model_terms:ir.ui.view,arch_db:maintenance.hr_equipment_view_form
 msgid "Preventive Maintenance Frequency"
-msgstr "Preventive Maintenance Frequency"
+msgstr "Ennetava hoolduse sagedus"
 
 #. module: maintenance
 #: model:maintenance.equipment.category,name:maintenance.equipment_printer
@@ -1071,7 +1072,7 @@ msgstr "Prioriteet"
 #. module: maintenance
 #: model_terms:ir.ui.view,arch_db:maintenance.hr_equipment_view_form
 msgid "Product Information"
-msgstr "Product Information"
+msgstr "Toote informatsioon"
 
 #. module: maintenance
 #: selection:maintenance.request,kanban_state:0
@@ -1113,17 +1114,17 @@ msgstr "Päring"
 #. module: maintenance
 #: model:mail.message.subtype,name:maintenance.mt_req_created
 msgid "Request Created"
-msgstr "Request Created"
+msgstr "Taotlus loodud"
 
 #. module: maintenance
 #: model:ir.model.fields,field_description:maintenance.field_maintenance_request__request_date
 msgid "Request Date"
-msgstr "Request Date"
+msgstr "Taotluse kuupäev"
 
 #. module: maintenance
 #: model:ir.model.fields,field_description:maintenance.field_maintenance_stage__done
 msgid "Request Done"
-msgstr "Request Done"
+msgstr "Taotlus tehtud"
 
 #. module: maintenance
 #: code:addons/maintenance/models/maintenance.py:375
@@ -1134,17 +1135,17 @@ msgstr ""
 #. module: maintenance
 #: model_terms:ir.ui.view,arch_db:maintenance.hr_equipment_request_view_form
 msgid "Requested By"
-msgstr "Requested By"
+msgstr "Nõutud"
 
 #. module: maintenance
 #: model_terms:ir.ui.view,arch_db:maintenance.hr_equipment_request_view_kanban
 msgid "Requested by :"
-msgstr "Requested by :"
+msgstr "Nõutud:"
 
 #. module: maintenance
 #: model:ir.model.fields,field_description:maintenance.field_maintenance_team__todo_request_ids
 msgid "Requests"
-msgstr "Requests"
+msgstr "Päringud"
 
 #. module: maintenance
 #: model:ir.model.fields,field_description:maintenance.field_maintenance_equipment_category__technician_user_id
@@ -1184,7 +1185,7 @@ msgstr "Praak"
 #. module: maintenance
 #: model:ir.model.fields,field_description:maintenance.field_maintenance_equipment__scrap_date
 msgid "Scrap Date"
-msgstr "Scrap Date"
+msgstr "Praagi kuupäev"
 
 #. module: maintenance
 #: model_terms:ir.ui.view,arch_db:maintenance.hr_equipment_category_view_search
@@ -1208,7 +1209,7 @@ msgstr "Seerianumber"
 msgid ""
 "Set archive to true to hide the maintenance request without deleting it."
 msgstr ""
-"Set archive to true to hide the maintenance request without deleting it."
+"Hooldustaotluse peitmiseks ilma seda kustutamata seadke väärtuseks tõene."
 
 #. module: maintenance
 #: model_terms:ir.ui.view,arch_db:maintenance.maintenance_team_kanban
@@ -1242,7 +1243,7 @@ msgstr "Etapid"
 #. module: maintenance
 #: model:mail.message.subtype,name:maintenance.mt_req_status
 msgid "Status Changed"
-msgstr "Status Changed"
+msgstr "Staatus on muudetud"
 
 #. module: maintenance
 #: model:ir.model.fields,help:maintenance.field_maintenance_equipment__activity_state
@@ -1267,7 +1268,7 @@ msgstr ""
 #. module: maintenance
 #: model:ir.model.fields,field_description:maintenance.field_maintenance_request__name
 msgid "Subjects"
-msgstr "Subjects"
+msgstr "Subjektid"
 
 #. module: maintenance
 #: model:ir.model.fields,field_description:maintenance.field_maintenance_request__maintenance_team_id
@@ -1282,23 +1283,23 @@ msgstr "Tiimiliikmed"
 #. module: maintenance
 #: model_terms:ir.ui.view,arch_db:maintenance.maintenance_team_view_form
 msgid "Team Name"
-msgstr "Team Name"
+msgstr "Meeskonna nimi"
 
 #. module: maintenance
 #: model:ir.actions.act_window,name:maintenance.maintenance_team_action_settings
 msgid "Teams"
-msgstr "Teams"
+msgstr "Meeskonnad"
 
 #. module: maintenance
 #: model:ir.model.fields,field_description:maintenance.field_maintenance_equipment__technician_user_id
 #: model:ir.model.fields,field_description:maintenance.field_maintenance_request__user_id
 msgid "Technician"
-msgstr "Technician"
+msgstr "Tehnik"
 
 #. module: maintenance
 #: model_terms:ir.ui.view,arch_db:maintenance.hr_equipment_view_search
 msgid "Technicians"
-msgstr "Technicians"
+msgstr "Tehnikud"
 
 #. module: maintenance
 #: model:ir.model.fields,help:maintenance.field_maintenance_equipment_category__alias_model_id
@@ -1346,7 +1347,7 @@ msgstr "Tegemiseks"
 #. module: maintenance
 #: model_terms:ir.ui.view,arch_db:maintenance.hr_equipment_request_view_search
 msgid "To do"
-msgstr "To do"
+msgstr "Tegemiseks"
 
 #. module: maintenance
 #: selection:maintenance.equipment,activity_state:0
@@ -1364,7 +1365,7 @@ msgstr "Tänased tegevused"
 #: model_terms:ir.ui.view,arch_db:maintenance.hr_equipment_request_view_search
 #: model_terms:ir.ui.view,arch_db:maintenance.maintenance_team_kanban
 msgid "Top Priorities"
-msgstr "Top Priorities"
+msgstr "Prioriteetsed"
 
 #. module: maintenance
 #: model_terms:ir.actions.act_window,help:maintenance.hr_equipment_action
@@ -1377,7 +1378,7 @@ msgstr ""
 #. module: maintenance
 #: model_terms:ir.ui.view,arch_db:maintenance.hr_equipment_view_search
 msgid "Under Maintenance"
-msgstr "Under Maintenance"
+msgstr "Hoolduses"
 
 #. module: maintenance
 #: model:ir.model.fields,field_description:maintenance.field_maintenance_equipment__message_unread
@@ -1399,17 +1400,17 @@ msgstr "Lugemata sõnumite loendur"
 #. module: maintenance
 #: model_terms:ir.ui.view,arch_db:maintenance.maintenance_team_kanban
 msgid "Unscheduled"
-msgstr "Unscheduled"
+msgstr "Planeerimata"
 
 #. module: maintenance
 #: model_terms:ir.ui.view,arch_db:maintenance.hr_equipment_request_view_search
 msgid "Unscheduled Maintenance"
-msgstr "Unscheduled Maintenance"
+msgstr "Planeerimata hooldus"
 
 #. module: maintenance
 #: model_terms:ir.ui.view,arch_db:maintenance.hr_equipment_view_form
 msgid "Used in location"
-msgstr "Used in location"
+msgstr "Kasutatakse asukohas"
 
 #. module: maintenance
 #: model:ir.model.fields,field_description:maintenance.field_maintenance_equipment__partner_id
@@ -1430,7 +1431,7 @@ msgstr "Väga madal"
 #. module: maintenance
 #: model:ir.model.fields,field_description:maintenance.field_maintenance_equipment__warranty_date
 msgid "Warranty Expiration Date"
-msgstr ""
+msgstr "Garantii lõppemise kuupäev"
 
 #. module: maintenance
 #: model:ir.model.fields,field_description:maintenance.field_maintenance_equipment__website_message_ids
@@ -1459,7 +1460,7 @@ msgstr ""
 #. module: maintenance
 #: model_terms:ir.ui.view,arch_db:maintenance.hr_equipment_view_form
 msgid "days"
-msgstr "päeva pärast"
+msgstr "päev(a)"
 
 #. module: maintenance
 #: model_terms:ir.ui.view,arch_db:maintenance.hr_equipment_view_form
@@ -1471,9 +1472,9 @@ msgstr "tundi"
 #: model_terms:ir.ui.view,arch_db:maintenance.hr_equipment_request_view_pivot
 #: model_terms:ir.ui.view,arch_db:maintenance.hr_equipment_request_view_tree
 msgid "maintenance Request"
-msgstr "maintenance Request"
+msgstr "Hoolduse taotlus"
 
 #. module: maintenance
 #: model_terms:ir.ui.view,arch_db:maintenance.hr_equipment_request_view_search
 msgid "maintenance Request Search"
-msgstr "maintenance Request Search"
+msgstr "Hooldustaotluse otsing"

--- a/addons/maintenance/i18n/eu.po
+++ b/addons/maintenance/i18n/eu.po
@@ -15,6 +15,8 @@
 # Naomi Hidalgo <naomihid96@gmail.com>, 2019
 # Victor Laskurain <blaskurain@binovo.es>, 2019
 # Maialen Rodriguez <maialenrodriguez98@gmail.com>, 2020
+# Miren Maiz <mirenmaizz@gmail.com>, 2020
+# Mikel Galarza <mikelgalarza99@gmail.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -22,7 +24,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-03-29 10:10+0000\n"
 "PO-Revision-Date: 2018-08-24 09:20+0000\n"
-"Last-Translator: Maialen Rodriguez <maialenrodriguez98@gmail.com>, 2020\n"
+"Last-Translator: Mikel Galarza <mikelgalarza99@gmail.com>, 2020\n"
 "Language-Team: Basque (https://www.transifex.com/odoo/teams/41243/eu/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -96,6 +98,8 @@ msgid ""
 "A Python dictionary that will be evaluated to provide default values when "
 "creating new records for this alias."
 msgstr ""
+"Python hiztegi bat, ezizen horrentzat erregistro berriak sortzen direnean "
+"lehenetsitako balioak emateko ebaluatuko dena."
 
 #. module: maintenance
 #: model:maintenance.equipment,name:maintenance.equipment_computer3
@@ -174,7 +178,7 @@ msgstr "Alias"
 #. module: maintenance
 #: model:ir.model.fields,field_description:maintenance.field_maintenance_equipment_category__alias_contact
 msgid "Alias Contact Security"
-msgstr ""
+msgstr "Segurtasun Kontaktu Ezizena"
 
 #. module: maintenance
 #: model:ir.model.fields,field_description:maintenance.field_maintenance_equipment_category__alias_name
@@ -189,7 +193,7 @@ msgstr "Alias domeinua "
 #. module: maintenance
 #: model:ir.model.fields,field_description:maintenance.field_maintenance_equipment_category__alias_model_id
 msgid "Aliased Model"
-msgstr ""
+msgstr "Ezizenaren eredua"
 
 #. module: maintenance
 #: model_terms:ir.ui.view,arch_db:maintenance.maintenance_team_kanban
@@ -1144,7 +1148,7 @@ msgstr "Arduraduna"
 #: model:ir.model.fields,field_description:maintenance.field_maintenance_equipment__activity_user_id
 #: model:ir.model.fields,field_description:maintenance.field_maintenance_request__activity_user_id
 msgid "Responsible User"
-msgstr ""
+msgstr "Erabiltzaile arduraduna"
 
 #. module: maintenance
 #: model:maintenance.equipment,name:maintenance.equipment_monitor1

--- a/addons/maintenance/i18n/eu.po
+++ b/addons/maintenance/i18n/eu.po
@@ -16,7 +16,7 @@
 # Victor Laskurain <blaskurain@binovo.es>, 2019
 # Maialen Rodriguez <maialenrodriguez98@gmail.com>, 2020
 # Miren Maiz <mirenmaizz@gmail.com>, 2020
-# Mikel Galarza <mikelgalarza99@gmail.com>, 2020
+# mgalarza005 <mikelgalarza99@gmail.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -24,7 +24,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-03-29 10:10+0000\n"
 "PO-Revision-Date: 2018-08-24 09:20+0000\n"
-"Last-Translator: Mikel Galarza <mikelgalarza99@gmail.com>, 2020\n"
+"Last-Translator: mgalarza005 <mikelgalarza99@gmail.com>, 2020\n"
 "Language-Team: Basque (https://www.transifex.com/odoo/teams/41243/eu/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -590,6 +590,8 @@ msgid ""
 "ID of the parent record holding the alias (example: project holding the task"
 " creation alias)"
 msgstr ""
+"Ezizena duen erregistro gurasoaren ID (adibidez: atazak sortzeko ezizena "
+"duen proiektua)"
 
 #. module: maintenance
 #: model:ir.model.fields,help:maintenance.field_maintenance_equipment__message_unread
@@ -1077,7 +1079,7 @@ msgstr ""
 #. module: maintenance
 #: model:ir.model.fields,field_description:maintenance.field_maintenance_equipment_category__alias_force_thread_id
 msgid "Record Thread ID"
-msgstr ""
+msgstr "Record Thread-en ID"
 
 #. module: maintenance
 #: model_terms:ir.ui.view,arch_db:maintenance.hr_equipment_request_view_form

--- a/addons/maintenance/i18n/it.po
+++ b/addons/maintenance/i18n/it.po
@@ -1408,7 +1408,7 @@ msgstr "Messaggi non letti"
 #: model:ir.model.fields,field_description:maintenance.field_maintenance_equipment_category__message_unread_counter
 #: model:ir.model.fields,field_description:maintenance.field_maintenance_request__message_unread_counter
 msgid "Unread Messages Counter"
-msgstr "Contatore messaggi non letti"
+msgstr "Numero messaggi non letti"
 
 #. module: maintenance
 #: model_terms:ir.ui.view,arch_db:maintenance.maintenance_team_kanban

--- a/addons/mass_mailing/i18n/et.po
+++ b/addons/mass_mailing/i18n/et.po
@@ -380,7 +380,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:mass_mailing.field_mail_mass_mailing_list_contact_rel__is_blacklisted
 #: model:ir.ui.menu,name:mass_mailing.mail_blacklist_mm_menu
 msgid "Blacklist"
-msgstr ""
+msgstr "Must nimekiri"
 
 #. module: mass_mailing
 #: model_terms:ir.ui.view,arch_db:mass_mailing.unsubscribe

--- a/addons/mass_mailing/i18n/eu.po
+++ b/addons/mass_mailing/i18n/eu.po
@@ -14,6 +14,8 @@
 # Victor Laskurain <blaskurain@binovo.es>, 2019
 # Martin Trigaux, 2019
 # Maialen Rodriguez <maialenrodriguez98@gmail.com>, 2020
+# Mikel Galarza <mikelgalarza99@gmail.com>, 2020
+# Unai Muñoz <unaimunoz9@gmail.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -21,7 +23,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-11-14 07:35+0000\n"
 "PO-Revision-Date: 2018-08-24 09:20+0000\n"
-"Last-Translator: Maialen Rodriguez <maialenrodriguez98@gmail.com>, 2020\n"
+"Last-Translator: Unai Muñoz <unaimunoz9@gmail.com>, 2020\n"
 "Language-Team: Basque (https://www.transifex.com/odoo/teams/41243/eu/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -354,7 +356,7 @@ msgstr ""
 #. module: mass_mailing
 #: model_terms:ir.ui.view,arch_db:mass_mailing.view_mail_mass_mailing_form
 msgid "Attach a file"
-msgstr ""
+msgstr "Fitxategia eranskin "
 
 #. module: mass_mailing
 #: model:ir.model.fields,field_description:mass_mailing.field_mail_mass_mailing_contact__message_attachment_count
@@ -405,7 +407,7 @@ msgstr "Gorputza"
 #: model_terms:ir.ui.view,arch_db:mass_mailing.view_mail_mass_mailing_form
 #: selection:mail.mail.statistics,state:0
 msgid "Bounced"
-msgstr ""
+msgstr "Berreskuratze"
 
 #. module: mass_mailing
 #: model:ir.model.fields,field_description:mass_mailing.field_mail_mass_mailing__bounced_ratio
@@ -904,7 +906,7 @@ msgstr "Aurreikusita"
 #. module: mass_mailing
 #: model_terms:ir.ui.view,arch_db:mass_mailing.view_mail_statistics_report_search
 msgid "Extended Filters..."
-msgstr ""
+msgstr "Iragazki hedatuak ..."
 
 #. module: mass_mailing
 #: model_terms:ir.ui.view,arch_db:mass_mailing.s_mail_block_discount1

--- a/addons/mass_mailing/i18n/fr.po
+++ b/addons/mass_mailing/i18n/fr.po
@@ -18,6 +18,7 @@
 # Jonathan <jcs@odoo.com>, 2020
 # Martin Trigaux, 2020
 # Cécile Collart <cco@odoo.com>, 2020
+# Priscilla Sanchez <prs@odoo.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -25,7 +26,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-11-14 07:35+0000\n"
 "PO-Revision-Date: 2018-08-24 09:20+0000\n"
-"Last-Translator: Cécile Collart <cco@odoo.com>, 2020\n"
+"Last-Translator: Priscilla Sanchez <prs@odoo.com>, 2020\n"
 "Language-Team: French (https://www.transifex.com/odoo/teams/41243/fr/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -377,7 +378,7 @@ msgstr "Des Apps qui vous aident à faire grandir votre business"
 #. module: mass_mailing
 #: model:ir.model.fields,field_description:mass_mailing.field_mass_mailing_list_merge__archive_src_lists
 msgid "Archive source mailing lists"
-msgstr ""
+msgstr "Archiver les listes de diffusion source"
 
 #. module: mass_mailing
 #: model_terms:ir.ui.view,arch_db:mass_mailing.view_mail_mass_mailing_list_search
@@ -801,7 +802,7 @@ msgstr "Conception"
 #. module: mass_mailing
 #: model:ir.model.fields,field_description:mass_mailing.field_mass_mailing_list_merge__dest_list_id
 msgid "Destination Mailing List"
-msgstr ""
+msgstr "Liste de diffusion à destination"
 
 #. module: mass_mailing
 #: model_terms:ir.ui.view,arch_db:mass_mailing.mass_mailing_schedule_date_view_form
@@ -1203,7 +1204,7 @@ msgstr "Surveillance de liens"
 #. module: mass_mailing
 #: model:ir.model,name:mass_mailing.model_link_tracker_click
 msgid "Link Tracker Click"
-msgstr ""
+msgstr "Lien Tracker Click"
 
 #. module: mass_mailing
 #: model:ir.model.fields,field_description:mass_mailing.field_mail_mail_statistics__links_click_ids
@@ -1434,7 +1435,7 @@ msgstr "Nom du publipostage"
 #. module: mass_mailing
 #: model:ir.model,name:mass_mailing.model_mass_mailing_schedule_date
 msgid "Mass Mailing Scheduling"
-msgstr ""
+msgstr "Planification du publipostage"
 
 #. module: mass_mailing
 #: model:ir.model,name:mass_mailing.model_mail_statistics_report
@@ -1460,7 +1461,7 @@ msgstr ""
 #. module: mass_mailing
 #: model:ir.model,name:mass_mailing.model_mail_mass_mailing_list_contact_rel
 msgid "Mass Mailing Subscription Information"
-msgstr ""
+msgstr "Informations d'abonnement à l'envoi de masse"
 
 #. module: mass_mailing
 #: model:ir.model,name:mass_mailing.model_mail_mass_mailing_tag
@@ -1495,27 +1496,27 @@ msgstr "Fusionner"
 #: model:ir.model,name:mass_mailing.model_mass_mailing_list_merge
 #: model_terms:ir.ui.view,arch_db:mass_mailing.mass_mailing_list_merge_view_form
 msgid "Merge Mass Mailing List"
-msgstr ""
+msgstr "Fusionner la liste de diffusion en masse"
 
 #. module: mass_mailing
 #: model:ir.model.fields,field_description:mass_mailing.field_mass_mailing_list_merge__merge_options
 msgid "Merge Option"
-msgstr ""
+msgstr "Option de fusion"
 
 #. module: mass_mailing
 #: model:ir.actions.act_window,name:mass_mailing.mass_mailing_list_merge_action
 msgid "Merge Selected Mailing Lists"
-msgstr ""
+msgstr "Fusionner les listes de diffusion sélectionnées"
 
 #. module: mass_mailing
 #: selection:mass.mailing.list.merge,merge_options:0
 msgid "Merge into a new mailing list"
-msgstr ""
+msgstr "Fusionner dans une nouvelle liste de diffusion"
 
 #. module: mass_mailing
 #: selection:mass.mailing.list.merge,merge_options:0
 msgid "Merge into an existing mailing list"
-msgstr ""
+msgstr "Fusionner dans une liste de diffusion existante"
 
 #. module: mass_mailing
 #: model:ir.model.fields,field_description:mass_mailing.field_mail_mass_mailing_contact__message_has_error
@@ -1572,7 +1573,7 @@ msgstr "Nom / Courriel"
 #. module: mass_mailing
 #: model:ir.model.fields,field_description:mass_mailing.field_mass_mailing_list_merge__new_list_name
 msgid "New Mailing List Name"
-msgstr ""
+msgstr "Nouveau nom de la liste de diffusion"
 
 #. module: mass_mailing
 #: model:mail.mass_mailing.campaign,name:mass_mailing.mass_mail_campaign_1
@@ -1727,6 +1728,9 @@ msgid ""
 "Opt out flag for a specific mailing list.This field should not be used in a "
 "view without a unique and active mailing list context."
 msgstr ""
+"Désactiver l'indicateur pour une liste de diffusion spécifique. Ce champ ne "
+"doit pas être utilisé dans une vue sans un contexte de liste de diffusion "
+"unique et actif."
 
 #. module: mass_mailing
 #: model_terms:ir.ui.view,arch_db:mass_mailing.view_mail_mass_mailing_form
@@ -1796,7 +1800,7 @@ msgstr "Ratio réception"
 #. module: mass_mailing
 #: selection:mail.mass_mailing,reply_to_mode:0
 msgid "Recipient Followers"
-msgstr ""
+msgstr "Abonnés bénéficiaires"
 
 #. module: mass_mailing
 #: model:ir.model.fields,field_description:mass_mailing.field_mail_mail_statistics__email
@@ -1889,19 +1893,19 @@ msgstr "Analyse"
 #: code:addons/mass_mailing/controllers/main.py:68
 #, python-format
 msgid "Requested blacklisting via unsubscribe link."
-msgstr ""
+msgstr "Liste noire demandée via le lien de désabonnement."
 
 #. module: mass_mailing
 #: code:addons/mass_mailing/controllers/main.py:127
 #, python-format
 msgid "Requested blacklisting via unsubscription page."
-msgstr ""
+msgstr "Liste noire demandée via la page de désabonnement."
 
 #. module: mass_mailing
 #: code:addons/mass_mailing/controllers/main.py:139
 #, python-format
 msgid "Requested de-blacklisting via unsubscription page."
-msgstr ""
+msgstr "Désinscription demandée via la page de désinscription."
 
 #. module: mass_mailing
 #: model:ir.model.fields,field_description:mass_mailing.field_mail_mass_mailing_campaign__user_id
@@ -1962,6 +1966,8 @@ msgid ""
 "Search opt out cannot be executed without a unique and valid active mailing "
 "list context."
 msgstr ""
+"La désactivation de la recherche ne peut pas être exécutée sans un contexte "
+"de liste de diffusion active unique et valide."
 
 #. module: mass_mailing
 #: model_terms:ir.ui.view,arch_db:mass_mailing.email_designer_snippets
@@ -2154,7 +2160,7 @@ msgstr "Étiquettes"
 #. module: mass_mailing
 #: model_terms:ir.ui.view,arch_db:mass_mailing.mass_mailing_schedule_date_view_form
 msgid "Take Future Schedule Date"
-msgstr ""
+msgstr "Prendre la date de planification future"
 
 #. module: mass_mailing
 #: model_terms:ir.ui.view,arch_db:mass_mailing.view_mail_mass_mailing_form
@@ -2364,7 +2370,7 @@ msgstr "Date de décinscription"
 #: code:addons/mass_mailing/models/mass_mailing.py:880
 #, python-format
 msgid "Unsupported mass mailing model %s"
-msgstr ""
+msgstr "Modèle d'envoi massif non pris en charge %s"
 
 #. module: mass_mailing
 #: model_terms:ir.ui.view,arch_db:mass_mailing.unsubscribe
@@ -2376,7 +2382,7 @@ msgstr "Mettre à jour mes abonnements"
 #: code:addons/mass_mailing/static/src/xml/mass_mailing.xml:17
 #, python-format
 msgid "Upgrade theme"
-msgstr ""
+msgstr "Thème de mise à niveau"
 
 #. module: mass_mailing
 #: model_terms:ir.ui.view,arch_db:mass_mailing.s_mail_block_paragraph
@@ -2406,6 +2412,9 @@ msgid ""
 "outgoing mail server available (based on their sequencing) as it does for "
 "normal mails."
 msgstr ""
+"Utilisez un serveur de messagerie spécifique en priorité. Sinon, Odoo "
+"s'appuie sur le premier serveur de messagerie sortant disponible (en "
+"fonction de leur séquence), comme c'est le cas pour les e-mails normaux."
 
 #. module: mass_mailing
 #: model_terms:ir.ui.view,arch_db:mass_mailing.s_mail_block_discount2
@@ -2451,6 +2460,8 @@ msgid ""
 "We would appreciate if you provide feedback about why you updated<br/>your "
 "subscriptions"
 msgstr ""
+"Nous vous serions reconnaissants de bien vouloir nous expliquer pourquoi "
+"vous avez mis à jour<br/>vos abonnements"
 
 #. module: mass_mailing
 #: model:ir.model.fields,field_description:mass_mailing.field_mail_mass_mailing_contact__website_message_ids
@@ -2517,7 +2528,7 @@ msgstr "Vous n'êtes pas abonné à l'une des notre liste d'envoi."
 #: code:addons/mass_mailing/static/src/js/unsubscribe.js:50
 #, python-format
 msgid "You have been <strong>successfully unsubscribed from %s</strong>."
-msgstr ""
+msgstr "Vous avez été <strong>désabonné avec succès de  %s</strong>."
 
 #. module: mass_mailing
 #. openerp-web

--- a/addons/mass_mailing/i18n/he.po
+++ b/addons/mass_mailing/i18n/he.po
@@ -1526,7 +1526,7 @@ msgstr ""
 #: model:mail.mass_mailing.campaign,name:mass_mailing.mass_mail_campaign_1
 #: model:utm.campaign,name:mass_mailing.mass_mail_campaign_1_utm_campaign
 msgid "Newsletter"
-msgstr ""
+msgstr "דיוור"
 
 #. module: mass_mailing
 #: model_terms:ir.ui.view,arch_db:mass_mailing.s_mail_block_comparison_table

--- a/addons/mass_mailing/i18n/it.po
+++ b/addons/mass_mailing/i18n/it.po
@@ -1516,7 +1516,7 @@ msgstr "Errore di consegna messaggio"
 #. module: mass_mailing
 #: model:ir.model.fields,field_description:mass_mailing.field_mail_mail_statistics__message_id
 msgid "Message-ID"
-msgstr "ID Messaggio"
+msgstr "ID messaggio"
 
 #. module: mass_mailing
 #: model:ir.model.fields,field_description:mass_mailing.field_mail_mass_mailing_contact__message_ids
@@ -2333,7 +2333,7 @@ msgstr "Messaggi non letti"
 #. module: mass_mailing
 #: model:ir.model.fields,field_description:mass_mailing.field_mail_mass_mailing_contact__message_unread_counter
 msgid "Unread Messages Counter"
-msgstr "Contatore messaggi non letti"
+msgstr "Numero messaggi non letti"
 
 #. module: mass_mailing
 #: model_terms:ir.ui.view,arch_db:mass_mailing.s_mail_block_footer_social

--- a/addons/mass_mailing/i18n/ro.po
+++ b/addons/mass_mailing/i18n/ro.po
@@ -4,7 +4,7 @@
 # 
 # Translators:
 # Martin Trigaux, 2019
-# Dorin Hongu <dhongu@gmail.com>, 2019
+# Dorin Hongu <dhongu@gmail.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -12,7 +12,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-11-14 07:35+0000\n"
 "PO-Revision-Date: 2018-08-24 09:20+0000\n"
-"Last-Translator: Dorin Hongu <dhongu@gmail.com>, 2019\n"
+"Last-Translator: Dorin Hongu <dhongu@gmail.com>, 2020\n"
 "Language-Team: Romanian (https://www.transifex.com/odoo/teams/41243/ro/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1915,12 +1915,12 @@ msgstr "Trimite acum"
 #. module: mass_mailing
 #: model_terms:ir.ui.view,arch_db:mass_mailing.view_mail_mass_mailing_test_form
 msgid "Send Sample Mail"
-msgstr ""
+msgstr "Trimite email de probă"
 
 #. module: mass_mailing
 #: model_terms:ir.ui.view,arch_db:mass_mailing.view_mail_mass_mailing_test_form
 msgid "Send a Sample Mail"
-msgstr ""
+msgstr "Trimite un email de probă"
 
 #. module: mass_mailing
 #: model_terms:ir.ui.view,arch_db:mass_mailing.view_mail_mass_mailing_test_form

--- a/addons/mrp/i18n/da.po
+++ b/addons/mrp/i18n/da.po
@@ -13,7 +13,7 @@
 # Joe Hansen <joedalton2@yahoo.dk>, 2019
 # Ejner Sønniksen <ejner@vkdata.dk>, 2019
 # lhmflexerp <lhm@flexerp.dk>, 2019
-# Sanne Kristensen <sanne@vkdata.dk>, 2019
+# Sanne Kristensen <sanne@vkdata.dk>, 2020
 # 
 msgid ""
 msgstr ""
@@ -21,7 +21,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-11-14 07:33+0000\n"
 "PO-Revision-Date: 2018-08-24 09:21+0000\n"
-"Last-Translator: Sanne Kristensen <sanne@vkdata.dk>, 2019\n"
+"Last-Translator: Sanne Kristensen <sanne@vkdata.dk>, 2020\n"
 "Language-Team: Danish (https://www.transifex.com/odoo/teams/41243/da/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -44,7 +44,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:mrp.field_product_product__bom_count
 #: model:ir.model.fields,field_description:mrp.field_product_template__bom_count
 msgid "# Bill of Material"
-msgstr "# Styklister"
+msgstr "# Stykliste"
 
 #. module: mrp
 #: model:ir.model.fields,field_description:mrp.field_product_product__used_in_bom_count
@@ -547,7 +547,7 @@ msgstr "Styklistelinje"
 #: model_terms:ir.ui.view,arch_db:mrp.product_product_form_view_bom_button
 #: model_terms:ir.ui.view,arch_db:mrp.product_template_form_view_bom_button
 msgid "Bill of Materials"
-msgstr "Stykliste"
+msgstr "Styklister"
 
 #. module: mrp
 #: model:ir.model.fields,help:mrp.field_mrp_production__bom_id
@@ -562,7 +562,7 @@ msgstr ""
 #: model:ir.actions.act_window,name:mrp.mrp_bom_form_action
 #: model:ir.ui.menu,name:mrp.menu_mrp_bom_form_action
 msgid "Bills of Materials"
-msgstr "Stykliste"
+msgstr "Styklister"
 
 #. module: mrp
 #: model_terms:ir.actions.act_window,help:mrp.mrp_bom_form_action
@@ -878,7 +878,7 @@ msgstr "Opret arbejdsordre"
 #. module: mrp
 #: model_terms:ir.actions.act_window,help:mrp.mrp_bom_form_action
 msgid "Create a bill of materials"
-msgstr ""
+msgstr "Opret styklister"
 
 #. module: mrp
 #: model_terms:ir.actions.act_window,help:mrp.mrp_production_action
@@ -1491,7 +1491,7 @@ msgid ""
 msgstr ""
 "Hvis produktet er et halvt produceret produkt: Når en produktionsordre behandles,\n"
 "                                    der indeholder det produkt som komponent,\n"
-"                                    så vil de rå materialer for det produkt blive tilføjet til\n"
+"                                    så vil råmaterialer for det produkt blive tilføjet til\n"
 "                                    produktionsordren for det endelige produkt."
 
 #. module: mrp
@@ -3968,12 +3968,12 @@ msgstr "Afventer tilgængelighed"
 #: code:addons/mrp/static/src/js/mrp.js:38
 #, python-format
 msgid "Waiting Materials"
-msgstr "Afventer Materialer"
+msgstr "Afventer materialer"
 
 #. module: mrp
 #: model_terms:ir.ui.view,arch_db:mrp.view_mrp_production_filter
 msgid "Waiting for Materials"
-msgstr ""
+msgstr "Afventer materialer"
 
 #. module: mrp
 #: model:ir.model,name:mrp.model_stock_warehouse
@@ -4339,7 +4339,7 @@ msgstr ""
 #: code:addons/mrp/models/mrp_bom.py:109
 #, python-format
 msgid "You cannot create a new Bill of Material from here."
-msgstr ""
+msgstr "Du kan ikke oprette en ny stykliste herfra."
 
 #. module: mrp
 #: code:addons/mrp/models/mrp_unbuild.py:88

--- a/addons/mrp/i18n/eu.po
+++ b/addons/mrp/i18n/eu.po
@@ -17,6 +17,8 @@
 # Victor Laskurain <blaskurain@binovo.es>, 2019
 # Iñaki Ibarrola <inakiibarrola@yahoo.es>, 2020
 # Maialen Rodriguez <maialenrodriguez98@gmail.com>, 2020
+# Miren Maiz <mirenmaizz@gmail.com>, 2020
+# Mikel Galarza <mikelgalarza99@gmail.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -24,7 +26,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-11-14 07:33+0000\n"
 "PO-Revision-Date: 2018-08-24 09:21+0000\n"
-"Last-Translator: Maialen Rodriguez <maialenrodriguez98@gmail.com>, 2020\n"
+"Last-Translator: Mikel Galarza <mikelgalarza99@gmail.com>, 2020\n"
 "Language-Team: Basque (https://www.transifex.com/odoo/teams/41243/eu/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -52,12 +54,12 @@ msgstr "Material zerrenda kop."
 #. module: mrp
 #: model:ir.model.fields,field_description:mrp.field_product_product__used_in_bom_count
 msgid "# BoM Where Used"
-msgstr ""
+msgstr "BOM ez erabilia"
 
 #. module: mrp
 #: model:ir.model.fields,field_description:mrp.field_mrp_production__workorder_done_count
 msgid "# Done Work Orders"
-msgstr ""
+msgstr "Egindako lanak"
 
 #. module: mrp
 #: model:ir.model.fields,field_description:mrp.field_mrp_workcenter__workorder_ready_count
@@ -87,7 +89,7 @@ msgstr ""
 #: model:product.product,description:mrp.product_product_computer_desk_leg
 #: model:product.template,description:mrp.product_product_computer_desk_leg_product_template
 msgid "18″ x 2½″ Square Leg"
-msgstr ""
+msgstr "18″ x 2½″ oin azalera"
 
 #. module: mrp
 #: model_terms:ir.ui.view,arch_db:mrp.mrp_workcenter_kanban
@@ -2959,7 +2961,7 @@ msgstr "Arduraduna"
 #: model:ir.model.fields,field_description:mrp.field_mrp_production__activity_user_id
 #: model:ir.model.fields,field_description:mrp.field_mrp_unbuild__activity_user_id
 msgid "Responsible User"
-msgstr ""
+msgstr "Erabiltzaile arduraduna"
 
 #. module: mrp
 #: model:ir.model.fields,field_description:mrp.field_mrp_bom__routing_id

--- a/addons/mrp/i18n/eu.po
+++ b/addons/mrp/i18n/eu.po
@@ -18,7 +18,7 @@
 # Iñaki Ibarrola <inakiibarrola@yahoo.es>, 2020
 # Maialen Rodriguez <maialenrodriguez98@gmail.com>, 2020
 # Miren Maiz <mirenmaizz@gmail.com>, 2020
-# Mikel Galarza <mikelgalarza99@gmail.com>, 2020
+# mgalarza005 <mikelgalarza99@gmail.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -26,7 +26,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-11-14 07:33+0000\n"
 "PO-Revision-Date: 2018-08-24 09:21+0000\n"
-"Last-Translator: Mikel Galarza <mikelgalarza99@gmail.com>, 2020\n"
+"Last-Translator: mgalarza005 <mikelgalarza99@gmail.com>, 2020\n"
 "Language-Team: Basque (https://www.transifex.com/odoo/teams/41243/eu/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -2359,7 +2359,7 @@ msgstr "Zain"
 #: model_terms:ir.ui.view,arch_db:mrp.mrp_workcenter_kanban
 #: selection:mrp.workcenter.productivity.loss.type,loss_type:0
 msgid "Performance"
-msgstr ""
+msgstr "Errendimendua"
 
 #. module: mrp
 #: model_terms:ir.ui.view,arch_db:mrp.oee_search_view

--- a/addons/mrp/i18n/fi.po
+++ b/addons/mrp/i18n/fi.po
@@ -16,7 +16,6 @@
 # Veikko Väätäjä <veikko.vaataja@gmail.com>, 2018
 # Pekko Tuomisto <pekko.tuomisto@web-veistamo.fi>, 2018
 # Mikko Närjänen <mikko.narjanen@web-veistamo.fi>, 2018
-# Jarmo Kortetjärvi <jarmo.kortetjarvi@gmail.com>, 2018
 # Martin Trigaux, 2018
 # Kari Lindgren <kari.lindgren@emsystems.fi>, 2018
 # Svante Suominen <svante.suominen@web-veistamo.fi>, 2018
@@ -29,6 +28,7 @@
 # Henri Komulainen <henri.komulainen@web-veistamo.fi>, 2019
 # Simo Suurla <simo@suurla.fi>, 2019
 # Tuomas Lyyra <tuomas.lyyra@legenda.fi>, 2019
+# Jarmo Kortetjärvi <jarmo.kortetjarvi@gmail.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -36,7 +36,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-11-14 07:33+0000\n"
 "PO-Revision-Date: 2018-08-24 09:21+0000\n"
-"Last-Translator: Tuomas Lyyra <tuomas.lyyra@legenda.fi>, 2019\n"
+"Last-Translator: Jarmo Kortetjärvi <jarmo.kortetjarvi@gmail.com>, 2020\n"
 "Language-Team: Finnish (https://www.transifex.com/odoo/teams/41243/fi/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -112,17 +112,17 @@ msgstr ""
 #. module: mrp
 #: model_terms:ir.ui.view,arch_db:mrp.workcenter_line_kanban
 msgid "<i class=\"fa fa-pause\" role=\"img\" aria-label=\"Pause\" title=\"Pause\"/>"
-msgstr ""
+msgstr "<i class=\"fa fa-pause\" role=\"img\" aria-label=\"Pause\" title=\"Pause\"/>"
 
 #. module: mrp
 #: model_terms:ir.ui.view,arch_db:mrp.workcenter_line_kanban
 msgid "<i class=\"fa fa-play\" role=\"img\" aria-label=\"Run\" title=\"Run\"/>"
-msgstr ""
+msgstr "<i class=\"fa fa-play\" role=\"img\" aria-label=\"Run\" title=\"Run\"/>"
 
 #. module: mrp
 #: model_terms:ir.ui.view,arch_db:mrp.workcenter_line_kanban
 msgid "<i class=\"fa fa-stop\" role=\"img\" aria-label=\"Stop\" title=\"Stop\"/>"
-msgstr ""
+msgstr "<i class=\"fa fa-stop\" role=\"img\" aria-label=\"Stop\" title=\"Stop\"/>"
 
 #. module: mrp
 #: code:addons/mrp/models/mrp_bom.py:332
@@ -170,7 +170,7 @@ msgstr "<span class=\"o_stat_text\">Hävinnyt</span>"
 #: model_terms:ir.ui.view,arch_db:mrp.product_product_form_view_bom_button
 #: model_terms:ir.ui.view,arch_db:mrp.product_template_form_view_bom_button
 msgid "<span class=\"o_stat_text\">Manufactured</span>"
-msgstr ""
+msgstr "<span class=\"o_stat_text\">Valmistettu</span>"
 
 #. module: mrp
 #: model_terms:ir.ui.view,arch_db:mrp.mrp_workcenter_view
@@ -211,7 +211,7 @@ msgstr ""
 #. module: mrp
 #: model_terms:ir.ui.view,arch_db:mrp.report_mrp_bom
 msgid "<span><strong>Unit Cost</strong></span>"
-msgstr ""
+msgstr "<span><strong>Yksikköhinta</strong></span>"
 
 #. module: mrp
 #: model_terms:ir.ui.view,arch_db:mrp.mrp_workcenter_kanban
@@ -636,7 +636,7 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:mrp.report_mrp_bom
 #, python-format
 msgid "BoM Cost"
-msgstr ""
+msgstr "Osaluettelon kustannukset"
 
 #. module: mrp
 #: model:ir.model.fields,field_description:mrp.field_stock_move__bom_line_id
@@ -654,7 +654,7 @@ msgstr "Osaluettelon rivit"
 #: model:ir.actions.report,name:mrp.action_report_bom_structure
 #, python-format
 msgid "BoM Structure"
-msgstr ""
+msgstr "Osaluettelon rakenne"
 
 #. module: mrp
 #. openerp-web
@@ -662,12 +662,12 @@ msgstr ""
 #: model:ir.actions.client,name:mrp.action_report_mrp_bom
 #, python-format
 msgid "BoM Structure & Cost"
-msgstr ""
+msgstr "Osaluettelon rakenne ja kustannukset"
 
 #. module: mrp
 #: model_terms:ir.ui.view,arch_db:mrp.report_mrp_bom
 msgid "BoM Structure &amp; Cost"
-msgstr ""
+msgstr "Osaluettelon rakenne ja kustannukset"
 
 #. module: mrp
 #: model:ir.model.fields,field_description:mrp.field_mrp_bom__type
@@ -769,7 +769,7 @@ msgstr "Tarkista saatavuus"
 #. module: mrp
 #: model:ir.model.fields,field_description:mrp.field_mrp_document__checksum
 msgid "Checksum/SHA1"
-msgstr ""
+msgstr "Checksum/SHA1"
 
 #. module: mrp
 #: model:ir.model.fields,field_description:mrp.field_mrp_workcenter__code

--- a/addons/mrp/i18n/he.po
+++ b/addons/mrp/i18n/he.po
@@ -2596,7 +2596,7 @@ msgstr ""
 #. module: mrp
 #: model_terms:ir.ui.view,arch_db:mrp.res_config_settings_view_form
 msgid "Produce residual products (A + B -&gt; C + D)"
-msgstr ""
+msgstr "ייצר מוצרי לוואי (א + ב -&gt; ג + ד)"
 
 #. module: mrp
 #: model_terms:ir.ui.view,arch_db:mrp.production_message

--- a/addons/mrp/i18n/hu.po
+++ b/addons/mrp/i18n/hu.po
@@ -11,8 +11,8 @@
 # Tamás Dombos, 2019
 # Ákos Nagy <akos.nagy@oregional.hu>, 2019
 # Istvan <leki69@gmail.com>, 2019
-# Tamás Németh <ntomasz81@gmail.com>, 2019
 # gezza <geza.nagy@oregional.hu>, 2020
+# Tamás Németh <ntomasz81@gmail.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -20,7 +20,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-11-14 07:33+0000\n"
 "PO-Revision-Date: 2018-08-24 09:21+0000\n"
-"Last-Translator: gezza <geza.nagy@oregional.hu>, 2020\n"
+"Last-Translator: Tamás Németh <ntomasz81@gmail.com>, 2020\n"
 "Language-Team: Hungarian (https://www.transifex.com/odoo/teams/41243/hu/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -3560,7 +3560,7 @@ msgstr ""
 #. module: mrp
 #: model_terms:ir.actions.act_window,help:mrp.action_mrp_unbuild_move_line
 msgid "There's no product move yet"
-msgstr ""
+msgstr "Még nincs termékmozgás"
 
 #. module: mrp
 #: model:ir.model.fields,help:mrp.field_mrp_workcenter__tz

--- a/addons/mrp/i18n/it.po
+++ b/addons/mrp/i18n/it.po
@@ -23,6 +23,7 @@
 # Léonie Bouchat <lbo@odoo.com>, 2019
 # Lorenzo Battistini <lb@takobi.online>, 2019
 # Sergio Zanchetta <primes2h@gmail.com>, 2020
+# Iacopo Simonelli <lsi@odoo.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -30,7 +31,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-11-14 07:33+0000\n"
 "PO-Revision-Date: 2018-08-24 09:21+0000\n"
-"Last-Translator: Sergio Zanchetta <primes2h@gmail.com>, 2020\n"
+"Last-Translator: Iacopo Simonelli <lsi@odoo.com>, 2020\n"
 "Language-Team: Italian (https://www.transifex.com/odoo/teams/41243/it/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1742,7 +1743,7 @@ msgstr "Attività in ritardo"
 #: model:product.product,description:mrp.product_product_wood_ply
 #: model:product.template,description:mrp.product_product_wood_ply_product_template
 msgid "Layers that are stick together to assemble wood panels."
-msgstr ""
+msgstr "Strati che si uniscono per assemblare pannelli di legno."
 
 #. module: mrp
 #: code:addons/mrp/models/mrp_production.py:492
@@ -1831,7 +1832,7 @@ msgstr "Ordini di produzione manufatturieri"
 #. module: mrp
 #: model:ir.model,name:mrp.model_mrp_workcenter_productivity_loss_type
 msgid "MRP Workorder productivity losses"
-msgstr ""
+msgstr "Perdite di produttività dell'ordine di lavoro (MRP)"
 
 #. module: mrp
 #: model:ir.model.fields,field_description:mrp.field_mrp_bom__message_main_attachment_id
@@ -3261,6 +3262,8 @@ msgid ""
 "Some of your components are tracked, you have to specify a manufacturing "
 "order in order to retrieve the correct components."
 msgstr ""
+"Alcuni dei tuoi componenti sono tracciati, devi specificare un ordine di "
+"produzione per selezionare i componenti corretti."
 
 #. module: mrp
 #: code:addons/mrp/models/mrp_production.py:590
@@ -3386,7 +3389,7 @@ msgstr "Report della regola dello stock"
 #: code:addons/mrp/models/stock_warehouse.py:200
 #, python-format
 msgid "Store Finished Product"
-msgstr ""
+msgstr "Immagazina il prodotto finito"
 
 #. module: mrp
 #: model:ir.model.fields,field_description:mrp.field_mrp_document__store_fname
@@ -3413,7 +3416,7 @@ msgstr "Tavolo (MTO)"
 #: model:product.product,name:mrp.product_product_table_kit
 #: model:product.template,name:mrp.product_product_table_kit_product_template
 msgid "Table Kit"
-msgstr ""
+msgstr "Tabella Kit"
 
 #. module: mrp
 #: model:product.product,name:mrp.product_product_computer_desk_leg
@@ -3431,7 +3434,7 @@ msgstr "Piano del tavolo"
 #: model:product.product,description:mrp.product_product_table_kit
 #: model:product.template,description:mrp.product_product_table_kit_product_template
 msgid "Table kit"
-msgstr ""
+msgstr "Tabella Kit"
 
 #. module: mrp
 #: model:ir.model.fields,help:mrp.field_stock_move__is_done
@@ -3470,7 +3473,7 @@ msgstr "Campo tecnico per verificare se si può pubblicare"
 #. module: mrp
 #: model:ir.model.fields,help:mrp.field_mrp_production__unreserve_visible
 msgid "Technical field to check when we can unreserve"
-msgstr ""
+msgstr "Campo tecnico per verificare se si può annullare la prenotazione"
 
 #. module: mrp
 #: model:ir.model.fields,help:mrp.field_mrp_document__key
@@ -3581,6 +3584,10 @@ msgid ""
 "production orders will  be executed through work orders, otherwise "
 "everything is processed in the production order itself. "
 msgstr ""
+"Le operazioni per produrre questa distinta dei materiali. Quando viene "
+"specificato un routing, gli ordini di produzione verranno eseguiti tramite "
+"ordini di lavoro, altrimenti tutto verrà elaborato nell'ordine di produzione"
+" stesso."
 
 #. module: mrp
 #: code:addons/mrp/wizard/mrp_product_produce.py:56
@@ -3605,6 +3612,9 @@ msgid ""
 "create work orders afterwards which alters the execution of the "
 "manufacturing order."
 msgstr ""
+"Il routing contiene tutti i centri di lavoro utilizzati e per quanto tempo. "
+"Ciò creerà in seguito ordini di lavoro che alterano l'esecuzione dell'ordine"
+" di produzione."
 
 #. module: mrp
 #: code:addons/mrp/models/stock_rule.py:38
@@ -3639,6 +3649,11 @@ msgid ""
 "the efficiency factor is 200%, however the expected duration will be 30 "
 "minutes."
 msgstr ""
+"Questo campo viene utilizzato per calcolare la durata prevista di un ordine "
+"di lavoro nel centro di lavoro. Ad esempio, se un ordine di lavoro richiede "
+"un'ora e il fattore di efficienza è del 100%, la durata prevista sarà di "
+"un'ora. Se il fattore di efficienza è del 200%, tuttavia la durata prevista "
+"sarà di 30 minuti."
 
 #. module: mrp
 #: model_terms:ir.ui.view,arch_db:mrp.report_mrp_bom
@@ -3722,6 +3737,8 @@ msgid ""
 "Time in minutes. Is the time used in manual mode, or the first time supposed"
 " in real time when there are not any work orders yet."
 msgstr ""
+"Tempo in minuti. È il tempo utilizzato in modalità manuale, se non ci sono "
+"ancora ordini di lavoro inserire il tempo supposto."
 
 #. module: mrp
 #: model_terms:ir.ui.view,arch_db:mrp.mrp_production_workorder_form_view_inherit
@@ -3793,7 +3810,7 @@ msgstr "Attività odierne"
 #: model:product.product,description:mrp.product_product_wood_wear
 #: model:product.template,description:mrp.product_product_wood_wear_product_template
 msgid "Top layer of a wood panel."
-msgstr ""
+msgstr "Strato superiore di un pannello di legno."
 
 #. module: mrp
 #: model:ir.model.fields,field_description:mrp.field_mrp_workcenter__workorder_late_count
@@ -3864,19 +3881,21 @@ msgstr "Sblocca"
 #: model:ir.model.fields,field_description:mrp.field_stock_warn_insufficient_qty_unbuild__unbuild_id
 #: model_terms:ir.ui.view,arch_db:mrp.mrp_unbuild_form_view
 msgid "Unbuild"
-msgstr ""
+msgstr "Smonta"
 
 #. module: mrp
 #: model:ir.model,name:mrp.model_mrp_unbuild
 #: model_terms:ir.ui.view,arch_db:mrp.mrp_unbuild_form_view
 msgid "Unbuild Order"
-msgstr ""
+msgstr "Ordine di Smontaggio"
 
 #. module: mrp
 #: code:addons/mrp/models/mrp_unbuild.py:77
 #, python-format
 msgid "Unbuild Order product quantity has to be strictly positive."
 msgstr ""
+"La quantità del prodotto nell'ordine di smontaggio deve essere strettamente "
+"positiva."
 
 #. module: mrp
 #: model:ir.actions.act_window,name:mrp.mrp_unbuild
@@ -3893,7 +3912,7 @@ msgstr "Aprire tutto"
 #. module: mrp
 #: model:ir.model.fields,field_description:mrp.field_stock_move__unit_factor
 msgid "Unit Factor"
-msgstr ""
+msgstr "Fattore unitario"
 
 #. module: mrp
 #: model:ir.model.fields,field_description:mrp.field_mrp_product_produce__product_uom_id
@@ -4022,6 +4041,9 @@ msgid ""
 "is useful if you have long lead time and if you produce based on sales "
 "forecasts."
 msgstr ""
+"L'utilizzo del report MPS per pianificare le operazioni di riordino e "
+"produzione è utile se si ha tempi di consegna lunghi e se si produce in base"
+" alle previsioni di vendita."
 
 #. module: mrp
 #: model:ir.model.fields,field_description:mrp.field_mrp_bom_line__valid_product_attribute_value_ids
@@ -4081,7 +4103,7 @@ msgstr "Magazzino"
 #. module: mrp
 #: model:ir.model,name:mrp.model_stock_warn_insufficient_qty_unbuild
 msgid "Warn Insufficient Unbuild Quantity"
-msgstr ""
+msgstr "Avviso quantità smontata insufficiente"
 
 #. module: mrp
 #: code:addons/mrp/models/mrp_bom.py:95 code:addons/mrp/models/mrp_bom.py:290
@@ -4227,6 +4249,10 @@ msgid ""
 "                considered as units for task assignation as well as capacity\n"
 "                and planning forecast."
 msgstr ""
+"I centri di lavoro ti consentono di creare e gestire la produzione.\n"
+"Sono costituiti da lavoratori e / o macchine, che sono\n"
+"considerate come unità per l'assegnazione di compiti e\n"
+"per le previsioni di pianificazione."
 
 #. module: mrp
 #: model_terms:ir.ui.view,arch_db:mrp.mrp_production_workorder_form_view_inherit
@@ -4298,6 +4324,9 @@ msgid ""
 "            Manufacturing Order. Work Orders are trigerred by Manufacturing Orders,\n"
 "            they are based on the Routing defined on these ones"
 msgstr ""
+"Gli ordini di lavoro sono operazioni che devono essere elaborate in un\n"
+"            ordine di produzione. Gli ordini di lavoro sono attivati dagli ordini di produzione,\n"
+"             si basano sul routing definito sugli ordini di produzione"
 
 #. module: mrp
 #: model_terms:ir.ui.view,arch_db:mrp.mrp_routing_workcenter_form_view
@@ -4456,12 +4485,16 @@ msgstr "Impossibile creare una nuova distinta base da qui."
 #, python-format
 msgid "You cannot delete an unbuild order if the state is 'Done'."
 msgstr ""
+"Non è possibile eliminare un ordine di smontaggio se lo stato è "
+"\"Completato\"."
 
 #. module: mrp
 #: code:addons/mrp/models/mrp_production.py:533
 #, python-format
 msgid "You cannot produce a MO with a bom kit product."
 msgstr ""
+"Non è possibile produrre un ordine di produzione con una distinta dei "
+"materiali di tipo kit."
 
 #. module: mrp
 #: code:addons/mrp/wizard/mrp_product_produce.py:82
@@ -4473,7 +4506,7 @@ msgstr "Impossibile produrre due volte lo stesso numero di serie. "
 #: code:addons/mrp/models/mrp_unbuild.py:99
 #, python-format
 msgid "You cannot unbuild a undone manufacturing order."
-msgstr ""
+msgstr "Non è possibile smontare un ordine di produzione annullato."
 
 #. module: mrp
 #: code:addons/mrp/wizard/change_production_qty.py:48
@@ -4557,6 +4590,8 @@ msgid ""
 "You will get here statistics about the\n"
 "              work orders duration related to this routing."
 msgstr ""
+"Riceverai qui le statistiche sulla durata degli\n"
+" ordini di lavoro relative a questo routing."
 
 #. module: mrp
 #: model_terms:ir.ui.view,arch_db:mrp.exception_on_mo

--- a/addons/mrp/i18n/pt.po
+++ b/addons/mrp/i18n/pt.po
@@ -3653,7 +3653,7 @@ msgstr ""
 #. module: mrp
 #: model_terms:ir.ui.view,arch_db:mrp.stock_production_type_kanban
 msgid "To Process"
-msgstr ""
+msgstr "Por Processar"
 
 #. module: mrp
 #: model_terms:ir.ui.view,arch_db:mrp.mrp_production_workorder_form_view_inherit

--- a/addons/mrp/i18n/ro.po
+++ b/addons/mrp/i18n/ro.po
@@ -4452,7 +4452,7 @@ msgstr ""
 #. module: mrp
 #: model_terms:ir.ui.view,arch_db:mrp.exception_on_mo
 msgid "cancelled"
-msgstr ""
+msgstr "anulat"
 
 #. module: mrp
 #: model_terms:ir.ui.view,arch_db:mrp.res_config_settings_view_form

--- a/addons/mrp/models/mrp_bom.py
+++ b/addons/mrp/models/mrp_bom.py
@@ -266,8 +266,7 @@ class MrpBomLine(models.Model):
         else:
             self.child_bom_id = self.env['mrp.bom']._bom_find(
                 product_tmpl=self.product_id.product_tmpl_id,
-                product=self.product_id,
-                picking_type=self.bom_id.picking_type_id)
+                product=self.product_id)
 
     @api.one
     @api.depends('product_id')

--- a/addons/note/i18n/eu.po
+++ b/addons/note/i18n/eu.po
@@ -15,6 +15,7 @@
 # Victor Laskurain <blaskurain@binovo.es>, 2019
 # Iñaki Ibarrola <inakiibarrola@yahoo.es>, 2020
 # Maialen Rodriguez <maialenrodriguez98@gmail.com>, 2020
+# Miren Maiz <mirenmaizz@gmail.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -22,7 +23,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-03-29 10:09+0000\n"
 "PO-Revision-Date: 2018-08-24 09:21+0000\n"
-"Last-Translator: Maialen Rodriguez <maialenrodriguez98@gmail.com>, 2020\n"
+"Last-Translator: Miren Maiz <mirenmaizz@gmail.com>, 2020\n"
 "Language-Team: Basque (https://www.transifex.com/odoo/teams/41243/eu/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -428,7 +429,7 @@ msgstr ""
 #. module: note
 #: model:ir.model.fields,field_description:note.field_note_note__activity_user_id
 msgid "Responsible User"
-msgstr ""
+msgstr "Erabiltzaile arduraduna"
 
 #. module: note
 #. openerp-web

--- a/addons/note/i18n/it.po
+++ b/addons/note/i18n/it.po
@@ -551,7 +551,7 @@ msgstr "Messaggi non letti"
 #. module: note
 #: model:ir.model.fields,field_description:note.field_note_note__message_unread_counter
 msgid "Unread Messages Counter"
-msgstr "Contatore messaggi non letti"
+msgstr "Numero messaggi non letti"
 
 #. module: note
 #: model:ir.model.fields,help:note.field_note_stage__sequence

--- a/addons/pad/i18n/eu.po
+++ b/addons/pad/i18n/eu.po
@@ -8,6 +8,7 @@
 # Eneko <eastigarraga@codesyntax.com>, 2019
 # Naomi Hidalgo <naomihid96@gmail.com>, 2019
 # Maialen Rodriguez <maialenrodriguez98@gmail.com>, 2020
+# mgalarza005 <mikelgalarza99@gmail.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -15,7 +16,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-01-22 11:12+0000\n"
 "PO-Revision-Date: 2018-08-24 09:21+0000\n"
-"Last-Translator: Maialen Rodriguez <maialenrodriguez98@gmail.com>, 2020\n"
+"Last-Translator: mgalarza005 <mikelgalarza99@gmail.com>, 2020\n"
 "Language-Team: Basque (https://www.transifex.com/odoo/teams/41243/eu/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -26,7 +27,7 @@ msgstr ""
 #. module: pad
 #: model_terms:ir.ui.view,arch_db:pad.res_config_settings_view_form
 msgid "API Key"
-msgstr ""
+msgstr "API giltza"
 
 #. module: pad
 #: model:ir.model,name:pad.model_res_company

--- a/addons/payment/i18n/fi.po
+++ b/addons/payment/i18n/fi.po
@@ -11,13 +11,13 @@
 # Pekko Tuomisto <pekko.tuomisto@web-veistamo.fi>, 2018
 # Tommi Rintala <tommi.rintala@gmail.com>, 2018
 # Svante Suominen <svante.suominen@web-veistamo.fi>, 2018
-# Jarmo Kortetjärvi <jarmo.kortetjarvi@gmail.com>, 2018
 # Mikko Salmela <salmemik@gmail.com>, 2018
 # Martin Trigaux, 2018
 # Tuomas Lyyra <tuomas.lyyra@legenda.fi>, 2019
 # Kari Lindgren <kari.lindgren@emsystems.fi>, 2019
 # Tuomo Aura <tuomo.aura@web-veistamo.fi>, 2019
 # Veikko Väätäjä <veikko.vaataja@gmail.com>, 2019
+# Jarmo Kortetjärvi <jarmo.kortetjarvi@gmail.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -25,7 +25,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-11-14 07:34+0000\n"
 "PO-Revision-Date: 2018-08-24 09:21+0000\n"
-"Last-Translator: Veikko Väätäjä <veikko.vaataja@gmail.com>, 2019\n"
+"Last-Translator: Jarmo Kortetjärvi <jarmo.kortetjarvi@gmail.com>, 2020\n"
 "Language-Team: Finnish (https://www.transifex.com/odoo/teams/41243/fi/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1207,7 +1207,7 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:payment.confirm
 #: model_terms:ir.ui.view,arch_db:payment.payment_confirmation_status
 msgid "Or scan me with your banking app."
-msgstr ""
+msgstr "Tai skannaa pankkiaplikaatiolla."
 
 #. module: payment
 #: selection:res.company,payment_onboarding_payment_method:0

--- a/addons/payment/i18n/fr.po
+++ b/addons/payment/i18n/fr.po
@@ -19,6 +19,7 @@
 # Shark McGnark <peculiarcheese@gmail.com>, 2019
 # William Olhasque <william.olhasque@scopea.fr>, 2019
 # Laura Piraux <lap@odoo.com>, 2020
+# Priscilla Sanchez <prs@odoo.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -26,7 +27,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-11-14 07:34+0000\n"
 "PO-Revision-Date: 2018-08-24 09:21+0000\n"
-"Last-Translator: Laura Piraux <lap@odoo.com>, 2020\n"
+"Last-Translator: Priscilla Sanchez <prs@odoo.com>, 2020\n"
 "Language-Team: French (https://www.transifex.com/odoo/teams/41243/fr/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -851,7 +852,7 @@ msgstr "Routage HTTP"
 #. module: payment
 #: model:ir.model.fields,field_description:payment.field_payment_transaction__is_processed
 msgid "Has the payment been post processed"
-msgstr ""
+msgstr "Le paiement a-t-il été post-traité"
 
 #. module: payment
 #: model:ir.model.fields,field_description:payment.field_payment_acquirer__pre_msg
@@ -1144,6 +1145,8 @@ msgid ""
 "No manual payment method could be found for this company. Please create one "
 "from the Payment Acquirer menu."
 msgstr ""
+"Aucun mode de paiement manuel n'a pu être trouvé pour cette entreprise. "
+"Veuillez en créer un dans le menu Acquéreur de paiement."
 
 #. module: payment
 #: model_terms:ir.ui.view,arch_db:payment.pay
@@ -1390,7 +1393,7 @@ msgstr "Transactions de paiement"
 #. module: payment
 #: model:ir.model,name:payment.model_payment_acquirer_onboarding_wizard
 msgid "Payment acquire onboarding wizard"
-msgstr ""
+msgstr "Assistant d'acquisition de paiement"
 
 #. module: payment
 #: selection:payment.acquirer,payment_flow:0
@@ -1525,7 +1528,7 @@ msgstr "Veuillez patienter..."
 #: model:ir.cron,cron_name:payment.cron_post_process_payment_tx
 #: model:ir.cron,name:payment.cron_post_process_payment_tx
 msgid "Post process payment transactions"
-msgstr ""
+msgstr "Opérations de paiement post-traitement"
 
 #. module: payment
 #: model_terms:ir.ui.view,arch_db:payment.confirm
@@ -1596,7 +1599,7 @@ msgstr "Les champs obligatoires ne sont pas remplis"
 #. module: payment
 #: model:ir.model.fields,field_description:payment.field_payment_transaction__return_url
 msgid "Return URL after payment"
-msgstr ""
+msgstr "URL de retour après paiement"
 
 #. module: payment
 #: model:ir.model.fields,field_description:payment.field_payment_acquirer__registration_view_template_id
@@ -1632,7 +1635,7 @@ msgstr "Enregistrement des données de la carte pris en charge"
 #. module: payment
 #: model:ir.model.fields,field_description:payment.field_res_company__payment_onboarding_payment_method
 msgid "Selected onboarding payment method"
-msgstr ""
+msgstr "Mode de paiement d'intégration sélectionné"
 
 #. module: payment
 #: model:ir.model.fields,field_description:payment.field_payment_acquirer__sequence
@@ -1711,7 +1714,7 @@ msgstr "Pays spécifiques"
 #. module: payment
 #: model:ir.model.fields,field_description:payment.field_res_company__payment_acquirer_onboarding_state
 msgid "State of the onboarding payment acquirer step"
-msgstr ""
+msgstr "État de l'étape d'acquéreur du paiement d'intégration"
 
 #. module: payment
 #: model:ir.model.fields,field_description:payment.field_payment_transaction__state
@@ -2044,7 +2047,7 @@ msgstr ""
 #: code:addons/payment/wizards/payment_acquirer_onboarding_wizard.py:135
 #, python-format
 msgid "You have to set a journal for your payment acquirer %s."
-msgstr ""
+msgstr "Vous devez définir un journal pour votre acquéreur de paiement %s."
 
 #. module: payment
 #. openerp-web

--- a/addons/payment/i18n/ja.po
+++ b/addons/payment/i18n/ja.po
@@ -1805,7 +1805,7 @@ msgstr ""
 #. module: payment
 #: model:ir.model.fields,field_description:payment.field_payment_acquirer__qr_code
 msgid "Use SEPA QR Code"
-msgstr ""
+msgstr "SEPA QRコード使用"
 
 #. module: payment
 #: model:ir.model.fields,field_description:payment.field_payment_transaction__date
@@ -1897,21 +1897,21 @@ msgstr ""
 #: code:addons/payment/static/src/js/payment_form.js:176
 #, python-format
 msgid "We are not able to redirect you to the payment form."
-msgstr ""
+msgstr "支払フォームにリダイレクトすることができません。"
 
 #. module: payment
 #. openerp-web
 #: code:addons/payment/static/src/js/payment_form.js:182
 #, python-format
 msgid "We are not able to redirect you to the payment form. "
-msgstr ""
+msgstr "支払フォームにリダイレクトすることができません。"
 
 #. module: payment
 #. openerp-web
 #: code:addons/payment/static/src/js/payment_processing.js:117
 #, python-format
 msgid "We are processing your payments, please wait ..."
-msgstr ""
+msgstr "お支払を処理しています。少々お待ちください..."
 
 #. module: payment
 #. openerp-web

--- a/addons/payment/i18n/ro.po
+++ b/addons/payment/i18n/ro.po
@@ -278,7 +278,7 @@ msgstr ""
 #: code:addons/payment/models/payment_acquirer.py:663
 #, python-format
 msgid "A transaction %s with %s initiated."
-msgstr ""
+msgstr "O tranzacție %s prin %s a fot inițiată."
 
 #. module: payment
 #: code:addons/payment/models/account_invoice.py:36
@@ -332,12 +332,12 @@ msgstr "Referință achizitor"
 #. module: payment
 #: model:ir.model.fields,field_description:payment.field_payment_icon__acquirer_ids
 msgid "Acquirers"
-msgstr ""
+msgstr "Colectori"
 
 #. module: payment
 #: model_terms:ir.ui.view,arch_db:payment.payment_icon_form_view
 msgid "Acquirers list"
-msgstr ""
+msgstr "Colectori"
 
 #. module: payment
 #: model_terms:ir.ui.view,arch_db:payment.acquirer_kanban
@@ -382,7 +382,7 @@ msgstr "Valoare"
 #: code:addons/payment/static/src/xml/payment_processing.xml:17
 #, python-format
 msgid "An error occured during the processing of this payment."
-msgstr ""
+msgstr "A apărut o eroare în timpul procesării acestei plăți"
 
 #. module: payment
 #: model_terms:ir.ui.view,arch_db:payment.payment_acquirer_onboarding_wizard_form
@@ -396,6 +396,8 @@ msgid ""
 "Are you sure you want to void the authorized transaction? This action can't "
 "be undone."
 msgstr ""
+"Sunteți sigur că doriți să anulați tranzacția autorizată? Această acțiune nu"
+" poate fi anulată."
 
 #. module: payment
 #: model:ir.model.fields,field_description:payment.field_payment_acquirer__authorize_implemented
@@ -484,7 +486,7 @@ msgstr "Anulat(ă)"
 #: code:addons/payment/static/src/xml/payment_processing.xml:109
 #, python-format
 msgid "Cancelled payments"
-msgstr ""
+msgstr "Plăți anulate"
 
 #. module: payment
 #. openerp-web
@@ -748,7 +750,7 @@ msgstr "Mesaj de eroare"
 #: code:addons/payment/static/src/js/payment_form.js:430
 #, python-format
 msgid "Error: "
-msgstr ""
+msgstr "Eroare:"
 
 #. module: payment
 #: model:ir.model.fields,field_description:payment.field_payment_transaction__fees
@@ -907,7 +909,7 @@ msgstr "Factură"
 #. module: payment
 #: model_terms:ir.ui.view,arch_db:payment.transaction_form
 msgid "Invoice(s)"
-msgstr ""
+msgstr "Facturi"
 
 #. module: payment
 #: code:addons/payment/models/payment_acquirer.py:851
@@ -1231,7 +1233,7 @@ msgstr "Plătește cu credit card (via Stripe)"
 #. module: payment
 #: selection:res.company,payment_onboarding_payment_method:0
 msgid "PayPal"
-msgstr ""
+msgstr "PayPal"
 
 #. module: payment
 #: model:ir.model.fields,field_description:payment.field_payment_acquirer_onboarding_wizard__paypal_email_account
@@ -1279,7 +1281,7 @@ msgstr ""
 #: model:ir.actions.act_window,name:payment.action_payment_icon
 #: model:ir.ui.menu,name:payment.payment_icon_menu
 msgid "Payment Icons"
-msgstr ""
+msgstr "Iconițe plată"
 
 #. module: payment
 #: model:ir.model.fields,field_description:payment.field_payment_acquirer_onboarding_wizard__manual_post_msg
@@ -1367,7 +1369,7 @@ msgstr ""
 #: code:addons/payment/static/src/xml/payment_processing.xml:26
 #, python-format
 msgid "Payments received"
-msgstr ""
+msgstr "Plăți primite"
 
 #. module: payment
 #: model:ir.model.fields,help:payment.field_payment_acquirer__journal_id
@@ -1458,7 +1460,7 @@ msgstr "Vă rugăm să folosiți numele comenzii ca referință de comunicare."
 #: code:addons/payment/static/src/xml/payment_processing.xml:139
 #, python-format
 msgid "Please wait ..."
-msgstr ""
+msgstr "Te rog așteaptă ..."
 
 #. module: payment
 #: model:ir.actions.server,name:payment.cron_post_process_payment_tx_ir_actions_server
@@ -1673,7 +1675,7 @@ msgstr ""
 #. module: payment
 #: model:ir.model.fields,field_description:payment.field_payment_acquirer__payment_icon_ids
 msgid "Supported Payment Icons"
-msgstr ""
+msgstr "Iconițe plată suportate "
 
 #. module: payment
 #: model:ir.model.fields,help:payment.field_payment_acquirer__registration_view_template_id
@@ -1790,7 +1792,7 @@ msgstr ""
 #: code:addons/payment/static/src/xml/payment_processing.xml:117
 #, python-format
 msgid "This transaction has been cancelled."
-msgstr ""
+msgstr "Această tranzacție a fost anulată."
 
 #. module: payment
 #: model:ir.model.fields,field_description:payment.field_account_invoice__transaction_ids
@@ -2059,14 +2061,14 @@ msgstr ""
 #: code:addons/payment/static/src/xml/payment_processing.xml:76
 #, python-format
 msgid "Your payment has been received but need to be confirmed manually."
-msgstr ""
+msgstr "Plata dvs. a fost primită, dar trebuie confirmată manual."
 
 #. module: payment
 #. openerp-web
 #: code:addons/payment/static/src/xml/payment_processing.xml:57
 #, python-format
 msgid "Your payment is in pending state."
-msgstr ""
+msgstr "Plata dvs. este în stare de așteptare."
 
 #. module: payment
 #: model_terms:ir.ui.view,arch_db:payment.transaction_form

--- a/addons/payment_paypal/i18n/nb.po
+++ b/addons/payment_paypal/i18n/nb.po
@@ -86,6 +86,8 @@ msgid ""
 "Payment Data Transfer allows you to receive notification of successful "
 "payments as they are made."
 msgstr ""
+"Payment Data Transfer gjør at du kan motta varsler ved gjennomførte "
+"betalinger."
 
 #. module: payment_paypal
 #: model:ir.model,name:payment_paypal.model_payment_transaction
@@ -105,7 +107,7 @@ msgstr "PayPayl epost-ID"
 #. module: payment_paypal
 #: model:ir.model.fields,help:payment_paypal.field_payment_acquirer__paypal_use_ipn
 msgid "Paypal Instant Payment Notification"
-msgstr ""
+msgstr "Paypal Instant Payment Notification"
 
 #. module: payment_paypal
 #: model:ir.model.fields,field_description:payment_paypal.field_payment_acquirer__paypal_seller_account
@@ -154,6 +156,8 @@ msgid ""
 "The Merchant ID is used to ensure communications coming from Paypal are "
 "valid and secured."
 msgstr ""
+"Merchant-ID brukes til å forsikre at kommunikasjon fra Paypal er gyldig og "
+"sikker."
 
 #. module: payment_paypal
 #: model:ir.model.fields,field_description:payment_paypal.field_payment_transaction__paypal_txn_type

--- a/addons/payment_transfer/i18n/nb.po
+++ b/addons/payment_transfer/i18n/nb.po
@@ -44,6 +44,13 @@ msgid ""
 "<p>Please use the order name as communication reference.</p>\n"
 "</div>"
 msgstr ""
+"<div>\n"
+"<h3>Bruk følgende betalingsdetaljer</h3>\n"
+"<h4>%(bank_title)s</h4>\n"
+"%(bank_accounts)s\n"
+"<h4>Kommunikasjon</h4>\n"
+"<p>Merk betalingen med ordrenummer.</p>\n"
+"</div>"
 
 #. module: payment_transfer
 #: selection:payment.acquirer,provider:0

--- a/addons/phone_validation/i18n/es.po
+++ b/addons/phone_validation/i18n/es.po
@@ -4,13 +4,15 @@
 # 
 # Translators:
 # Martin Trigaux, 2018
+# Leonardo J. Caballero G. <leonardocaballero@gmail.com>, 2020
+# 
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server saas~11.5\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2018-09-21 13:18+0000\n"
-"PO-Revision-Date: 2018-09-21 13:18+0000\n"
-"Last-Translator: Martin Trigaux, 2018\n"
+"PO-Revision-Date: 2018-08-24 09:22+0000\n"
+"Last-Translator: Leonardo J. Caballero G. <leonardocaballero@gmail.com>, 2020\n"
 "Language-Team: Spanish (https://www.transifex.com/odoo/teams/41243/es/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -80,7 +82,7 @@ msgstr "Sin prefijo"
 #. module: phone_validation
 #: model:ir.model,name:phone_validation.model_phone_validation_mixin
 msgid "Phone Validation Mixin"
-msgstr ""
+msgstr "Mixin de Validación de teléfono"
 
 #. module: phone_validation
 #: code:addons/phone_validation/tools/phone_validation.py:44

--- a/addons/phone_validation/i18n/eu.po
+++ b/addons/phone_validation/i18n/eu.po
@@ -5,6 +5,7 @@
 # Translators:
 # Martin Trigaux, 2019
 # Eneko <eastigarraga@codesyntax.com>, 2019
+# Maialen Rodriguez <maialenrodriguez98@gmail.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -12,7 +13,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2018-09-21 13:18+0000\n"
 "PO-Revision-Date: 2018-08-24 09:22+0000\n"
-"Last-Translator: Eneko <eastigarraga@codesyntax.com>, 2019\n"
+"Last-Translator: Maialen Rodriguez <maialenrodriguez98@gmail.com>, 2020\n"
 "Language-Team: Basque (https://www.transifex.com/odoo/teams/41243/eu/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -68,7 +69,7 @@ msgstr "Azken aldaketa"
 #. module: phone_validation
 #: model:ir.model.fields,field_description:phone_validation.field_res_company__phone_international_format
 msgid "Local Numbers"
-msgstr ""
+msgstr "Tokiko zenbakiak"
 
 #. module: phone_validation
 #: selection:res.company,phone_international_format:0

--- a/addons/phone_validation/i18n/he.po
+++ b/addons/phone_validation/i18n/he.po
@@ -5,6 +5,7 @@
 # Translators:
 # Yihya Hugirat <hugirat@gmail.com>, 2018
 # דודי מלכה <Dudimalka6@gmail.com>, 2019
+# ZVI BLONDER <ZVIBLONDER@gmail.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -12,7 +13,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2018-09-21 13:18+0000\n"
 "PO-Revision-Date: 2018-08-24 09:22+0000\n"
-"Last-Translator: דודי מלכה <Dudimalka6@gmail.com>, 2019\n"
+"Last-Translator: ZVI BLONDER <ZVIBLONDER@gmail.com>, 2020\n"
 "Language-Team: Hebrew (https://www.transifex.com/odoo/teams/41243/he/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -54,13 +55,13 @@ msgstr "מזהה"
 #: code:addons/phone_validation/tools/phone_validation.py:23
 #, python-format
 msgid "Impossible number %s: probably invalid number of digits"
-msgstr ""
+msgstr "מספר לא תקין %s: כנראה מספר ספרות לא תקין"
 
 #. module: phone_validation
 #: code:addons/phone_validation/tools/phone_validation.py:25
 #, python-format
 msgid "Invalid number %s: probably incorrect prefix"
-msgstr ""
+msgstr "מספר לא תקין %s: כנראה קידומת שגויה"
 
 #. module: phone_validation
 #: model:ir.model.fields,field_description:phone_validation.field_phone_validation_mixin____last_update

--- a/addons/point_of_sale/i18n/es.po
+++ b/addons/point_of_sale/i18n/es.po
@@ -15,6 +15,7 @@
 # Jon Perez <jop@odoo.com>, 2019
 # Luis Guzman <ark@switnet.org>, 2019
 # José Vicente <txusev@gmail.com>, 2019
+# Osiris Román <osiris.roman@yachaytech.edu.ec>, 2020
 # 
 msgid ""
 msgstr ""
@@ -22,7 +23,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-11-14 07:33+0000\n"
 "PO-Revision-Date: 2018-08-24 09:22+0000\n"
-"Last-Translator: José Vicente <txusev@gmail.com>, 2019\n"
+"Last-Translator: Osiris Román <osiris.roman@yachaytech.edu.ec>, 2020\n"
 "Language-Team: Spanish (https://www.transifex.com/odoo/teams/41243/es/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -3733,7 +3734,7 @@ msgstr "Saltar pantalla de vista previa"
 #: code:addons/point_of_sale/static/src/xml/pos.xml:212
 #, python-format
 msgid "Slash"
-msgstr ""
+msgstr "barra oblicua"
 
 #. module: point_of_sale
 #: model:product.product,name:point_of_sale.small_shelf
@@ -3766,6 +3767,9 @@ msgid ""
 "errors. You can exit the Point of Sale, but do not close the session before "
 "the issue has been resolved."
 msgstr ""
+"Algunas órdenes no se pudieron enviar al servidor debido a errores de "
+"configuración. Puede salir del punto de venta, pero no cierre la sesión "
+"antes de que se resuelva el problema."
 
 #. module: point_of_sale
 #. openerp-web
@@ -3776,6 +3780,9 @@ msgid ""
 "issues. You can exit the Point of Sale, but do not close the session before "
 "the issue has been resolved."
 msgstr ""
+"Algunos pedidos no se pudieron enviar al servidor debido a problemas de "
+"conexión a Internet. Puede salir del punto de venta, pero no cierre la "
+"sesión antes de que se resuelva el problema."
 
 #. module: point_of_sale
 #: model:ir.model,name:point_of_sale.model_pos_pack_operation_lot
@@ -4129,6 +4136,8 @@ msgid ""
 "The order has been synchronized earlier. To print the invoice please refer "
 "to the order in the backend"
 msgstr ""
+"El pedido se ha sincronizado anteriormente. Para imprimir la factura, consulte el pedido en el backend\n"
+" "
 
 #. module: point_of_sale
 #: model:ir.model.fields,help:point_of_sale.field_pos_config__iface_precompute_cash

--- a/addons/point_of_sale/i18n/et.po
+++ b/addons/point_of_sale/i18n/et.po
@@ -2697,7 +2697,7 @@ msgstr ""
 #: code:addons/point_of_sale/static/src/xml/pos.xml:332
 #, python-format
 msgid "Picture"
-msgstr ""
+msgstr "Foto"
 
 #. module: point_of_sale
 #. openerp-web

--- a/addons/point_of_sale/i18n/eu.po
+++ b/addons/point_of_sale/i18n/eu.po
@@ -15,6 +15,9 @@
 # Naomi Hidalgo <naomihid96@gmail.com>, 2019
 # Victor Laskurain <blaskurain@binovo.es>, 2019
 # ibinka lete <ilete@fpbidasoa.net>, 2019
+# Maialen Rodriguez <maialenrodriguez98@gmail.com>, 2020
+# Miren Maiz <mirenmaizz@gmail.com>, 2020
+# Unai Muñoz <unaimunoz9@gmail.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -22,7 +25,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-11-14 07:33+0000\n"
 "PO-Revision-Date: 2018-08-24 09:22+0000\n"
-"Last-Translator: ibinka lete <ilete@fpbidasoa.net>, 2019\n"
+"Last-Translator: Unai Muñoz <unaimunoz9@gmail.com>, 2020\n"
 "Language-Team: Basque (https://www.transifex.com/odoo/teams/41243/eu/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -95,12 +98,12 @@ msgstr ""
 #. module: point_of_sale
 #: model_terms:ir.ui.view,arch_db:point_of_sale.view_pos_config_kanban
 msgid "<i class=\"fa fa-ellipsis-v\" role=\"img\" aria-label=\"Manage\" title=\"Manage\"/>"
-msgstr ""
+msgstr "<i class=\"fa fa-ellipsis-v\" role=\"img\" aria-label=\"Manage\" title=\"Manage\"/>"
 
 #. module: point_of_sale
 #: model_terms:ir.ui.view,arch_db:point_of_sale.customer_facing_display_snippets
 msgid "<i class=\"fa fa-eye-slash\"/>Hide"
-msgstr ""
+msgstr "<i class=\"fa fa-eye-slash\"/>Ezkutatu"
 
 #. module: point_of_sale
 #: model_terms:ir.ui.view,arch_db:point_of_sale.pos_config_view_form
@@ -113,11 +116,13 @@ msgid ""
 "<i class=\"fa fa-fw fa-shopping-bag\" role=\"img\" aria-label=\"Shopping "
 "cart\" title=\"Shopping cart\"/>"
 msgstr ""
+"<i class=\"fa fa-fw fa-shopping-bag\" role=\"img\" aria-label=\"Shopping "
+"cart\" title=\"Shopping cart\"/>"
 
 #. module: point_of_sale
 #: model_terms:ir.ui.view,arch_db:point_of_sale.view_pos_order_kanban
 msgid "<i class=\"fa fa-money\" role=\"img\" aria-label=\"Amount\" title=\"Amount\"/>"
-msgstr ""
+msgstr "<i class=\"fa fa-money\" role=\"img\" aria-label=\"Amount\" title=\"Amount\"/>"
 
 #. module: point_of_sale
 #. openerp-web
@@ -391,7 +396,7 @@ msgstr ""
 #. module: point_of_sale
 #: model_terms:ir.ui.view,arch_db:point_of_sale.pos_config_view_form
 msgid "Add a custom message to header and footer"
-msgstr ""
+msgstr "Gehitu pertsonalizatutako mezu bat goiburukora eta orri-oinera"
 
 #. module: point_of_sale
 #. openerp-web
@@ -691,7 +696,7 @@ msgstr "Eskudiru Kontrola"
 #. module: point_of_sale
 #: model:ir.model.fields,field_description:point_of_sale.field_pos_session__cash_journal_id
 msgid "Cash Journal"
-msgstr ""
+msgstr "Diru-agiria"
 
 #. module: point_of_sale
 #: model:ir.model.fields,field_description:point_of_sale.field_pos_session__cash_register_id
@@ -952,7 +957,7 @@ msgstr "Enpresa"
 #. module: point_of_sale
 #: model:ir.model,name:point_of_sale.model_res_config_settings
 msgid "Config Settings"
-msgstr ""
+msgstr "Konfigurazio ezarpenak"
 
 #. module: point_of_sale
 #: model:ir.ui.menu,name:point_of_sale.menu_point_config_product
@@ -1079,7 +1084,7 @@ msgstr "Kreditu txartela"
 #. module: point_of_sale
 #: model_terms:ir.ui.view,arch_db:point_of_sale.res_config_settings_view_form
 msgid "Credit Card Reader"
-msgstr ""
+msgstr "Kreditu txartel irakurlea"
 
 #. module: point_of_sale
 #: model_terms:ir.ui.view,arch_db:point_of_sale.res_config_settings_view_form
@@ -1247,7 +1252,7 @@ msgstr ""
 #: code:addons/point_of_sale/static/src/xml/pos.xml:1356
 #, python-format
 msgid "Delete Unpaid Orders"
-msgstr ""
+msgstr "Ezabatu ordaindu gabeko eskaerak"
 
 #. module: point_of_sale
 #. openerp-web
@@ -1311,7 +1316,7 @@ msgstr ""
 #. module: point_of_sale
 #: model:ir.model,name:point_of_sale.model_digest_digest
 msgid "Digest"
-msgstr ""
+msgstr "Laburpen"
 
 #. module: point_of_sale
 #. openerp-web
@@ -1533,7 +1538,7 @@ msgstr ""
 #. module: point_of_sale
 #: model:ir.model.fields,field_description:point_of_sale.field_pos_session__cash_register_balance_end_real
 msgid "Ending Balance"
-msgstr ""
+msgstr "Amaiera balantzea"
 
 #. module: point_of_sale
 #: code:addons/point_of_sale/models/pos_category.py:13
@@ -1546,7 +1551,7 @@ msgstr "Errorea! Ezin duzu errekurtsibitate kategoriak sortu."
 #: code:addons/point_of_sale/static/src/js/screens.js:1307
 #, python-format
 msgid "Error: Could not Save Changes"
-msgstr ""
+msgstr "Errorea: Ezin izan dira aldaketak gorde"
 
 #. module: point_of_sale
 #. openerp-web
@@ -1795,7 +1800,7 @@ msgstr ""
 #. module: point_of_sale
 #: model:ir.model.fields,field_description:point_of_sale.field_pos_config__iface_start_categ_id
 msgid "Initial Category"
-msgstr ""
+msgstr "Hasierako kategoria"
 
 #. module: point_of_sale
 #: model:ir.model.fields,field_description:point_of_sale.field_pos_config__module_pos_mercury
@@ -3306,7 +3311,7 @@ msgstr ""
 #. module: point_of_sale
 #: model:ir.model.fields,field_description:point_of_sale.field_pos_order__amount_return
 msgid "Returned"
-msgstr ""
+msgstr "Itzulita"
 
 #. module: point_of_sale
 #: model:ir.model.fields,field_description:point_of_sale.field_report_pos_order__nbr_lines
@@ -3408,7 +3413,7 @@ msgstr ""
 #: code:addons/point_of_sale/static/src/xml/pos.xml:220
 #, python-format
 msgid "Search Products"
-msgstr ""
+msgstr "Bilatu produktuak"
 
 #. module: point_of_sale
 #: model_terms:ir.ui.view,arch_db:point_of_sale.view_pos_order_filter
@@ -3418,7 +3423,7 @@ msgstr "Search Sales Order"
 #. module: point_of_sale
 #: model:ir.model.fields,field_description:point_of_sale.field_res_users__pos_security_pin
 msgid "Security PIN"
-msgstr ""
+msgstr "Segurtasun PINa"
 
 #. module: point_of_sale
 #: code:addons/point_of_sale/models/res_users.py:15
@@ -3470,7 +3475,7 @@ msgstr ""
 #: code:addons/point_of_sale/static/src/xml/pos.xml:1026
 #, python-format
 msgid "Send by email"
-msgstr ""
+msgstr "Epostaz bidalia"
 
 #. module: point_of_sale
 #: model:ir.model.fields,field_description:point_of_sale.field_pos_category__sequence
@@ -3480,7 +3485,7 @@ msgstr "Sekuentzia"
 #. module: point_of_sale
 #: model:ir.model.fields,field_description:point_of_sale.field_pos_order__sequence_number
 msgid "Sequence Number"
-msgstr ""
+msgstr "Sekuentzia zenbakia"
 
 #. module: point_of_sale
 #. openerp-web
@@ -3826,7 +3831,7 @@ msgstr "GUZTIRA"
 #. module: point_of_sale
 #: model:ir.actions.act_window,name:point_of_sale.action_pos_box_out
 msgid "Take Money Out"
-msgstr ""
+msgstr "Dirua atera"
 
 #. module: point_of_sale
 #. openerp-web
@@ -3853,7 +3858,7 @@ msgstr "Zergen bistaratzea"
 #: code:addons/point_of_sale/static/src/xml/pos.xml:452
 #, python-format
 msgid "Tax ID"
-msgstr ""
+msgstr "Zerga identifikazioa"
 
 #. module: point_of_sale
 #: model:ir.model.fields,field_description:point_of_sale.field_pos_config__tax_regime
@@ -4364,7 +4369,7 @@ msgstr ""
 #. module: point_of_sale
 #: model_terms:ir.ui.view,arch_db:point_of_sale.view_pos_order_line
 msgid "Total qty"
-msgstr ""
+msgstr "Kalitate totala"
 
 #. module: point_of_sale
 #. openerp-web
@@ -4487,7 +4492,7 @@ msgstr ""
 #: code:addons/point_of_sale/static/src/xml/pos.xml:1456
 #, python-format
 msgid "User:"
-msgstr ""
+msgstr "Erabiltzailea:"
 
 #. module: point_of_sale
 #: model:ir.model,name:point_of_sale.model_res_users
@@ -4743,7 +4748,7 @@ msgstr ""
 #: code:addons/point_of_sale/static/src/xml/pos.xml:1222
 #, python-format
 msgid "belong to another session:"
-msgstr ""
+msgstr "beste saio batera sartu:"
 
 #. module: point_of_sale
 #. openerp-web
@@ -4855,7 +4860,7 @@ msgstr "kg"
 #: code:addons/point_of_sale/models/pos_config.py:336
 #, python-format
 msgid "not used"
-msgstr ""
+msgstr "erabili gabea"
 
 #. module: point_of_sale
 #. openerp-web
@@ -4877,7 +4882,7 @@ msgstr ""
 #: code:addons/point_of_sale/static/src/xml/pos.xml:1648
 #, python-format
 msgid "return"
-msgstr ""
+msgstr "itzuli"
 
 #. module: point_of_sale
 #. openerp-web

--- a/addons/point_of_sale/i18n/fi.po
+++ b/addons/point_of_sale/i18n/fi.po
@@ -13,7 +13,6 @@
 # Tommi Rintala <tommi.rintala@gmail.com>, 2018
 # Kari Lindgren <kari.lindgren@emsystems.fi>, 2018
 # Svante Suominen <svante.suominen@web-veistamo.fi>, 2018
-# Jarmo Kortetjärvi <jarmo.kortetjarvi@gmail.com>, 2018
 # Atte Isopuro <atte.isopuro@web-veistamo.fi>, 2018
 # Veikko Väätäjä <veikko.vaataja@gmail.com>, 2018
 # Mikko Närjänen <mikko.narjanen@web-veistamo.fi>, 2018
@@ -24,6 +23,7 @@
 # Retropikzel, 2019
 # Martin Trigaux, 2019
 # Tuomo Aura <tuomo.aura@web-veistamo.fi>, 2020
+# Jarmo Kortetjärvi <jarmo.kortetjarvi@gmail.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -31,7 +31,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-11-14 07:33+0000\n"
 "PO-Revision-Date: 2018-08-24 09:22+0000\n"
-"Last-Translator: Tuomo Aura <tuomo.aura@web-veistamo.fi>, 2020\n"
+"Last-Translator: Jarmo Kortetjärvi <jarmo.kortetjarvi@gmail.com>, 2020\n"
 "Language-Team: Finnish (https://www.transifex.com/odoo/teams/41243/fi/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -2281,7 +2281,7 @@ msgstr "Tulosteiden määrä"
 #: model_terms:ir.ui.view,arch_db:point_of_sale.customer_facing_display_html
 #: model_terms:pos.config,customer_facing_display_html:point_of_sale.pos_config_main
 msgid "Odoo Logo"
-msgstr ""
+msgstr "Odoo Logo"
 
 #. module: point_of_sale
 #. openerp-web

--- a/addons/point_of_sale/i18n/hu.po
+++ b/addons/point_of_sale/i18n/hu.po
@@ -8,10 +8,10 @@
 # Martin Trigaux, 2018
 # Kovács Tibor <kovika@gmail.com>, 2018
 # Tibor Kőnig <konig.tibor@evitalit.hu>, 2018
-# Ákos Nagy <akos.nagy@oregional.hu>, 2019
 # gezza <geza.nagy@oregional.hu>, 2019
 # krnkris, 2019
 # Tamás Németh <ntomasz81@gmail.com>, 2020
+# Ákos Nagy <akos.nagy@oregional.hu>, 2020
 # 
 msgid ""
 msgstr ""
@@ -19,7 +19,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-11-14 07:33+0000\n"
 "PO-Revision-Date: 2018-08-24 09:22+0000\n"
-"Last-Translator: Tamás Németh <ntomasz81@gmail.com>, 2020\n"
+"Last-Translator: Ákos Nagy <akos.nagy@oregional.hu>, 2020\n"
 "Language-Team: Hungarian (https://www.transifex.com/odoo/teams/41243/hu/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -768,7 +768,7 @@ msgstr ""
 #. module: point_of_sale
 #: model:pos.category,name:point_of_sale.pos_category_chairs
 msgid "Chairs"
-msgstr ""
+msgstr "Székek"
 
 #. module: point_of_sale
 #. openerp-web

--- a/addons/point_of_sale/i18n/id.po
+++ b/addons/point_of_sale/i18n/id.po
@@ -18,9 +18,9 @@
 # Edi Santoso <repopamor@gmail.com>, 2019
 # Bonny Useful <bonny.useful@gmail.com>, 2019
 # alfieqashwa <alfieqashwa@gmail.com>, 2019
-# Muhammad Syarif <mhdsyarif.ms@gmail.com>, 2019
 # Ryanto The <ry.the77@gmail.com>, 2019
 # PAS IRVANUS <ipankbiz@gmail.com>, 2019
+# Muhammad Syarif <mhdsyarif.ms@gmail.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -28,7 +28,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-11-14 07:33+0000\n"
 "PO-Revision-Date: 2018-08-24 09:22+0000\n"
-"Last-Translator: PAS IRVANUS <ipankbiz@gmail.com>, 2019\n"
+"Last-Translator: Muhammad Syarif <mhdsyarif.ms@gmail.com>, 2020\n"
 "Language-Team: Indonesian (https://www.transifex.com/odoo/teams/41243/id/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -702,7 +702,7 @@ msgstr "Kembalian tidak dapat dikeluarkan kecuali untuk transaksi tunai"
 #. module: point_of_sale
 #: model:ir.model,name:point_of_sale.model_cash_box_in
 msgid "Cash Box In"
-msgstr ""
+msgstr "Tempat Penyimpana Kas Masuk"
 
 #. module: point_of_sale
 #: model:ir.model,name:point_of_sale.model_cash_box_out

--- a/addons/point_of_sale/i18n/tr.po
+++ b/addons/point_of_sale/i18n/tr.po
@@ -2849,7 +2849,7 @@ msgstr "POS Siparişleri"
 #. module: point_of_sale
 #: model_terms:ir.ui.view,arch_db:point_of_sale.product_template_form_view
 msgid "Point Of Sale"
-msgstr ""
+msgstr "Satış Noktası"
 
 #. module: point_of_sale
 #: model:ir.actions.act_window,name:point_of_sale.action_pos_config_kanban

--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -852,7 +852,7 @@ class PosOrder(models.Model):
                     if self.env.user.partner_id.email:
                         return_picking.message_post(body=message)
                     else:
-                        return_picking.message_post(body=message)
+                        return_picking.sudo().message_post(body=message)
 
             for line in order.lines.filtered(lambda l: l.product_id.type in ['product', 'consu'] and not float_is_zero(l.qty, precision_rounding=l.product_id.uom_id.rounding)):
                 moves |= Move.create({

--- a/addons/portal/i18n/es.po
+++ b/addons/portal/i18n/es.po
@@ -9,6 +9,7 @@
 # Efrem Jimenez <efj@odoo.com>, 2019
 # Mariana Santos Romo <msn@odoo.com>, 2019
 # Leonardo J. Caballero G. <leonardocaballero@gmail.com>, 2020
+# Pedro M. Baeza <pedro.baeza@gmail.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -16,7 +17,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-08-08 13:50+0000\n"
 "PO-Revision-Date: 2018-08-24 09:22+0000\n"
-"Last-Translator: Leonardo J. Caballero G. <leonardocaballero@gmail.com>, 2020\n"
+"Last-Translator: Pedro M. Baeza <pedro.baeza@gmail.com>, 2020\n"
 "Language-Team: Spanish (https://www.transifex.com/odoo/teams/41243/es/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -40,7 +41,7 @@ msgstr "%sno es la referencia de un informe"
 #. module: portal
 #: model_terms:ir.ui.view,arch_db:portal.portal_show_sign_in
 msgid "<b>Sign in</b>"
-msgstr "<b>Registrarse</b>"
+msgstr "<b>Identificarse</b>"
 
 #. module: portal
 #: model_terms:ir.ui.view,arch_db:portal.portal_back_in_edit_mode

--- a/addons/portal/i18n/et.po
+++ b/addons/portal/i18n/et.po
@@ -556,12 +556,12 @@ msgstr "Saajad"
 #. module: portal
 #: model:ir.model.fields,field_description:portal.field_portal_share__res_id
 msgid "Related Document ID"
-msgstr ""
+msgstr "Seotud dokumendi ID"
 
 #. module: portal
 #: model:ir.model.fields,field_description:portal.field_portal_share__res_model
 msgid "Related Document Model"
-msgstr ""
+msgstr "Seotud dokumendi mudel"
 
 #. module: portal
 #: model_terms:ir.ui.view,arch_db:portal.portal_searchbar

--- a/addons/portal/i18n/eu.po
+++ b/addons/portal/i18n/eu.po
@@ -11,6 +11,9 @@
 # Naomi Hidalgo <naomihid96@gmail.com>, 2019
 # Victor Laskurain <blaskurain@binovo.es>, 2019
 # Iñaki Ibarrola <inakiibarrola@yahoo.es>, 2020
+# Maialen Rodriguez <maialenrodriguez98@gmail.com>, 2020
+# Miren Maiz <mirenmaizz@gmail.com>, 2020
+# Mikel Galarza <mikelgalarza99@gmail.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -18,7 +21,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-08-08 13:50+0000\n"
 "PO-Revision-Date: 2018-08-24 09:22+0000\n"
-"Last-Translator: Iñaki Ibarrola <inakiibarrola@yahoo.es>, 2020\n"
+"Last-Translator: Mikel Galarza <mikelgalarza99@gmail.com>, 2020\n"
 "Language-Team: Basque (https://www.transifex.com/odoo/teams/41243/eu/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -31,7 +34,7 @@ msgstr ""
 #: code:addons/portal/static/src/js/portal_sidebar.js:43
 #, python-format
 msgid "%d days overdue"
-msgstr ""
+msgstr "%dAtzeratze egunak "
 
 #. module: portal
 #: code:addons/portal/controllers/portal.py:277
@@ -188,7 +191,7 @@ msgstr "Onartu eta sinatu"
 #: model:ir.model.fields,field_description:portal.field_portal_mixin__access_warning
 #: model:ir.model.fields,field_description:portal.field_portal_share__access_warning
 msgid "Access warning"
-msgstr ""
+msgstr "Sarbide abisua"
 
 #. module: portal
 #: model_terms:ir.ui.view,arch_db:portal.portal_share_wizard
@@ -377,7 +380,7 @@ msgstr ""
 #. module: portal
 #: model:ir.model,name:portal.model_ir_http
 msgid "HTTP Routing"
-msgstr ""
+msgstr "HTTP bideratzea"
 
 #. module: portal
 #: model_terms:ir.ui.view,arch_db:portal.portal_breadcrumbs
@@ -407,7 +410,7 @@ msgstr "Eposta baliogabea! Mesedez, sar ezazu helbide elektroniko egokia."
 #: code:addons/portal/controllers/portal.py:272
 #, python-format
 msgid "Invalid report type: %s"
-msgstr ""
+msgstr "Txosten mota baliogabea: %s"
 
 #. module: portal
 #: model:ir.model.fields,field_description:portal.field_portal_wizard__welcome_message

--- a/addons/portal/i18n/eu.po
+++ b/addons/portal/i18n/eu.po
@@ -13,7 +13,7 @@
 # Iñaki Ibarrola <inakiibarrola@yahoo.es>, 2020
 # Maialen Rodriguez <maialenrodriguez98@gmail.com>, 2020
 # Miren Maiz <mirenmaizz@gmail.com>, 2020
-# Mikel Galarza <mikelgalarza99@gmail.com>, 2020
+# mgalarza005 <mikelgalarza99@gmail.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -21,7 +21,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-08-08 13:50+0000\n"
 "PO-Revision-Date: 2018-08-24 09:22+0000\n"
-"Last-Translator: Mikel Galarza <mikelgalarza99@gmail.com>, 2020\n"
+"Last-Translator: mgalarza005 <mikelgalarza99@gmail.com>, 2020\n"
 "Language-Team: Basque (https://www.transifex.com/odoo/teams/41243/eu/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -328,7 +328,7 @@ msgstr ""
 #. module: portal
 #: model_terms:ir.ui.view,arch_db:portal.portal_share_template
 msgid "Dear"
-msgstr ""
+msgstr "Maitea"
 
 #. module: portal
 #: model:ir.model.fields,field_description:portal.field_portal_mixin__display_name

--- a/addons/portal/i18n/fi.po
+++ b/addons/portal/i18n/fi.po
@@ -9,7 +9,6 @@
 # Sanna Edelman <direct@generare.com>, 2018
 # Teija Hölttä <teija.holtta@gmail.com>, 2018
 # Kari Lindgren <karisatu@gmail.com>, 2018
-# Jarmo Kortetjärvi <jarmo.kortetjarvi@gmail.com>, 2018
 # Jukka Paulin <jukka.paulin@gmail.com>, 2018
 # Pekko Tuomisto <pekko.tuomisto@web-veistamo.fi>, 2018
 # Heikki Katajisto <heikki.katajisto@myyntivoima.fi>, 2018
@@ -19,6 +18,7 @@
 # Veikko Väätäjä <veikko.vaataja@gmail.com>, 2019
 # Tuomas Lyyra <tuomas.lyyra@legenda.fi>, 2019
 # Tuomo Aura <tuomo.aura@web-veistamo.fi>, 2019
+# Jarmo Kortetjärvi <jarmo.kortetjarvi@gmail.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -26,7 +26,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-08-08 13:50+0000\n"
 "PO-Revision-Date: 2018-08-24 09:22+0000\n"
-"Last-Translator: Tuomo Aura <tuomo.aura@web-veistamo.fi>, 2019\n"
+"Last-Translator: Jarmo Kortetjärvi <jarmo.kortetjarvi@gmail.com>, 2020\n"
 "Language-Team: Finnish (https://www.transifex.com/odoo/teams/41243/fi/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -45,7 +45,7 @@ msgstr "%d päivää myöhässä"
 #: code:addons/portal/controllers/portal.py:277
 #, python-format
 msgid "%s is not the reference of a report"
-msgstr ""
+msgstr "%s ei ole raportin viite"
 
 #. module: portal
 #: model_terms:ir.ui.view,arch_db:portal.portal_show_sign_in
@@ -94,7 +94,7 @@ msgstr "<span class=\"small mr-1 navbar-text\">Lajittele:</span>"
 #. module: portal
 #: model_terms:ir.ui.view,arch_db:portal.portal_share_template
 msgid "<strong>Open </strong>"
-msgstr ""
+msgstr "<strong>Avoin </strong>"
 
 #. module: portal
 #: model:mail.template,body_html:portal.mail_template_data_portal_welcome
@@ -182,6 +182,88 @@ msgid ""
 "</table>\n"
 "            "
 msgstr ""
+"<table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" style=\"padding-top: 16px; background-color: #F1F1F1; font-family:Verdana, Arial,sans-serif; color: #454748; width: 100%; border-collapse:separate;\"><tr><td align=\"center\">\n"
+"<table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" width=\"590\" style=\"padding: 16px; background-color: white; color: #454748; border-collapse:separate;\">\n"
+"<tbody>\n"
+"    <!-- HEADER -->\n"
+"    <tr>\n"
+"        <td align=\"center\" style=\"min-width: 590px;\">\n"
+"            <table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" width=\"590\" style=\"min-width: 590px; background-color: white; padding: 0px 8px 0px 8px; border-collapse:separate;\">\n"
+"                <tr><td valign=\"middle\">\n"
+"                    <span style=\"font-size: 10px;\">Käyttäjätilisi</span><br/>\n"
+"                    <span style=\"font-size: 20px; font-weight: bold;\">\n"
+"                        ${object.user_id.name}\n"
+"                    </span>\n"
+"                </td><td valign=\"middle\" align=\"right\">\n"
+"                    <img src=\"/logo.png?company=${object.user_id.company_id.id}\" style=\"padding: 0px; margin: 0px; height: auto; width: 80px;\" alt=\"${object.user_id.company_id.name}\"/>\n"
+"                </td></tr>\n"
+"                <tr><td colspan=\"2\" style=\"text-align:center;\">\n"
+"                  <hr width=\"100%\" style=\"background-color:rgb(204,204,204);border:medium none;clear:both;display:block;font-size:0px;min-height:1px;line-height:0; margin:16px 0px 16px 0px;\"/>\n"
+"                </td></tr>\n"
+"            </table>\n"
+"        </td>\n"
+"    </tr>\n"
+"    <!-- CONTENT -->\n"
+"    <tr>\n"
+"        <td align=\"center\" style=\"min-width: 590px;\">\n"
+"            <table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" width=\"590\" style=\"min-width: 590px; background-color: white; padding: 0px 8px 0px 8px; border-collapse:separate;\">\n"
+"                <tr><td valign=\"top\" style=\"font-size: 13px;\">\n"
+"                    <div>\n"
+"                        Hyvä ${object.user_id.name or ''},<br/> <br/>\n"
+"                        Olet saanut pääsyn ${object.user_id.company_id.name} portaaliin.<br/>\n"
+"                        Käyttäjätunnuksesi on:\n"
+"                        <ul>\n"
+"                            <li>Käyttäjätunnus: ${object.user_id.login or ''}</li>\n"
+"                            <li>Portaali: <a href=\"${'portal_url' in ctx and ctx['portal_url'] or ''}\">${'portal_url' in ctx and ctx['portal_url'] or ''}</a></li>\n"
+"                            <li>Tietokanta: ${'dbname' in ctx and ctx['dbname'] or ''}</li>\n"
+"                        </ul>\n"
+"                        Voit vaihtaa salasanasi seuraavasta linkistä:\n"
+"                        <ul>\n"
+"                            <li><a href=\"${object.user_id.signup_url}\">${object.user_id.signup_url}</a></li>\n"
+"                        </ul>\n"
+"                        ${object.wizard_id.welcome_message or ''}\n"
+"                    </div>\n"
+"                </td></tr>\n"
+"                <tr><td style=\"text-align:center;\">\n"
+"                  <hr width=\"100%\" style=\"background-color:rgb(204,204,204);border:medium none;clear:both;display:block;font-size:0px;min-height:1px;line-height:0; margin: 16px 0px 16px 0px;\"/>\n"
+"                </td></tr>\n"
+"            </table>\n"
+"        </td>\n"
+"    </tr>\n"
+"    <!-- FOOTER -->\n"
+"    <tr>\n"
+"        <td align=\"center\" style=\"min-width: 590px;\">\n"
+"            <table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" width=\"590\" style=\"min-width: 590px; background-color: white; font-size: 11px; padding: 0px 8px 0px 8px; border-collapse:separate;\">\n"
+"                <tr><td valign=\"middle\" align=\"left\">\n"
+"                    ${object.user_id.company_id.name}\n"
+"                </td></tr>\n"
+"                <tr><td valign=\"middle\" align=\"left\" style=\"opacity: 0.7;\">\n"
+"                    ${object.user_id.company_id.phone}\n"
+"                    % if object.user_id.company_id.email\n"
+"                        | <a href=\"'mailto:%s' % ${object.user_id.company_id.email}\" style=\"text-decoration:none; color: #454748;\">${object.user_id.company_id.email}</a>\n"
+"                    % endif\n"
+"                    % if object.user_id.company_id.website\n"
+"                        | <a href=\"'%s' % ${object.user_id.company_id.website}\" style=\"text-decoration:none; color: #454748;\">\n"
+"                        ${object.user_id.company_id.website}\n"
+"                    </a>\n"
+"                    % endif\n"
+"                </td></tr>\n"
+"            </table>\n"
+"        </td>\n"
+"    </tr>\n"
+"</tbody>\n"
+"</table>\n"
+"</td></tr>\n"
+"<!-- POWERED BY -->\n"
+"<tr><td align=\"center\" style=\"min-width: 590px;\">\n"
+"    <table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" width=\"590\" style=\"min-width: 590px; background-color: #F1F1F1; color: #454748; padding: 8px; border-collapse:separate;\">\n"
+"      <tr><td style=\"text-align: center; font-size: 13px;\">\n"
+"        Järjestelmää pyörittää <a target=\"_blank\" href=\"https://www.odoo.com?utm_source=db&amp;utm_medium=portalinvite\" style=\"color: #875A7B;\">Odoo</a>\n"
+"      </td></tr>\n"
+"    </table>\n"
+"</td></tr>\n"
+"</table>\n"
+"            "
 
 #. module: portal
 #. openerp-web
@@ -209,7 +291,7 @@ msgstr "Lisää kontaktit, joille dokumentti jaetaan..."
 #. module: portal
 #: model:ir.model.fields,help:portal.field_portal_share__note
 msgid "Add extra content to display in the email"
-msgstr ""
+msgstr "Lisää sisältöä joka näytetään sähköpostissa"
 
 #. module: portal
 #: model_terms:ir.ui.view,arch_db:portal.wizard_view
@@ -241,6 +323,8 @@ msgid ""
 "Changing VAT number is not allowed once document(s) have been issued for "
 "your account. Please contact us directly for this operation."
 msgstr ""
+"ALV-numeron muuttaminen ei ole sallittua sen jälkeen kun dokumentti on "
+"liitetty tiliisi. Jos tämä toiminto täytyy tehdä, ota meihin yhteyttä."
 
 #. module: portal
 #: model_terms:ir.ui.view,arch_db:portal.portal_my_details
@@ -248,6 +332,8 @@ msgid ""
 "Changing company name is not allowed once document(s) have been issued for "
 "your account. Please contact us directly for this operation."
 msgstr ""
+"Yrityksen nimen muuttaminen ei ole sallittua sen jälkeen kun dokumentti on "
+"liitetty tiliisi. Jos tämä toiminto täytyy tehdä, ota meihin yhteyttä."
 
 #. module: portal
 #: model_terms:ir.ui.view,arch_db:portal.portal_my_details
@@ -413,7 +499,7 @@ msgstr "Sähköpostiosoite on virheellinen. Anna oikean muotoinen osoite."
 #: code:addons/portal/controllers/portal.py:272
 #, python-format
 msgid "Invalid report type: %s"
-msgstr ""
+msgstr "Virheellinen raportin tyyppi: %s"
 
 #. module: portal
 #: model:ir.model.fields,field_description:portal.field_portal_wizard__welcome_message
@@ -457,7 +543,7 @@ msgstr "Linkki"
 #. module: portal
 #: model:ir.model.fields,field_description:portal.field_portal_wizard_user__user_id
 msgid "Login User"
-msgstr ""
+msgstr "Käyttäjätunnus"
 
 #. module: portal
 #: model_terms:ir.ui.view,arch_db:portal.frontend_layout
@@ -495,7 +581,7 @@ msgstr "Odoo"
 #. module: portal
 #: model_terms:ir.ui.view,arch_db:portal.portal_record_sidebar
 msgid "Odoo Logo"
-msgstr ""
+msgstr "Odoo Logo"
 
 #. module: portal
 #. openerp-web
@@ -517,12 +603,12 @@ msgstr "Portaalin osoite"
 #. module: portal
 #: model:ir.model,name:portal.model_portal_mixin
 msgid "Portal Mixin"
-msgstr ""
+msgstr "Portal Mixin"
 
 #. module: portal
 #: model:ir.model,name:portal.model_portal_share
 msgid "Portal Sharing"
-msgstr ""
+msgstr "Jako portaalissa"
 
 #. module: portal
 #: model:ir.model,name:portal.model_portal_wizard_user
@@ -687,11 +773,14 @@ msgid ""
 "- Correct the emails of the relevant contacts\n"
 "- Grant access only to contacts with unique emails"
 msgstr ""
+"Ratkaistaksesi tämän ongelman voit: \n"
+"- Korjata vastaanottajien sähköpostiosoitteet\n"
+"- Sallia pääsyn vain kontakteille joilla on uniikki sähköpostiosoite"
 
 #. module: portal
 #: model_terms:ir.ui.view,arch_db:portal.portal_searchbar
 msgid "Toggle filters"
-msgstr ""
+msgstr "Kytke suotimet"
 
 #. module: portal
 #: model:ir.model.fields,field_description:portal.field_portal_wizard__user_ids
@@ -825,12 +914,12 @@ msgstr "Nimesi"
 #. module: portal
 #: model:mail.template,subject:portal.mail_template_data_portal_welcome
 msgid "Your Odoo account at ${object.user_id.company_id.name}"
-msgstr ""
+msgstr "Odoo-tunnuksesi - ${object.user_id.company_id.name}"
 
 #. module: portal
 #: model_terms:ir.ui.view,arch_db:portal.portal_contact
 msgid "Your contact"
-msgstr ""
+msgstr "Kontaktinne"
 
 #. module: portal
 #: model_terms:ir.ui.view,arch_db:portal.portal_my_details

--- a/addons/portal/i18n/ja.po
+++ b/addons/portal/i18n/ja.po
@@ -692,7 +692,7 @@ msgstr "VAT番号"
 #: code:addons/portal/models/portal_mixin.py:83
 #, python-format
 msgid "View %s"
-msgstr ""
+msgstr "%sを見る"
 
 #. module: portal
 #: model:ir.model.fields,field_description:portal.field_account_analytic_account__website_message_ids

--- a/addons/pos_discount/static/src/js/discount.js
+++ b/addons/pos_discount/static/src/js/discount.js
@@ -3,6 +3,7 @@ odoo.define('pos_discount.pos_discount', function (require) {
 
 var core = require('web.core');
 var screens = require('point_of_sale.screens');
+var field_utils = require('web.field_utils');
 
 var _t = core._t;
 
@@ -14,7 +15,7 @@ var DiscountButton = screens.ActionButtonWidget.extend({
             'title': _t('Discount Percentage'),
             'value': this.pos.config.discount_pc,
             'confirm': function(val) {
-                val = Math.round(Math.max(0,Math.min(100,val)));
+                val = Math.round(Math.max(0,Math.min(100,field_utils.parse.float(val))));
                 self.apply_discount(val);
             },
         });

--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -148,13 +148,13 @@
                         <page string="Inventory" name="inventory" groups="product.group_stock_packaging" attrs="{'invisible':[('type', '=', 'service')]}">
                             <group name="inventory">
                                 <group name="group_lots_and_weight" string="Logistics" attrs="{'invisible': [('type', 'not in', ['product', 'consu'])]}">
-                                    <label for="weight" attrs="{'invisible':[('product_variant_count', '>', 1)]}"/>
-                                    <div class="o_row" name="weight" attrs="{'invisible':[('product_variant_count', '>', 1)]}">
+                                    <label for="weight" attrs="{'invisible':[('product_variant_count', '>', 1), ('is_product_variant', '=', False)]}"/>
+                                    <div class="o_row" name="weight" attrs="{'invisible':[('product_variant_count', '>', 1), ('is_product_variant', '=', False)]}">
                                         <field name="weight"/>
                                         <span><field name="weight_uom_name"/></span>
                                     </div>
-                                    <label for="volume" attrs="{'invisible':[('product_variant_count', '>', 1)]}"/>
-                                    <div class="o_row" name="volume" attrs="{'invisible':[('product_variant_count', '>', 1)]}">
+                                    <label for="volume" attrs="{'invisible':[('product_variant_count', '>', 1), ('is_product_variant', '=', False)]}"/>
+                                    <div class="o_row" name="volume" attrs="{'invisible':[('product_variant_count', '>', 1), ('is_product_variant', '=', False)]}">
                                         <field name="volume" string="Volume"/>
                                         <span>m³</span>
                                     </div>
@@ -162,7 +162,7 @@
                             </group>
                             <group name="packaging" string="Packaging"
                                 colspan="4"
-                                attrs="{'invisible':['|', ('type', 'not in', ['product', 'consu']), ('product_variant_count', '>', 1)]}"
+                                attrs="{'invisible':['|', ('type', 'not in', ['product', 'consu']), ('product_variant_count', '>', 1), ('is_product_variant', '=', False)]}"
                                 groups="product.group_stock_packaging">
                                 <field name="packaging_ids" nolabel="1" context="{'tree_view_ref':'product.product_packaging_tree_view2', 'form_view_ref':'product.product_packaging_form_view2'}"/>
                             </group>

--- a/addons/sale/models/sale.py
+++ b/addons/sale/models/sale.py
@@ -1573,7 +1573,7 @@ class SaleOrderLine(models.Model):
         PricelistItem = self.env['product.pricelist.item']
         field_name = 'lst_price'
         currency_id = None
-        product_currency = None
+        product_currency = product.currency_id
         if rule_id:
             pricelist_item = PricelistItem.browse(rule_id)
             if pricelist_item.pricelist_id.discount_policy == 'without_discount':
@@ -1583,13 +1583,13 @@ class SaleOrderLine(models.Model):
 
             if pricelist_item.base == 'standard_price':
                 field_name = 'standard_price'
-            if pricelist_item.base == 'pricelist' and pricelist_item.base_pricelist_id:
+                product_currency = product.cost_currency_id
+            elif pricelist_item.base == 'pricelist' and pricelist_item.base_pricelist_id:
                 field_name = 'price'
                 product = product.with_context(pricelist=pricelist_item.base_pricelist_id.id)
                 product_currency = pricelist_item.base_pricelist_id.currency_id
             currency_id = pricelist_item.pricelist_id.currency_id
 
-        product_currency = product_currency or(product.company_id and product.company_id.currency_id) or self.env.user.company_id.currency_id
         if not currency_id:
             currency_id = product_currency
             cur_factor = 1.0

--- a/addons/sale/tests/test_sale_order.py
+++ b/addons/sale/tests/test_sale_order.py
@@ -280,3 +280,134 @@ class TestSaleOrder(TestCommonSaleNoChart):
 
         self.assertEqual(set(so_1.order_line.tax_id.ids), set([tax_company_1.id]),
             'Only taxes from the right company are put by default')
+
+    def test_multi_currency_discount(self):
+        """Verify the currency used for pricelist price & discount computation."""
+        products = self.env["product.product"].search([], limit=2)
+        product_1 = products[0]
+        product_2 = products[1]
+
+        # Make sure the company is in USD
+        main_company = self.env.ref('base.main_company')
+        main_curr = main_company.currency_id
+        other_curr = (self.env.ref('base.USD') + self.env.ref('base.EUR')) - main_curr
+        # main_company.currency_id = other_curr # product.currency_id when no company_id set
+        other_company = self.env["res.company"].create({
+            "name": "Test",
+            "currency_id": other_curr.id
+        })
+        user_in_other_company = self.env["res.users"].create({
+            "company_id": other_company.id,
+            "company_ids": [(6, 0, [other_company.id])],
+            "name": "E.T",
+            "login": "hohoho",
+        })
+        user_in_other_company.groups_id |= self.env.ref('sale.group_discount_per_so_line')
+        self.env['res.currency.rate'].search([]).unlink()
+        self.env['res.currency.rate'].create({
+            'name': '2010-01-01',
+            'rate': 2.0,
+            'currency_id': main_curr.id,
+            "company_id": False,
+        })
+
+        product_1.company_id = False
+        product_2.company_id = False
+
+        self.assertEqual(product_1.currency_id, main_curr)
+        self.assertEqual(product_2.currency_id, main_curr)
+        self.assertEqual(product_1.cost_currency_id, main_curr)
+        self.assertEqual(product_2.cost_currency_id, main_curr)
+
+        product_1_ctxt = product_1.with_env(self.env(user=user_in_other_company.id))
+        product_2_ctxt = product_2.with_env(self.env(user=user_in_other_company.id))
+        self.assertEqual(product_1_ctxt.currency_id, main_curr)
+        self.assertEqual(product_2_ctxt.currency_id, main_curr)
+        self.assertEqual(product_1_ctxt.cost_currency_id, other_curr)
+        self.assertEqual(product_2_ctxt.cost_currency_id, other_curr)
+
+        product_1.lst_price = 100.0
+        product_2_ctxt.standard_price = 10.0 # cost is company_dependent
+
+        pricelist = self.env["product.pricelist"].create({
+            "name": "Test multi-currency",
+            "discount_policy": "without_discount",
+            "currency_id": other_curr.id,
+            "item_ids": [
+                (0, 0, {
+                    "base": "list_price",
+                    "product_id": product_1.id,
+                    "compute_price": "percentage",
+                    "percent_price": 20,
+                }),
+                (0, 0, {
+                    "base": "standard_price",
+                    "product_id": product_2.id,
+                    "compute_price": "percentage",
+                    "percent_price": 10,
+                })
+            ]
+        })
+
+        # Create a SO in the other company
+        ##################################
+        # product_currency = main_company.currency_id when no company_id on the product
+
+        # CASE 1:
+        # company currency = so currency
+        # product_1.currency != so currency
+        # product_2.cost_currency_id = so currency
+        sales_order = product_1_ctxt.with_context(mail_notrack=True, mail_create_nolog=True).env["sale.order"].create({
+            "partner_id": self.env.user.partner_id.id,
+            "pricelist_id": pricelist.id,
+            "order_line": [
+                (0, 0, {
+                    "product_id": product_1.id,
+                    "product_uom_qty": 1.0
+                }),
+                (0, 0, {
+                    "product_id": product_2.id,
+                    "product_uom_qty": 1.0
+                })
+            ]
+        })
+        for line in sales_order.order_line:
+            # Create values autofill does not compute discount.
+            line._onchange_discount()
+
+        so_line_1 = sales_order.order_line[0]
+        so_line_2 = sales_order.order_line[1]
+        self.assertEqual(so_line_1.discount, 20)
+        self.assertEqual(so_line_1.price_unit, 50.0)
+        self.assertEqual(so_line_2.discount, 10)
+        self.assertEqual(so_line_2.price_unit, 10)
+
+        # CASE 2
+        # company currency != so currency
+        # product_1.currency == so currency
+        # product_2.cost_currency_id != so currency
+        pricelist.currency_id = main_curr
+        sales_order = product_1_ctxt.with_context(mail_notrack=True, mail_create_nolog=True).env["sale.order"].create({
+            "partner_id": self.env.user.partner_id.id,
+            "pricelist_id": pricelist.id,
+            "order_line": [
+                # Verify discount is considered in create hack
+                (0, 0, {
+                    "product_id": product_1.id,
+                    "product_uom_qty": 1.0
+                }),
+                (0, 0, {
+                    "product_id": product_2.id,
+                    "product_uom_qty": 1.0
+                })
+            ]
+        })
+        for line in sales_order.order_line:
+            line._onchange_discount()
+
+        so_line_1 = sales_order.order_line[0]
+        so_line_2 = sales_order.order_line[1]
+        self.assertEqual(so_line_1.discount, 20)
+        self.assertEqual(so_line_1.price_unit, 100.0)
+        self.assertEqual(so_line_2.discount, 10)
+        self.assertEqual(so_line_2.price_unit, 20)

--- a/addons/sale_timesheet/models/project.py
+++ b/addons/sale_timesheet/models/project.py
@@ -156,7 +156,7 @@ class ProjectTask(models.Model):
     def _compute_sale_order_id(self):
         for task in self:
             if task.billable_type == 'task_rate':
-                task.sale_order_id = task.sale_line_id.order_id or task.project_id.sale_order_id
+                task.sale_order_id = task.sale_line_id.sudo().order_id or task.project_id.sale_order_id
             elif task.billable_type == 'employee_rate':
                 task.sale_order_id = task.project_id.sale_order_id
             elif task.billable_type == 'no':

--- a/addons/sale_timesheet/views/project_task_views.xml
+++ b/addons/sale_timesheet/views/project_task_views.xml
@@ -62,7 +62,7 @@
             <field name="inherit_id" ref="project.view_task_form2"/>
             <field name="arch" type="xml">
                 <field name="user_id" position="after">
-                    <field name="sale_line_id" string="Sales Order Item" attrs="{'invisible': ['|', ('partner_id', '=', False)]}" options='{"no_open": True}' readonly="1" context="{'create': False, 'edit': False, 'delete': False}"/>
+                    <field name="sale_line_id" string="Sales Order Item" attrs="{'invisible': [('partner_id', '=', False)]}" options='{"no_open": True}' readonly="1" context="{'create': False, 'edit': False, 'delete': False}"/>
                     <field name="billable_type" invisible="1"/>
                 </field>
             </field>

--- a/addons/stock/i18n/stock.pot
+++ b/addons/stock/i18n/stock.pot
@@ -6201,7 +6201,7 @@ msgstr ""
 
 #. module: stock
 #: model:ir.model.fields,help:stock.field_stock_location_route__warehouse_selectable
-msgid "When a warehouse is selected for this route, this route should be seen as the default route when products pass through this warehouse.  This behaviour can be overridden by the routes on the Product/Product Categories or by the Preferred Routes on the Procurement"
+msgid "When a warehouse is selected for this route, this route should be seen as the default route when products pass through this warehouse."
 msgstr ""
 
 #. module: stock
@@ -6211,12 +6211,12 @@ msgstr ""
 
 #. module: stock
 #: model:ir.model.fields,help:stock.field_stock_location_route__product_selectable
-msgid "When checked, the route will be selectable in the Inventory tab of the Product form.  It will take priority over the Warehouse route. "
+msgid "When checked, the route will be selectable in the Inventory tab of the Product form."
 msgstr ""
 
 #. module: stock
 #: model:ir.model.fields,help:stock.field_stock_location_route__product_categ_selectable
-msgid "When checked, the route will be selectable on the Product Category.  It will take priority over the Warehouse route. "
+msgid "When checked, the route will be selectable on the Product Category."
 msgstr ""
 
 #. module: stock

--- a/addons/stock/models/stock_location.py
+++ b/addons/stock/models/stock_location.py
@@ -153,9 +153,9 @@ class Route(models.Model):
     active = fields.Boolean('Active', default=True, help="If the active field is set to False, it will allow you to hide the route without removing it.")
     sequence = fields.Integer('Sequence', default=0)
     rule_ids = fields.One2many('stock.rule', 'route_id', 'Rules', copy=True)
-    product_selectable = fields.Boolean('Applicable on Product', default=True, help="When checked, the route will be selectable in the Inventory tab of the Product form.  It will take priority over the Warehouse route. ")
-    product_categ_selectable = fields.Boolean('Applicable on Product Category', help="When checked, the route will be selectable on the Product Category.  It will take priority over the Warehouse route. ")
-    warehouse_selectable = fields.Boolean('Applicable on Warehouse', help="When a warehouse is selected for this route, this route should be seen as the default route when products pass through this warehouse.  This behaviour can be overridden by the routes on the Product/Product Categories or by the Preferred Routes on the Procurement")
+    product_selectable = fields.Boolean('Applicable on Product', default=True, help="When checked, the route will be selectable in the Inventory tab of the Product form.")
+    product_categ_selectable = fields.Boolean('Applicable on Product Category', help="When checked, the route will be selectable on the Product Category.")
+    warehouse_selectable = fields.Boolean('Applicable on Warehouse', help="When a warehouse is selected for this route, this route should be seen as the default route when products pass through this warehouse.")
     supplied_wh_id = fields.Many2one('stock.warehouse', 'Supplied Warehouse')
     supplier_wh_id = fields.Many2one('stock.warehouse', 'Supplying Warehouse')
     company_id = fields.Many2one(

--- a/addons/website/models/ir_translation.py
+++ b/addons/website/models/ir_translation.py
@@ -35,11 +35,7 @@ class IrTranslation(models.Model):
                 ON t.type = 'model' AND t.name = 'website.menu,name' AND t.res_id = o_menu.id
              INNER JOIN website_menu s_menu
                 ON o_menu.name = s_menu.name AND o_menu.url = s_menu.url
-             INNER JOIN website_menu root_menu
-                ON s_menu.parent_id = root_menu.id AND root_menu.parent_id IS NULL
-             WHERE t.lang IN %s and t.module IN %s
-               AND o_menu.website_id IS NULL AND o_menu.parent_id = %s
-               AND s_menu.website_id IS NOT NULL""" + conflict_clause,
-            (tuple(langs), tuple(modules), default_menu.id))
+             WHERE t.lang IN %s and t.module IN %s AND s_menu.website_id IS NOT NULL""" + conflict_clause,
+            (tuple(langs), tuple(modules)))
 
         return res

--- a/addons/website_sale/models/product.py
+++ b/addons/website_sale/models/product.py
@@ -172,7 +172,7 @@ class ProductTemplate(models.Model):
     website_size_y = fields.Integer('Size Y', default=1)
     website_style_ids = fields.Many2many('product.style', string='Styles')
     website_sequence = fields.Integer('Website Sequence', help="Determine the display order in the Website E-commerce",
-                                      default=lambda self: self._default_website_sequence())
+                                      default=lambda self: self._default_website_sequence(), copy=False)
     public_categ_ids = fields.Many2many('product.public.category', string='Website Product Category',
                                         help="The product will be available in each mentioned e-commerce category. Go to"
                                         "Shop > Customize and enable 'E-commerce categories' to view all e-commerce categories.")

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -1481,7 +1481,7 @@
                                         </h2>
                                     </div>
                                 </t>
-                                <t t-if="request.env['ir.config_parameter'].sudo().get_param('auth_signup.invitation_scope', 'b2b') == 'b2c' and request.website.is_public_user()">
+                                <t t-if="request.env['res.users']._get_signup_invitation_scope() == 'b2c' and request.website.is_public_user()">
                                     <p class="alert alert-info mt-3" role="status">
                                         <a role="button" t-att-href='order.partner_id.signup_prepare() and order.partner_id.signup_url' class='btn btn-primary'>Sign Up</a>
                                          to follow your order.

--- a/doc/cla/individual/skeller1.md
+++ b/doc/cla/individual/skeller1.md
@@ -1,0 +1,11 @@
+Germany, 2020-04-14
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Stephan Keller skeller1 mistk@gmx.de https://github.com/skeller1

--- a/doc/cla/individual/uglaos.md
+++ b/doc/cla/individual/uglaos.md
@@ -1,0 +1,11 @@
+Croatia, 2020-05-04
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Alen Uglik alen.uglik@notus.hr https://github.com/Uglaos

--- a/doc/reference/views.rst
+++ b/doc/reference/views.rst
@@ -299,9 +299,6 @@ Possible children elements of the list view are:
             unexpected results as domains are combined with a logical AND.
     ``context``
         merged into the view's context when performing the button's Odoo call
-    ``confirm``
-        confirmation message to display (and for the user to accept) before
-        performing the button's Odoo call
 
     .. declared but unused: help
 
@@ -480,6 +477,9 @@ system. Available semantic components are:
   ``special``
     for form views opened in dialogs: ``save`` to save the record and close the
     dialog, ``cancel`` to close the dialog without saving.
+  ``confirm``
+    confirmation message to display (and for the user to accept) before
+    performing the button's Odoo call (also works in Kanban views).
 
 ``field``
   renders (and allow edition of, possibly) a single field of the current

--- a/odoo/addons/base/i18n/ar.po
+++ b/odoo/addons/base/i18n/ar.po
@@ -23060,6 +23060,14 @@ msgid "The list of models that extends the current model."
 msgstr "قائمة الكائنات التي يمتد لها الكائن الحالي."
 
 #. module: base
+#: code:addons/base/models/ir_model.py:522
+#, python-format
+msgid ""
+"The m2o field %s is required but declares its ondelete policy as being 'set "
+"null'. Only 'restrict' and 'cascade' make sense."
+msgstr ""
+
+#. module: base
 #: model:ir.model.fields,help:base.field_ir_filters__action_id
 msgid ""
 "The menu action this filter applies to. When left empty the filter applies "

--- a/odoo/addons/base/i18n/az.po
+++ b/odoo/addons/base/i18n/az.po
@@ -21261,6 +21261,14 @@ msgid "The list of models that extends the current model."
 msgstr ""
 
 #. module: base
+#: code:addons/base/models/ir_model.py:522
+#, python-format
+msgid ""
+"The m2o field %s is required but declares its ondelete policy as being 'set "
+"null'. Only 'restrict' and 'cascade' make sense."
+msgstr ""
+
+#. module: base
 #: model:ir.model.fields,help:base.field_ir_filters__action_id
 msgid ""
 "The menu action this filter applies to. When left empty the filter applies "

--- a/odoo/addons/base/i18n/base.pot
+++ b/odoo/addons/base/i18n/base.pot
@@ -20652,6 +20652,12 @@ msgid "The list of models that extends the current model."
 msgstr ""
 
 #. module: base
+#: code:addons/base/models/ir_model.py:522
+#, python-format
+msgid "The m2o field %s is required but declares its ondelete policy as being 'set null'. Only 'restrict' and 'cascade' make sense."
+msgstr ""
+
+#. module: base
 #: model:ir.model.fields,help:base.field_ir_filters__action_id
 msgid "The menu action this filter applies to. When left empty the filter applies to all menus for this model."
 msgstr ""

--- a/odoo/addons/base/i18n/bg.po
+++ b/odoo/addons/base/i18n/bg.po
@@ -25018,6 +25018,14 @@ msgid "The list of models that extends the current model."
 msgstr "The list of models that extends the current model."
 
 #. module: base
+#: code:addons/base/models/ir_model.py:522
+#, python-format
+msgid ""
+"The m2o field %s is required but declares its ondelete policy as being 'set "
+"null'. Only 'restrict' and 'cascade' make sense."
+msgstr ""
+
+#. module: base
 #: model:ir.model.fields,help:base.field_ir_filters__action_id
 msgid ""
 "The menu action this filter applies to. When left empty the filter applies "

--- a/odoo/addons/base/i18n/bn.po
+++ b/odoo/addons/base/i18n/bn.po
@@ -21494,6 +21494,14 @@ msgid "The list of models that extends the current model."
 msgstr ""
 
 #. module: base
+#: code:addons/base/models/ir_model.py:522
+#, python-format
+msgid ""
+"The m2o field %s is required but declares its ondelete policy as being 'set "
+"null'. Only 'restrict' and 'cascade' make sense."
+msgstr ""
+
+#. module: base
 #: model:ir.model.fields,help:base.field_ir_filters__action_id
 msgid ""
 "The menu action this filter applies to. When left empty the filter applies "

--- a/odoo/addons/base/i18n/bs.po
+++ b/odoo/addons/base/i18n/bs.po
@@ -21504,6 +21504,14 @@ msgid "The list of models that extends the current model."
 msgstr "Lista modela koji proširuju trenutni model."
 
 #. module: base
+#: code:addons/base/models/ir_model.py:522
+#, python-format
+msgid ""
+"The m2o field %s is required but declares its ondelete policy as being 'set "
+"null'. Only 'restrict' and 'cascade' make sense."
+msgstr ""
+
+#. module: base
 #: model:ir.model.fields,help:base.field_ir_filters__action_id
 msgid ""
 "The menu action this filter applies to. When left empty the filter applies "

--- a/odoo/addons/base/i18n/ca.po
+++ b/odoo/addons/base/i18n/ca.po
@@ -22515,6 +22515,14 @@ msgid "The list of models that extends the current model."
 msgstr "La llista de models que estenen al model actual."
 
 #. module: base
+#: code:addons/base/models/ir_model.py:522
+#, python-format
+msgid ""
+"The m2o field %s is required but declares its ondelete policy as being 'set "
+"null'. Only 'restrict' and 'cascade' make sense."
+msgstr ""
+
+#. module: base
 #: model:ir.model.fields,help:base.field_ir_filters__action_id
 msgid ""
 "The menu action this filter applies to. When left empty the filter applies "

--- a/odoo/addons/base/i18n/cs.po
+++ b/odoo/addons/base/i18n/cs.po
@@ -24349,6 +24349,14 @@ msgid "The list of models that extends the current model."
 msgstr "Seznam modelů, které rozšiřují aktuální model."
 
 #. module: base
+#: code:addons/base/models/ir_model.py:522
+#, python-format
+msgid ""
+"The m2o field %s is required but declares its ondelete policy as being 'set "
+"null'. Only 'restrict' and 'cascade' make sense."
+msgstr ""
+
+#. module: base
 #: model:ir.model.fields,help:base.field_ir_filters__action_id
 msgid ""
 "The menu action this filter applies to. When left empty the filter applies "

--- a/odoo/addons/base/i18n/da.po
+++ b/odoo/addons/base/i18n/da.po
@@ -21586,6 +21586,14 @@ msgid "The list of models that extends the current model."
 msgstr "Listen over modeller der udvider den nuværende model."
 
 #. module: base
+#: code:addons/base/models/ir_model.py:522
+#, python-format
+msgid ""
+"The m2o field %s is required but declares its ondelete policy as being 'set "
+"null'. Only 'restrict' and 'cascade' make sense."
+msgstr ""
+
+#. module: base
 #: model:ir.model.fields,help:base.field_ir_filters__action_id
 msgid ""
 "The menu action this filter applies to. When left empty the filter applies "

--- a/odoo/addons/base/i18n/de.po
+++ b/odoo/addons/base/i18n/de.po
@@ -25893,6 +25893,14 @@ msgid "The list of models that extends the current model."
 msgstr "Die Liste der Modelle, die das aktuelle Modell erweitern."
 
 #. module: base
+#: code:addons/base/models/ir_model.py:522
+#, python-format
+msgid ""
+"The m2o field %s is required but declares its ondelete policy as being 'set "
+"null'. Only 'restrict' and 'cascade' make sense."
+msgstr ""
+
+#. module: base
 #: model:ir.model.fields,help:base.field_ir_filters__action_id
 msgid ""
 "The menu action this filter applies to. When left empty the filter applies "

--- a/odoo/addons/base/i18n/el.po
+++ b/odoo/addons/base/i18n/el.po
@@ -21990,6 +21990,14 @@ msgid "The list of models that extends the current model."
 msgstr "Η λίστα των υποδειγμάτων που εκτείνεται στο τρέχον υπόδειγμα."
 
 #. module: base
+#: code:addons/base/models/ir_model.py:522
+#, python-format
+msgid ""
+"The m2o field %s is required but declares its ondelete policy as being 'set "
+"null'. Only 'restrict' and 'cascade' make sense."
+msgstr ""
+
+#. module: base
 #: model:ir.model.fields,help:base.field_ir_filters__action_id
 msgid ""
 "The menu action this filter applies to. When left empty the filter applies "

--- a/odoo/addons/base/i18n/es.po
+++ b/odoo/addons/base/i18n/es.po
@@ -66,10 +66,10 @@
 # Oscar Soto <oscar.soto.ochoa@gmail.com>, 2020
 # Marco Alejandro Martinez <martinezsuarezmarcoalejandro@gmail.com>, 2020
 # Pedro M. Baeza <pedro.baeza@gmail.com>, 2020
-# Elena Aguirre Claeyssens <eac@odoo.com>, 2020
 # Leonardo J. Caballero G. <leonardocaballero@gmail.com>, 2020
 # gpi odoo <gpi@odoo.com>, 2020
 # Osiris Román <osiris.roman@yachaytech.edu.ec>, 2020
+# Elena Aguirre Claeyssens <eac@odoo.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -77,7 +77,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-12-10 14:44+0000\n"
 "PO-Revision-Date: 2018-08-24 09:14+0000\n"
-"Last-Translator: Osiris Román <osiris.roman@yachaytech.edu.ec>, 2020\n"
+"Last-Translator: Elena Aguirre Claeyssens <eac@odoo.com>, 2020\n"
 "Language-Team: Spanish (https://www.transifex.com/odoo/teams/41243/es/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -13918,6 +13918,7 @@ msgstr "Herramientas extra"
 #: model:ir.module.module,summary:base.module_account_invoice_extract
 msgid "Extract data from invoice scans to fill them automatically"
 msgstr ""
+"Extraiga datos de los escaneos de facturas para rellenarlas automáticamente"
 
 #. module: base
 #: model:res.partner.industry,name:base.res_partner_industry_U
@@ -14809,12 +14810,12 @@ msgstr "Alemania SKR04 - Contabilidad"
 #. module: base
 #: model:ir.module.module,summary:base.module_website_sale_dashboard
 msgid "Get a new dashboard view in the Website App"
-msgstr ""
+msgstr "Obtenga una nueva vista de tablero en la aplicación Sitio web"
 
 #. module: base
 #: model:ir.module.module,summary:base.module_website_enterprise
 msgid "Get the enterprise look and feel"
-msgstr ""
+msgstr "Obtenga el aspecto y experiencia Enterprise"
 
 #. module: base
 #: model:res.country,name:base.gh
@@ -21227,7 +21228,7 @@ msgstr "Reimpresion del ticket del punto de venta"
 #. module: base
 #: model:ir.module.module,shortdesc:base.module_pos_enterprise
 msgid "Point of Sale enterprise"
-msgstr ""
+msgstr "Punto de Venta Enterprise"
 
 #. module: base
 #: model:res.country,name:base.pl
@@ -24756,6 +24757,14 @@ msgstr "El usuario interno a cargo de este contacto."
 #: model:ir.model.fields,help:base.field_ir_model__inherited_model_ids
 msgid "The list of models that extends the current model."
 msgstr "La lista de modelos que extienden el modelo actual."
+
+#. module: base
+#: code:addons/base/models/ir_model.py:522
+#, python-format
+msgid ""
+"The m2o field %s is required but declares its ondelete policy as being 'set "
+"null'. Only 'restrict' and 'cascade' make sense."
+msgstr ""
 
 #. module: base
 #: model:ir.model.fields,help:base.field_ir_filters__action_id

--- a/odoo/addons/base/i18n/es.po
+++ b/odoo/addons/base/i18n/es.po
@@ -45,7 +45,7 @@
 # Massiel Acuna <mac@odoo.com>, 2018
 # Fernando Herrera <baloosoftware@gmail.com>, 2018
 # Rodrigo Aragon <conectacoatepec@gmail.com>, 2018
-# Gabriel Umana <gabriel.umana@delfixcr.com>, 2019
+# gabriumaa <gabriel.umana@delfixcr.com>, 2019
 # Carolina Gonzalez <cgo@odoo.com>, 2019
 # Vivian Montana <vmo@odoo.com>, 2019
 # pepito alialabs <pepitoalialabs@gmail.com>, 2019
@@ -65,11 +65,11 @@
 # Jesús Alan Ramos Rodríguez <alan.ramos@jarsa.com.mx>, 2020
 # Oscar Soto <oscar.soto.ochoa@gmail.com>, 2020
 # Marco Alejandro Martinez <martinezsuarezmarcoalejandro@gmail.com>, 2020
-# Osiris Román <osiris.roman@yachaytech.edu.ec>, 2020
 # Pedro M. Baeza <pedro.baeza@gmail.com>, 2020
 # Elena Aguirre Claeyssens <eac@odoo.com>, 2020
 # Leonardo J. Caballero G. <leonardocaballero@gmail.com>, 2020
 # gpi odoo <gpi@odoo.com>, 2020
+# Osiris Román <osiris.roman@yachaytech.edu.ec>, 2020
 # 
 msgid ""
 msgstr ""
@@ -77,7 +77,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-12-10 14:44+0000\n"
 "PO-Revision-Date: 2018-08-24 09:14+0000\n"
-"Last-Translator: gpi odoo <gpi@odoo.com>, 2020\n"
+"Last-Translator: Osiris Román <osiris.roman@yachaytech.edu.ec>, 2020\n"
 "Language-Team: Spanish (https://www.transifex.com/odoo/teams/41243/es/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -21748,7 +21748,7 @@ msgstr ""
 #. module: base
 #: model:ir.module.module,shortdesc:base.module_sale_quotation_builder
 msgid "Quotation Builder"
-msgstr ""
+msgstr "Generador de cotizaciones"
 
 #. module: base
 #: model:ir.module.module,summary:base.module_sale_expense

--- a/odoo/addons/base/i18n/et.po
+++ b/odoo/addons/base/i18n/et.po
@@ -22127,6 +22127,14 @@ msgid "The list of models that extends the current model."
 msgstr "Käesolevat mudelit laiendavate mudelite nimekiri"
 
 #. module: base
+#: code:addons/base/models/ir_model.py:522
+#, python-format
+msgid ""
+"The m2o field %s is required but declares its ondelete policy as being 'set "
+"null'. Only 'restrict' and 'cascade' make sense."
+msgstr ""
+
+#. module: base
 #: model:ir.model.fields,help:base.field_ir_filters__action_id
 msgid ""
 "The menu action this filter applies to. When left empty the filter applies "

--- a/odoo/addons/base/i18n/et.po
+++ b/odoo/addons/base/i18n/et.po
@@ -9703,7 +9703,7 @@ msgstr ""
 #. module: base
 #: selection:ir.actions.server,state:0
 msgid "Create Next Activity"
-msgstr ""
+msgstr "Looge järgmine tegevus"
 
 #. module: base
 #: model:ir.module.module,summary:base.module_crm_project

--- a/odoo/addons/base/i18n/eu.po
+++ b/odoo/addons/base/i18n/eu.po
@@ -18,6 +18,8 @@
 # Iñaki Ibarrola <inakiibarrola@yahoo.es>, 2020
 # Maialen Rodriguez <maialenrodriguez98@gmail.com>, 2020
 # Miren Maiz <mirenmaizz@gmail.com>, 2020
+# Unai Muñoz <unaimunoz9@gmail.com>, 2020
+# Mikel Galarza <mikelgalarza99@gmail.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -25,7 +27,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-12-10 14:44+0000\n"
 "PO-Revision-Date: 2018-08-24 09:14+0000\n"
-"Last-Translator: Miren Maiz <mirenmaizz@gmail.com>, 2020\n"
+"Last-Translator: Mikel Galarza <mikelgalarza99@gmail.com>, 2020\n"
 "Language-Team: Basque (https://www.transifex.com/odoo/teams/41243/eu/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -76,6 +78,10 @@ msgid ""
 "Allow cashier to reprint receipts\n"
 "\n"
 msgstr ""
+"\n"
+"\n"
+"Utzi kutxazainari ordainagiriak berriro inprimatzen\n"
+"\n"
 
 #. module: base
 #: model:ir.module.module,description:base.module_l10n_hu
@@ -294,6 +300,9 @@ msgid ""
 "\n"
 "This addon is already installed on your system"
 msgstr ""
+"\n"
+"\n"
+"Addon hori dagoeneko instalatuta dago zure sisteman"
 
 #. module: base
 #: model:ir.module.module,description:base.module_pos_sale
@@ -364,6 +373,8 @@ msgid ""
 "        Accounting reports for Belgium\n"
 "    "
 msgstr ""
+"\n"
+"Belgikarako kontabilitate-txostenak"
 
 #. module: base
 #: model:ir.module.module,description:base.module_l10n_br_reports
@@ -372,6 +383,8 @@ msgid ""
 "        Accounting reports for Brazilian\n"
 "    "
 msgstr ""
+"\n"
+"Brazilerako kontabilitate-txostenak"
 
 #. module: base
 #: model:ir.module.module,description:base.module_l10n_cl_reports
@@ -380,6 +393,8 @@ msgid ""
 "        Accounting reports for Chile\n"
 "    "
 msgstr ""
+"\n"
+"Txilerako kontabilitate-txostenak"
 
 #. module: base
 #: model:ir.module.module,description:base.module_l10n_de_reports
@@ -398,6 +413,8 @@ msgid ""
 "        Accounting reports for Hungarian\n"
 " "
 msgstr ""
+"\n"
+"Hungariarako kontabilitate-txostenak"
 
 #. module: base
 #: model:ir.module.module,description:base.module_l10n_lt_reports
@@ -416,6 +433,8 @@ msgid ""
 "        Accounting reports for Netherlands\n"
 "    "
 msgstr ""
+"\n"
+"Herbereretarako kontabilitate-txostenak"
 
 #. module: base
 #: model:ir.module.module,description:base.module_l10n_ro_reports
@@ -424,6 +443,8 @@ msgid ""
 "        Accounting reports for Romania\n"
 "    "
 msgstr ""
+"\n"
+"Romaniarako kontabilitate-txostenak"
 
 #. module: base
 #: model:ir.module.module,description:base.module_l10n_si_reports
@@ -432,6 +453,8 @@ msgid ""
 "        Accounting reports for Slovenian\n"
 "    "
 msgstr ""
+"\n"
+"Slobeniarako kontabilitate-txostenak"
 
 #. module: base
 #: model:ir.module.module,description:base.module_l10n_za_reports
@@ -448,6 +471,8 @@ msgid ""
 "        Accounting reports for Spain\n"
 "    "
 msgstr ""
+"\n"
+"Espainiarako kontabilitate-txostenak"
 
 #. module: base
 #: model:ir.module.module,description:base.module_l10n_ch_reports
@@ -456,6 +481,8 @@ msgid ""
 "        Accounting reports for Switzerland\n"
 "    "
 msgstr ""
+"\n"
+"Suitzarako kontabilitate-txostenak"
 
 #. module: base
 #: model:ir.module.module,description:base.module_l10n_uk_reports
@@ -521,6 +548,8 @@ msgid ""
 "\n"
 "        Allows to use python code to define taxes"
 msgstr ""
+"\n"
+"Taxiak definitzeko python code erabiltzea"
 
 #. module: base
 #: model:ir.module.module,description:base.module_documents
@@ -551,6 +580,8 @@ msgid ""
 "\n"
 "        Bridge between HR and Maintenance."
 msgstr ""
+"\n"
+"HR eta Mantentze-lanen arteko zubia."
 
 #. module: base
 #: model:ir.module.module,description:base.module_sale_intrastat
@@ -791,6 +822,8 @@ msgid ""
 "\n"
 "        This module is used for Online bank synchronization."
 msgstr ""
+"\n"
+"Modulu hau lineako banku-sinkronizaziorako erabiltzen da"
 
 #. module: base
 #: model:ir.module.module,description:base.module_account_online_sync
@@ -807,6 +840,8 @@ msgid ""
 "        This module provides the core of the Odoo Mobile App.\n"
 "        "
 msgstr ""
+"\n"
+"Modulu honek Odoo aplikazio mugikorraren gunea ematen du."
 
 #. module: base
 #: model:ir.module.module,description:base.module_maintenance
@@ -821,6 +856,8 @@ msgid ""
 "\n"
 "        Use Plaid.com to retrieve bank statements"
 msgstr ""
+"\n"
+"Erabili Plaid.com banku-adierazpenak berreskuratzeko"
 
 #. module: base
 #: model:ir.module.module,description:base.module_account_plaid
@@ -829,6 +866,8 @@ msgid ""
 "        Use Plaid.com to retrieve bank statements.\n"
 "    "
 msgstr ""
+"\n"
+"Erabili Plaid.com banku-adierazpenak berreskuratzeko."
 
 #. module: base
 #: model:ir.module.module,description:base.module_hr_recruitment_survey
@@ -903,6 +942,8 @@ msgid ""
 "\n"
 "    Adds workcenters to Quality Control\n"
 msgstr ""
+"\n"
+"Lantokiak gehitu dizkio Quality Control-i\n"
 
 #. module: base
 #: model:ir.module.module,description:base.module_quality_mrp_iot
@@ -929,6 +970,8 @@ msgid ""
 "    Gantt view for Leaves Dashboard\n"
 "    "
 msgstr ""
+"\n"
+"Gantt ikuspegia Dashboard orrietarako"
 
 #. module: base
 #: model:ir.module.module,description:base.module_account_lock
@@ -949,6 +992,8 @@ msgid ""
 "    Module linking the attendance module to the timesheet app.\n"
 "    "
 msgstr ""
+"\n"
+"Timesheet aplikaziora joateko modulua lotzen duen modulua."
 
 #. module: base
 #: model:ir.module.module,description:base.module_payment_payumoney
@@ -983,6 +1028,8 @@ msgid ""
 "\n"
 "  Publish your products on eBay"
 msgstr ""
+"\n"
+"Argitaratu zure produktuak eBayn"
 
 #. module: base
 #: model:ir.module.module,description:base.module_timesheet_grid
@@ -1136,6 +1183,9 @@ msgid ""
 "==================\n"
 "    "
 msgstr ""
+"\n"
+"Kontabilitate Txostenak\n"
+"===================="
 
 #. module: base
 #: model:ir.module.module,description:base.module_l10n_ar_reports
@@ -1146,6 +1196,8 @@ msgid ""
 "\n"
 "    "
 msgstr ""
+"\n"
+"Kontabilitate Txostenak Argetinarako"
 
 #. module: base
 #: model:ir.module.module,description:base.module_l10n_bo_reports
@@ -1156,6 +1208,8 @@ msgid ""
 "\n"
 "    "
 msgstr ""
+"\n"
+"Kontabilitate Txostenak Boliviarako"
 
 #. module: base
 #: model:ir.module.module,description:base.module_l10n_co_reports
@@ -1165,6 +1219,8 @@ msgid ""
 "================================\n"
 "    "
 msgstr ""
+"\n"
+"Kontabilitate Txostenak Kolonbiarako"
 
 #. module: base
 #: model:ir.module.module,description:base.module_l10n_hr_reports
@@ -1174,6 +1230,8 @@ msgid ""
 "================================\n"
 "    "
 msgstr ""
+"\n"
+"Kontabilitate Txostenak Kroaziarako"
 
 #. module: base
 #: model:ir.module.module,description:base.module_l10n_dk_reports
@@ -1193,6 +1251,8 @@ msgid ""
 "\n"
 "    "
 msgstr ""
+"\n"
+"Kontabilitate Txostenak Etiopearako"
 
 #. module: base
 #: model:ir.module.module,description:base.module_l10n_fr_reports
@@ -1203,6 +1263,8 @@ msgid ""
 "\n"
 "    "
 msgstr ""
+"\n"
+"Kontabilitate Txostenak Frantziarako"
 
 #. module: base
 #: model:ir.module.module,description:base.module_l10n_gr_reports
@@ -1213,6 +1275,8 @@ msgid ""
 "\n"
 "    "
 msgstr ""
+"\n"
+"Kontabilitate Txostenak Graziarako"
 
 #. module: base
 #: model:ir.module.module,description:base.module_l10n_in_reports
@@ -1222,6 +1286,8 @@ msgid ""
 "================================\n"
 "    "
 msgstr ""
+"\n"
+"Kontabilitate Txostenak Indiarako"
 
 #. module: base
 #: model:ir.module.module,description:base.module_l10n_jp_reports
@@ -1231,6 +1297,8 @@ msgid ""
 "================================\n"
 "    "
 msgstr ""
+"\n"
+"Kontabilitate Txostenak Japoniarako"
 
 #. module: base
 #: model:ir.module.module,description:base.module_l10n_lu_reports
@@ -1240,6 +1308,8 @@ msgid ""
 "=================================\n"
 "    "
 msgstr ""
+"\n"
+"Kontabilitate Txostenak Luxemburgorako"
 
 #. module: base
 #: model:ir.module.module,description:base.module_l10n_ma_reports
@@ -1249,6 +1319,8 @@ msgid ""
 "================================\n"
 "    "
 msgstr ""
+"\n"
+"Kontabilitate Txostenak Marruekoserako"
 
 #. module: base
 #: model:ir.module.module,description:base.module_l10n_no_reports
@@ -1258,6 +1330,8 @@ msgid ""
 "================================\n"
 "    "
 msgstr ""
+"\n"
+"Kontabilitate Txostenak Noruegarako"
 
 #. module: base
 #: model:ir.module.module,description:base.module_l10n_pl_reports
@@ -1267,6 +1341,8 @@ msgid ""
 "================================\n"
 "    "
 msgstr ""
+"\n"
+"Kontabilitate Txostenak Poloniarako"
 
 #. module: base
 #: model:ir.module.module,description:base.module_l10n_sg_reports
@@ -1288,6 +1364,8 @@ msgid ""
 "================================\n"
 "    "
 msgstr ""
+"\n"
+"Kontabilitate Txostenak Tailandiarako"
 
 #. module: base
 #: model:ir.module.module,description:base.module_website_sale_delivery
@@ -6175,7 +6253,7 @@ msgstr ""
 #. module: base
 #: model:ir.module.module,shortdesc:base.module_account_taxcloud
 msgid "Account TaxCloud"
-msgstr ""
+msgstr "TaxCloud kontua"
 
 #. module: base
 #: model:ir.module.module,shortdesc:base.module_website_sale_account_taxcloud
@@ -6392,7 +6470,7 @@ msgstr ""
 #. module: base
 #: selection:ir.actions.server,state:0
 msgid "Add Followers"
-msgstr ""
+msgstr "Jarraitzaileak gehitu"
 
 #. module: base
 #: model:ir.module.module,summary:base.module_mail_bot
@@ -20936,7 +21014,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:base.field_res_partner__vat
 #: model:ir.model.fields,field_description:base.field_res_users__vat
 msgid "Tax ID"
-msgstr ""
+msgstr "Zerga identifikazioa"
 
 #. module: base
 #: model:ir.module.module,shortdesc:base.module_website_sale_taxcloud_delivery

--- a/odoo/addons/base/i18n/eu.po
+++ b/odoo/addons/base/i18n/eu.po
@@ -18,8 +18,8 @@
 # Iñaki Ibarrola <inakiibarrola@yahoo.es>, 2020
 # Maialen Rodriguez <maialenrodriguez98@gmail.com>, 2020
 # Miren Maiz <mirenmaizz@gmail.com>, 2020
+# mgalarza005 <mikelgalarza99@gmail.com>, 2020
 # Unai Muñoz <unaimunoz9@gmail.com>, 2020
-# Mikel Galarza <mikelgalarza99@gmail.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -27,7 +27,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-12-10 14:44+0000\n"
 "PO-Revision-Date: 2018-08-24 09:14+0000\n"
-"Last-Translator: Mikel Galarza <mikelgalarza99@gmail.com>, 2020\n"
+"Last-Translator: Unai Muñoz <unaimunoz9@gmail.com>, 2020\n"
 "Language-Team: Basque (https://www.transifex.com/odoo/teams/41243/eu/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -7015,12 +7015,12 @@ msgstr "Aplikazioak:"
 #. module: base
 #: model:ir.model.fields,field_description:base.field_ir_ui_view__arch_db
 msgid "Arch Blob"
-msgstr ""
+msgstr "Arch Blob"
 
 #. module: base
 #: model:ir.model.fields,field_description:base.field_ir_ui_view__arch_fs
 msgid "Arch Filename"
-msgstr ""
+msgstr "Fitxategiaren izena "
 
 #. module: base
 #: model_terms:ir.ui.view,arch_db:base.view_view_form
@@ -7204,7 +7204,7 @@ msgstr ""
 #. module: base
 #: selection:ir.actions.server,usage:0
 msgid "Automated Action"
-msgstr ""
+msgstr "Ekintza automatizatua"
 
 #. module: base
 #: model:ir.module.module,shortdesc:base.module_base_automation
@@ -7716,7 +7716,7 @@ msgstr ""
 #. module: base
 #: selection:ir.property,type:0
 msgid "Boolean"
-msgstr ""
+msgstr "Boolean"
 
 #. module: base
 #: model:ir.module.module,shortdesc:base.module_theme_bootswatch
@@ -9419,7 +9419,7 @@ msgstr ""
 #. module: base
 #: model:ir.module.module,shortdesc:base.module_rating
 msgid "Customer Rating"
-msgstr ""
+msgstr "Bezeroaren kalifikazioa"
 
 #. module: base
 #: model:ir.module.module,shortdesc:base.module_website_customer
@@ -9721,7 +9721,7 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:base.res_partner_kanban_view
 #: model_terms:ir.ui.view,arch_db:base.view_partner_form
 msgid "Delivery"
-msgstr ""
+msgstr "Entrega"
 
 #. module: base
 #: model:ir.module.module,shortdesc:base.module_delivery_barcode
@@ -11581,7 +11581,7 @@ msgstr "Flota"
 #. module: base
 #: selection:ir.property,type:0
 msgid "Float"
-msgstr ""
+msgstr "Float"
 
 #. module: base
 #: selection:report.paperformat,format:0
@@ -12370,7 +12370,7 @@ msgstr ""
 #: model:ir.module.module,shortdesc:base.module_hw_drivers
 #: model:ir.module.module,shortdesc:base.module_hw_proxy
 msgid "Hardware Proxy"
-msgstr ""
+msgstr "Hardware Proxy"
 
 #. module: base
 #: model:ir.model.fields,field_description:base.field_res_partner_bank__qr_code_valid
@@ -12472,7 +12472,7 @@ msgstr ""
 #. module: base
 #: model:ir.module.category,description:base.module_category_event_management
 msgid "Helps you manage your Events."
-msgstr ""
+msgstr "Zure gertaerak kudeatzen lagunduko dizu."
 
 #. module: base
 #: model:ir.module.category,description:base.module_category_hr_appraisal
@@ -21369,6 +21369,14 @@ msgid "The list of models that extends the current model."
 msgstr ""
 
 #. module: base
+#: code:addons/base/models/ir_model.py:522
+#, python-format
+msgid ""
+"The m2o field %s is required but declares its ondelete policy as being 'set "
+"null'. Only 'restrict' and 'cascade' make sense."
+msgstr ""
+
+#. module: base
 #: model:ir.model.fields,help:base.field_ir_filters__action_id
 msgid ""
 "The menu action this filter applies to. When left empty the filter applies "
@@ -23789,7 +23797,7 @@ msgstr "false"
 #. module: base
 #: selection:ir.model.fields,ttype:0
 msgid "float"
-msgstr ""
+msgstr "float"
 
 #. module: base
 #: model_terms:ir.ui.view,arch_db:base.view_model_fields_form
@@ -23824,7 +23832,7 @@ msgstr "init"
 #. module: base
 #: selection:ir.model.fields,ttype:0
 msgid "integer"
-msgstr ""
+msgstr "integer"
 
 #. module: base
 #: model_terms:ir.ui.view,arch_db:base.view_partner_form
@@ -23932,7 +23940,7 @@ msgstr ""
 #. module: base
 #: selection:ir.model.fields,ttype:0
 msgid "selection"
-msgstr ""
+msgstr "aukeraketa"
 
 #. module: base
 #: selection:ir.model.fields,ttype:0
@@ -24037,7 +24045,7 @@ msgstr "test_convert"
 #. module: base
 #: selection:ir.model.fields,ttype:0
 msgid "text"
-msgstr ""
+msgstr "Testua"
 
 #. module: base
 #: model_terms:ir.ui.view,arch_db:base.res_config_installer

--- a/odoo/addons/base/i18n/fa.po
+++ b/odoo/addons/base/i18n/fa.po
@@ -21543,6 +21543,14 @@ msgid "The list of models that extends the current model."
 msgstr "لیست ماجولهایی که این مدل را گسترش می‌دهد."
 
 #. module: base
+#: code:addons/base/models/ir_model.py:522
+#, python-format
+msgid ""
+"The m2o field %s is required but declares its ondelete policy as being 'set "
+"null'. Only 'restrict' and 'cascade' make sense."
+msgstr ""
+
+#. module: base
 #: model:ir.model.fields,help:base.field_ir_filters__action_id
 msgid ""
 "The menu action this filter applies to. When left empty the filter applies "

--- a/odoo/addons/base/i18n/fi.po
+++ b/odoo/addons/base/i18n/fi.po
@@ -8692,7 +8692,7 @@ msgstr "Valitse tämä, jos kontakti on työntekijä."
 #. module: base
 #: model:ir.model.fields,field_description:base.field_ir_attachment__checksum
 msgid "Checksum/SHA1"
-msgstr ""
+msgstr "Checksum/SHA1"
 
 #. module: base
 #: model:ir.model.fields,field_description:base.field_ir_actions_server__child_ids

--- a/odoo/addons/base/i18n/fi.po
+++ b/odoo/addons/base/i18n/fi.po
@@ -27,8 +27,8 @@
 # Retropikzel, 2019
 # Tuomo Aura <tuomo.aura@web-veistamo.fi>, 2019
 # Martin Trigaux, 2019
-# Veikko Väätäjä <veikko.vaataja@gmail.com>, 2020
 # Jarmo Kortetjärvi <jarmo.kortetjarvi@gmail.com>, 2020
+# Veikko Väätäjä <veikko.vaataja@gmail.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -36,7 +36,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-12-10 14:44+0000\n"
 "PO-Revision-Date: 2018-08-24 09:14+0000\n"
-"Last-Translator: Jarmo Kortetjärvi <jarmo.kortetjarvi@gmail.com>, 2020\n"
+"Last-Translator: Veikko Väätäjä <veikko.vaataja@gmail.com>, 2020\n"
 "Language-Team: Finnish (https://www.transifex.com/odoo/teams/41243/fi/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -6922,7 +6922,7 @@ msgstr ""
 #. module: base
 #: model:ir.model,name:base.model_ir_actions_act_window_view
 msgid "Action Window View"
-msgstr ""
+msgstr "Action Window View"
 
 #. module: base
 #: model:ir.actions.act_window,name:base.ir_sequence_actions
@@ -9195,7 +9195,7 @@ msgstr "Määritä ohjattuja toimintoja"
 #. module: base
 #: model:ir.module.module,summary:base.module_timesheet_grid_sale
 msgid "Configure timesheet invoicing"
-msgstr ""
+msgstr "Määrittele tuntikirjausten laskutus"
 
 #. module: base
 #: model_terms:ir.ui.view,arch_db:base.view_base_module_uninstall
@@ -19193,7 +19193,7 @@ msgstr ""
 #. module: base
 #: model:ir.model,name:base.model_ir_qweb_field_image
 msgid "Qweb Field Image"
-msgstr ""
+msgstr "Qweb kentän kuva"
 
 #. module: base
 #: model:ir.model,name:base.model_ir_qweb_field_integer
@@ -22077,6 +22077,14 @@ msgstr ""
 #: model:ir.model.fields,help:base.field_ir_model__inherited_model_ids
 msgid "The list of models that extends the current model."
 msgstr "Lista malleistajotka laajentavat tätä mallia."
+
+#. module: base
+#: code:addons/base/models/ir_model.py:522
+#, python-format
+msgid ""
+"The m2o field %s is required but declares its ondelete policy as being 'set "
+"null'. Only 'restrict' and 'cascade' make sense."
+msgstr ""
 
 #. module: base
 #: model:ir.model.fields,help:base.field_ir_filters__action_id

--- a/odoo/addons/base/i18n/fil.po
+++ b/odoo/addons/base/i18n/fil.po
@@ -21257,6 +21257,14 @@ msgid "The list of models that extends the current model."
 msgstr ""
 
 #. module: base
+#: code:addons/base/models/ir_model.py:522
+#, python-format
+msgid ""
+"The m2o field %s is required but declares its ondelete policy as being 'set "
+"null'. Only 'restrict' and 'cascade' make sense."
+msgstr ""
+
+#. module: base
 #: model:ir.model.fields,help:base.field_ir_filters__action_id
 msgid ""
 "The menu action this filter applies to. When left empty the filter applies "

--- a/odoo/addons/base/i18n/fr.po
+++ b/odoo/addons/base/i18n/fr.po
@@ -66,12 +66,13 @@
 # Martin Trigaux, 2019
 # lcaodoo <lca@odoo.com>, 2019
 # Alexandra Jubert <aju@odoo.com>, 2020
-# Julien Goergen <jgo@odoo.com>, 2020
-# Vallen Delobel <edv@odoo.com>, 2020
 # Cécile Collart <cco@odoo.com>, 2020
 # Jonathan Quique <jqu@odoo.com>, 2020
-# Priscilla Sanchez <prs@odoo.com>, 2020
 # Pauline Thiry <pth@odoo.com>, 2020
+# Christelle Pinchart <cpi@odoo.com>, 2020
+# Vallen Delobel <edv@odoo.com>, 2020
+# Julien Goergen <jgo@odoo.com>, 2020
+# Priscilla Sanchez <prs@odoo.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -79,7 +80,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-12-10 14:44+0000\n"
 "PO-Revision-Date: 2018-08-24 09:14+0000\n"
-"Last-Translator: Pauline Thiry <pth@odoo.com>, 2020\n"
+"Last-Translator: Priscilla Sanchez <prs@odoo.com>, 2020\n"
 "Language-Team: French (https://www.transifex.com/odoo/teams/41243/fr/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1514,6 +1515,96 @@ msgid ""
 "    file from which you can click on the file to download locally.  This\n"
 "    file can then be uploaded to the bank.\n"
 msgstr ""
+"\n"
+"Transfert de crédit ABA\n"
+"===================\n"
+"\n"
+"Ce module permet la génération de lots de paiement en ABA (Australian\n"
+"Bankers Association) fichiers texte. Le fichier 'aba' généré peut être téléchargé\n"
+"à de nombreuses banques australiennes.\n"
+"\n"
+"Configuration\n"
+"-----\n"
+"\n"
+"- *Configuration > Journaux*\n"
+"\n"
+"    Si nécessaire, créez un nouveau journal ou choisissez un journal existant de ** Type ** * \"Banque\" *.\n"
+"\n"
+"    Sur ** Paramètres avancés **, assurez-vous que ABA Credit Transfer est coché.\n"
+"\n"
+"    Dans l'onglet ** Compte bancaire **, entrez le ** Numéro de compte **.\n"
+"\n"
+"- * Configuration> Comptes bancaires *\n"
+"\n"
+"   Le compte apparaîtra dans la liste comme nom de journal.\n"
+"\n"
+"    L'édition affichera le ** Numéro de compte **. Ceci est important car il est utilisé par     le processus ABA.\n"
+"\n"
+"    **Banque** est optionel.\n"
+"\n"
+"- * Ventes> Configuration> Comptes bancaires> Comptes bancaires *\n"
+"\n"
+"    Le compte apparaîtra dans la liste comme numéro de compte.\n"
+"\n"
+"    ** Paiements ABA ** - Réglez sur * «Compte pour effectuer des paiements ABA» *.\n"
+"\n"
+"   ** BSB ** - Obligatoire, 6 chiffres, et sera automatiquement formaté.\n"
+"\n"
+"    ** Titulaire du compte ** - Facultatif.\n"
+"\n"
+"    ** Nom du compte / bénéficiaire ** - Obligatoire. Généralement non validé par les banques     sur les transferts de fichiers ABA, et peut apparaître sur le relevé bancaire du paiement.\n"
+"\n"
+"    ** Code de l'institution financière ** - Obligatoire (fourni par la banque ou peut être trouvé\n"
+"    sur Google). Il s'agit de trois caractères majuscules 3.\n"
+"\n"
+"    ** Fournir le nom d'utilisateur ** - Certaines banques autorisent ce format libre, certaines banques peuvent rejeter le fichier ABA si le nom d'utilisateur fournisseur n'est pas celui attendu. Il ne peut pas dépasser 26 caractères.\n"
+"\n"
+"   ** Numéro d'identification (APCA) ** - Le numéro d'identification de l'utilisateur est une alloué par une banque. Il est composé de 6 chiffres.\n"
+"\n"
+"    ** Inclure les transactions d'auto-équilibrage ** - Certaines institutions exigent qu'une transaction d'auto-équilibrage qui est utilisée comme vérification.\n"
+"\n"
+"- Les comptes bancaires des fournisseurs peuvent être créés au même endroit, mais il est\n"
+"généralement plus facile à mettre en place à partir du partenaire qu'à partir du vendeur.\n"
+"\n"
+"- *Comptabilité > Achats > Vendeurs*\n"
+"\n"
+"    Dans l'onglet ** Ventes et achats **, cliquez sur * \"Compte (s) bancaire (s)\" * d'où un compte bancaire du fournisseur peut être créé ou modifié.\n"
+"\n"
+"    **Numéro de compte** - Requis.\n"
+"\n"
+"    ** Paiements ABA ** - Réglez sur * «Autoriser les paiements ABA sur ce compte» *.\n"
+"  \n"
+"  ** BSB ** - Obligatoire, 6 chiffres, et sera automatiquement formaté.\n"
+"\n"
+"    ** Titulaire du compte ** - Facultatif\n"
+"\n"
+"    ** Nom du compte / bénéficiaire ** - Obligatoire. Généralement non validé par le\n"
+"    banques.\n"
+"\n"
+"Utilisation\n"
+"---\n"
+"\n"
+"- Créez un paiement fournisseur de la manière habituelle.\n"
+"\n"
+"    Assurez-vous que le ** fournisseur ** ne possède qu'un compte de paiement ABA valide.\n"
+"\n"
+"    Choisissez le ** Journal des paiements ** correct qui est défini pour les paiements ABA.\n"
+"\n"
+"    Sélectionnez le bouton radio ** ABA Credit Transfer **\n"
+"\n"
+"    Si le fournisseur possède plusieurs comptes bancaires, vous devrez peut-être sélectionner\n"
+"    correct ** Compte bancaire du destinataire **.\n"
+"\n"
+"    Entrez le montant du paiement, etc.\n"
+"\n"
+"- *Achats > Paiements*\n"
+"\n"
+"    Une fois les paiements confirmés, ils apparaîtront dans la liste des paiements.\n"
+"\n"
+"    À l'aide de filtres ou de tri, sélectionnez les paiements à inclure. En dessous de\n"
+"    *Actions* choisissez * Télécharger le paiement ABA *. Un pop-up apparaît avec le fichier\n"
+"    à partir duquel vous pouvez cliquer sur le fichier à télécharger localement. Ce\n"
+"    fichier peut ensuite être téléchargé vers la banque.\n"
 
 #. module: base
 #: model:ir.module.module,description:base.module_account_accountant
@@ -6120,6 +6211,11 @@ msgid ""
 "    - a generic chart of accounts\n"
 "    - SARS VAT Ready Structure"
 msgstr ""
+"\n"
+"C'est la dernière localisation de base sud-africaine nécessaire pour faire fonctionner Odoo dans ZA:\n"
+"================================================================================\n"
+"- Un plan comptable générique\n"
+"- Structure de préparation à la TVA pour le SRAS"
 
 #. module: base
 #: model:ir.module.module,description:base.module_l10n_ro
@@ -10239,7 +10335,7 @@ msgstr "Lecture de code-barres sur mobile"
 #: code:addons/base/models/ir_qweb_fields.py:607
 #, python-format
 msgid "Barcode symbology"
-msgstr ""
+msgstr "Symbologie du code-barres"
 
 #. module: base
 #: code:addons/base/models/ir_qweb_fields.py:607
@@ -10445,7 +10541,7 @@ msgstr "Bhoutan"
 #. module: base
 #: model:ir.module.module,summary:base.module_website_delivery_ups
 msgid "Bill to your UPS account number"
-msgstr ""
+msgstr "Facturez sur votre numéro de compte UPS"
 
 #. module: base
 #: selection:ir.property,type:0
@@ -11807,7 +11903,7 @@ msgstr "Créer le menu"
 #. module: base
 #: model:ir.model,name:base.model_wizard_ir_model_menu_create
 msgid "Create Menu Wizard"
-msgstr ""
+msgstr "Créer un menu"
 
 #. module: base
 #: selection:ir.actions.server,state:0
@@ -12619,7 +12715,7 @@ msgstr "Données de démonstration"
 #. module: base
 #: model:ir.model,name:base.model_ir_demo_failure_wizard
 msgid "Demo Failure wizard"
-msgstr ""
+msgstr "Échec de la démo"
 
 #. module: base
 #: model:ir.model.fields,field_description:base.field_ir_demo_failure_wizard__failure_ids
@@ -13018,7 +13114,7 @@ msgstr ""
 #. module: base
 #: model:ir.module.module,summary:base.module_event_enterprise
 msgid "Displays cohort analysis on attendees."
-msgstr ""
+msgstr "Affiche l'analyse des cohortes sur les participants."
 
 #. module: base
 #: model:res.country,name:base.dj
@@ -13801,7 +13897,7 @@ msgstr ""
 #. module: base
 #: model:ir.module.module,summary:base.module_website
 msgid "Enterprise website builder"
-msgstr ""
+msgstr "Constructeur de sites web d'entreprise"
 
 #. module: base
 #: model:res.partner.industry,name:base.res_partner_industry_R
@@ -13915,7 +14011,7 @@ msgstr "Organisation d'événements"
 #. module: base
 #: model:ir.module.module,shortdesc:base.module_event_enterprise
 msgid "Events Organization Add-on"
-msgstr ""
+msgstr "Complément d'Organisation d'Evènements"
 
 #. module: base
 #: model:ir.module.module,shortdesc:base.module_event_sale
@@ -14314,7 +14410,7 @@ msgstr "Outils supplémentaires"
 #. module: base
 #: model:ir.module.module,summary:base.module_account_invoice_extract
 msgid "Extract data from invoice scans to fill them automatically"
-msgstr ""
+msgstr "Extraire les données des scans de facture automatiquement"
 
 #. module: base
 #: model:res.partner.industry,name:base.res_partner_industry_U
@@ -15013,7 +15109,7 @@ msgstr "Plein écran"
 #: model:ir.module.module,shortdesc:base.module_purchase_mrp_workorder_quality
 #: model:ir.module.module,summary:base.module_purchase_mrp_workorder_quality
 msgid "Full Traceability Report Demo Data"
-msgstr ""
+msgstr "Données de démo pour le rapport de traçabilité"
 
 #. module: base
 #: model:ir.model.fields,field_description:base.field_ir_logging__func
@@ -15165,6 +15261,11 @@ msgid ""
 "\n"
 "OFX and QIF imports are available in Enterprise version."
 msgstr ""
+"Assistant générique pour l'import des relevés bancaires.\n"
+"\n"
+"(Ce module n'inclut aucun type de format d'importation.)\n"
+"\n"
+"Les imports OFX et QIF sont disponible dans la version Entreprise."
 
 #. module: base
 #: model:ir.module.module,description:base.module_website_form
@@ -15210,12 +15311,12 @@ msgstr "Allemagne SKR04 - Comptabilité"
 #. module: base
 #: model:ir.module.module,summary:base.module_website_sale_dashboard
 msgid "Get a new dashboard view in the Website App"
-msgstr ""
+msgstr "Obtenez une nouvelle vue du tableau de bord dans l'application Web"
 
 #. module: base
 #: model:ir.module.module,summary:base.module_website_enterprise
 msgid "Get the enterprise look and feel"
-msgstr ""
+msgstr "Obtenez l’aspect et la convivialité de l’entreprise"
 
 #. module: base
 #: model:res.country,name:base.gh
@@ -15864,7 +15965,7 @@ msgstr "Action page d'accueil"
 #. module: base
 #: model:ir.actions.act_url,name:base.action_open_website
 msgid "Home Menu"
-msgstr ""
+msgstr "Acceuil"
 
 #. module: base
 #: model:res.country,name:base.hn
@@ -16928,7 +17029,7 @@ msgstr ""
 #. module: base
 #: model:ir.module.module,shortdesc:base.module_hw_posbox_upgrade
 msgid "IoTBox Software Upgrader"
-msgstr ""
+msgstr "Mise à niveau du Logiciel IoTBox"
 
 #. module: base
 #: model:res.country,name:base.ir
@@ -17884,7 +17985,7 @@ msgstr "Échec d'envoi du courriel"
 #. module: base
 #: model:ir.module.module,shortdesc:base.module_mail_enterprise
 msgid "Mail Enterprise"
-msgstr ""
+msgstr "E-Mail Entreprise"
 
 #. module: base
 #: model:ir.model,name:base.model_ir_mail_server
@@ -21989,7 +22090,7 @@ msgstr "Format de papier"
 #. module: base
 #: model:ir.model,name:base.model_report_paperformat
 msgid "Paper Format Config"
-msgstr ""
+msgstr "Configuration du format papier"
 
 #. module: base
 #: model:ir.actions.act_window,name:base.paper_format_action
@@ -23047,7 +23148,7 @@ msgstr "Champ Qweb image"
 #. module: base
 #: model:ir.model,name:base.model_ir_qweb_field_integer
 msgid "Qweb Field Integer"
-msgstr ""
+msgstr "Champ entier Qweb"
 
 #. module: base
 #: model:ir.model,name:base.model_ir_qweb_field_many2one
@@ -23062,7 +23163,7 @@ msgstr ""
 #. module: base
 #: model:ir.model,name:base.model_ir_qweb_field_relative
 msgid "Qweb Field Relative"
-msgstr ""
+msgstr "Relatif au champ Qweb"
 
 #. module: base
 #: model:ir.model,name:base.model_ir_qweb_field_selection
@@ -23705,7 +23806,7 @@ msgstr "Distribution de coupons de vente"
 #. module: base
 #: model:ir.module.module,shortdesc:base.module_sale_intrastat
 msgid "Sale Intrastat"
-msgstr ""
+msgstr "Vente Intrastat"
 
 #. module: base
 #: model:ir.module.module,shortdesc:base.module_sale_purchase
@@ -25689,7 +25790,7 @@ msgstr "Suites de tests pour les campagnes d'Automatisation Marketing"
 #. module: base
 #: model:ir.module.module,shortdesc:base.module_test_testing_utilities
 msgid "Test testing utilities"
-msgstr ""
+msgstr "Tester les utilitaires de test"
 
 #. module: base
 #: model:ir.module.module,description:base.module_test_access_rights
@@ -27446,7 +27547,7 @@ msgstr "Types d'utilisateur"
 #. module: base
 #: model:ir.model,name:base.model_change_password_user
 msgid "User, Change Password Wizard"
-msgstr ""
+msgstr "Utilisateur, Assistant de changement de mot de passe"
 
 #. module: base
 #: model:ir.actions.act_window,name:base.ir_default_menu_action

--- a/odoo/addons/base/i18n/fr.po
+++ b/odoo/addons/base/i18n/fr.po
@@ -26083,6 +26083,14 @@ msgid "The list of models that extends the current model."
 msgstr "La liste des modèles qui étendent le modèle actuel."
 
 #. module: base
+#: code:addons/base/models/ir_model.py:522
+#, python-format
+msgid ""
+"The m2o field %s is required but declares its ondelete policy as being 'set "
+"null'. Only 'restrict' and 'cascade' make sense."
+msgstr ""
+
+#. module: base
 #: model:ir.model.fields,help:base.field_ir_filters__action_id
 msgid ""
 "The menu action this filter applies to. When left empty the filter applies "

--- a/odoo/addons/base/i18n/gu.po
+++ b/odoo/addons/base/i18n/gu.po
@@ -21270,6 +21270,14 @@ msgid "The list of models that extends the current model."
 msgstr ""
 
 #. module: base
+#: code:addons/base/models/ir_model.py:522
+#, python-format
+msgid ""
+"The m2o field %s is required but declares its ondelete policy as being 'set "
+"null'. Only 'restrict' and 'cascade' make sense."
+msgstr ""
+
+#. module: base
 #: model:ir.model.fields,help:base.field_ir_filters__action_id
 msgid ""
 "The menu action this filter applies to. When left empty the filter applies "

--- a/odoo/addons/base/i18n/he.po
+++ b/odoo/addons/base/i18n/he.po
@@ -20720,7 +20720,7 @@ msgstr "רצף"
 #. module: base
 #: model:ir.model.fields,field_description:base.field_ir_sequence__code
 msgid "Sequence Code"
-msgstr ""
+msgstr "קוד רצף"
 
 #. module: base
 #: model:ir.model,name:base.model_ir_sequence_date_range
@@ -22537,6 +22537,14 @@ msgstr "המשתמש הפנימי הממונה על איש קשר זה."
 #: model:ir.model.fields,help:base.field_ir_model__inherited_model_ids
 msgid "The list of models that extends the current model."
 msgstr "רשימת הדגמים שמרחיבה את המודל הנוכחי."
+
+#. module: base
+#: code:addons/base/models/ir_model.py:522
+#, python-format
+msgid ""
+"The m2o field %s is required but declares its ondelete policy as being 'set "
+"null'. Only 'restrict' and 'cascade' make sense."
+msgstr ""
 
 #. module: base
 #: model:ir.model.fields,help:base.field_ir_filters__action_id

--- a/odoo/addons/base/i18n/he.po
+++ b/odoo/addons/base/i18n/he.po
@@ -6883,7 +6883,7 @@ msgstr ""
 #. module: base
 #: model:res.partner.industry,full_name:base.res_partner_industry_A
 msgid "A AGRICULTURE, FORESTRY AND FISHING"
-msgstr ""
+msgstr "חקלאות, ייעור ודייג"
 
 #. module: base
 #: code:addons/models.py:2986
@@ -8750,7 +8750,7 @@ msgstr "כברירת מחדל, הווידג'ט משתמש במידע מהשדו�
 #. module: base
 #: model:res.partner.industry,full_name:base.res_partner_industry_C
 msgid "C MANUFACTURING"
-msgstr ""
+msgstr "ייצור"
 
 #. module: base
 #: selection:report.paperformat,format:0
@@ -12871,7 +12871,7 @@ msgstr "תפקוד"
 #. module: base
 #: model:res.partner.industry,full_name:base.res_partner_industry_G
 msgid "G WHOLESALE AND RETAIL TRADE;REPAIR OF MOTOR VEHICLES AND MOTORCYCLES"
-msgstr ""
+msgstr "G סחר סיטונאי וקמעוני, תיקון כלי רכב ואופנועים"
 
 #. module: base
 #: selection:ir.module.module,license:0
@@ -13745,7 +13745,7 @@ msgstr "הונגריה"
 #. module: base
 #: model:res.partner.industry,full_name:base.res_partner_industry_I
 msgid "I ACCOMMODATION AND FOOD SERVICE ACTIVITIES"
-msgstr ""
+msgstr "I פעילויות אירוח ושירותי מזון"
 
 #. module: base
 #: model:ir.module.module,shortdesc:base.module_base_iban
@@ -13897,7 +13897,7 @@ msgstr ""
 #. module: base
 #: model:res.partner.industry,name:base.res_partner_industry_J
 msgid "IT/Communication"
-msgstr ""
+msgstr "מערכות מידע/תקשורת"
 
 #. module: base
 #: model:res.country,name:base.is
@@ -14816,7 +14816,7 @@ msgstr "הרגע נעשה"
 #. module: base
 #: model:res.partner.industry,full_name:base.res_partner_industry_K
 msgid "K FINANCIAL AND INSURANCE ACTIVITIES"
-msgstr ""
+msgstr "K פעילויות פיננסיות וביטוח"
 
 #. module: base
 #: model:ir.module.module,shortdesc:base.module_digest
@@ -14891,7 +14891,7 @@ msgstr "קירגיזסטן"
 #. module: base
 #: model:res.partner.industry,full_name:base.res_partner_industry_L
 msgid "L REAL ESTATE ACTIVITIES"
-msgstr ""
+msgstr "L פעילויות נדל\"ן"
 
 #. module: base
 #: selection:ir.module.module,license:0
@@ -15584,7 +15584,7 @@ msgstr "לוקסמבורג - דוחות כספיים"
 #. module: base
 #: model:res.partner.industry,full_name:base.res_partner_industry_M
 msgid "M PROFESSIONAL, SCIENTIFIC AND TECHNICAL ACTIVITIES"
-msgstr ""
+msgstr "M פעילויות מקצועיות, מדעיות וטכנולוגיות"
 
 #. module: base
 #: model:ir.module.module,shortdesc:base.module_mrp_byproduct
@@ -16542,7 +16542,7 @@ msgstr "מיאנמר"
 #. module: base
 #: model:res.partner.industry,full_name:base.res_partner_industry_N
 msgid "N ADMINISTRATIVE AND SUPPORT SERVICE ACTIVITIES"
-msgstr ""
+msgstr "פעילויות מנהלתיות ותמיכה"
 
 #. module: base
 #: model:res.country,vat_label:base.gt
@@ -16906,7 +16906,7 @@ msgstr "מספר מודולים עודכנו."
 #. module: base
 #: model:res.partner.industry,full_name:base.res_partner_industry_O
 msgid "O PUBLIC ADMINISTRATION AND DEFENCE;COMPULSORY SOCIAL SECURITY"
-msgstr ""
+msgstr "מנהל ציבורי, הגנה וביטחון"
 
 #. module: base
 #: model:ir.module.module,shortdesc:base.module_auth_oauth
@@ -19520,7 +19520,7 @@ msgstr "ביטוי Python"
 #. module: base
 #: model:res.partner.industry,full_name:base.res_partner_industry_Q
 msgid "Q HUMAN HEALTH AND SOCIAL WORK ACTIVITIES"
-msgstr ""
+msgstr "Q בריאות ופעילויות עבודה סוציאלית"
 
 #. module: base
 #: model_terms:ir.ui.view,arch_db:base.view_view_search
@@ -19702,7 +19702,7 @@ msgstr ""
 #. module: base
 #: model:res.partner.industry,full_name:base.res_partner_industry_R
 msgid "R ARTS, ENTERTAINMENT AND RECREATION"
-msgstr ""
+msgstr "R אומנויות, בידור ופנאי"
 
 #. module: base
 #: model:res.country,vat_label:base.mx
@@ -20198,7 +20198,7 @@ msgstr "ראוניון"
 #. module: base
 #: model:res.partner.industry,full_name:base.res_partner_industry_S
 msgid "S OTHER SERVICE ACTIVITIES"
-msgstr ""
+msgstr "S פעילויות שירות אחרות"
 
 #. module: base
 #: model:ir.module.module,shortdesc:base.module_account_sepa
@@ -21520,6 +21520,8 @@ msgid ""
 "T ACTIVITIES OF HOUSEHOLDS AS EMPLOYERS;UNDIFFERENTIATED GOODS- AND "
 "SERVICES-PRODUCING ACTIVITIES OF HOUSEHOLDS FOR OWN USE"
 msgstr ""
+"פעילויות של משקי בית כמעסיקים, ייצור שירותים של פעילויות משקי בית לשימוש "
+"עצמי"
 
 #. module: base
 #: selection:base.language.export,format:0
@@ -23424,7 +23426,7 @@ msgstr "סוג:"
 #. module: base
 #: model:res.partner.industry,full_name:base.res_partner_industry_U
 msgid "U ACTIVITIES OF EXTRA TERRITORIAL ORGANISATIONS AND BODIES"
-msgstr ""
+msgstr "U פעילויות של גופים וארגונים מחוץ לתחום השיפוטי של המדינה"
 
 #. module: base
 #: model:ir.module.module,shortdesc:base.module_l10n_ae

--- a/odoo/addons/base/i18n/hr.po
+++ b/odoo/addons/base/i18n/hr.po
@@ -21823,6 +21823,14 @@ msgid "The list of models that extends the current model."
 msgstr "Popis modela koji proširuju trenutni model."
 
 #. module: base
+#: code:addons/base/models/ir_model.py:522
+#, python-format
+msgid ""
+"The m2o field %s is required but declares its ondelete policy as being 'set "
+"null'. Only 'restrict' and 'cascade' make sense."
+msgstr ""
+
+#. module: base
 #: model:ir.model.fields,help:base.field_ir_filters__action_id
 msgid ""
 "The menu action this filter applies to. When left empty the filter applies "

--- a/odoo/addons/base/i18n/hu.po
+++ b/odoo/addons/base/i18n/hu.po
@@ -12,9 +12,9 @@
 # gezza <geza.nagy@oregional.hu>, 2019
 # Istvan <leki69@gmail.com>, 2019
 # krnkris, 2019
-# Ákos Nagy <akos.nagy@oregional.hu>, 2019
 # Martin Trigaux, 2019
-# Tamás Németh <ntomasz81@gmail.com>, 2019
+# Tamás Németh <ntomasz81@gmail.com>, 2020
+# Ákos Nagy <akos.nagy@oregional.hu>, 2020
 # 
 msgid ""
 msgstr ""
@@ -22,7 +22,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-12-10 14:44+0000\n"
 "PO-Revision-Date: 2018-08-24 09:14+0000\n"
-"Last-Translator: Tamás Németh <ntomasz81@gmail.com>, 2019\n"
+"Last-Translator: Ákos Nagy <akos.nagy@oregional.hu>, 2020\n"
 "Language-Team: Hungarian (https://www.transifex.com/odoo/teams/41243/hu/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -8032,7 +8032,7 @@ msgstr "Adminisztráció"
 #. module: base
 #: model:res.partner.industry,name:base.res_partner_industry_N
 msgid "Administrative"
-msgstr ""
+msgstr "Közigazgatási"
 
 #. module: base
 #: model:ir.model.fields,help:base.field_res_country_state__name
@@ -8052,7 +8052,7 @@ msgstr "Adminisztrátori hozzáférés szükséges a modul törléséhez"
 #. module: base
 #: model_terms:ir.ui.view,arch_db:base.view_country_form
 msgid "Advanced Address Formatting"
-msgstr ""
+msgstr "Haladó címformázás"
 
 #. module: base
 #: model:ir.module.module,shortdesc:base.module_website_event_track
@@ -8189,6 +8189,8 @@ msgstr ""
 #: model:ir.module.module,summary:base.module_website_sale_comparison
 msgid "Allow shoppers to compare products based on their attributes"
 msgstr ""
+"Engedje, hogy a vásárlók összehasonlítsák a termékeket tulajdonságaik "
+"alapján"
 
 #. module: base
 #: model:ir.module.module,summary:base.module_website_sale_wishlist
@@ -8670,7 +8672,7 @@ msgstr "Automatizálás"
 #. module: base
 #: model_terms:ir.ui.view,arch_db:base.ir_filters_view_form
 msgid "Available for User"
-msgstr ""
+msgstr "Elérhető fehasználónak"
 
 #. module: base
 #: model_terms:ir.ui.view,arch_db:base.res_partner_kanban_view
@@ -9143,12 +9145,12 @@ msgstr "Bootswatch téma"
 #. module: base
 #: model:ir.module.module,description:base.module_theme_bootswatch
 msgid "Bootswatch themes"
-msgstr ""
+msgstr "Bootswatch témák"
 
 #. module: base
 #: model:res.country,name:base.ba
 msgid "Bosnia and Herzegovina"
-msgstr ""
+msgstr "Bosznia-Hercegovina"
 
 #. module: base
 #: model:res.country,name:base.bw
@@ -10791,22 +10793,22 @@ msgstr "Árfolyamok"
 #. module: base
 #: model:ir.model.fields,field_description:base.field_res_currency__currency_subunit_label
 msgid "Currency Subunit"
-msgstr ""
+msgstr "Váltópénz"
 
 #. module: base
 #: model:ir.model.fields,help:base.field_res_currency__currency_subunit_label
 msgid "Currency Subunit Name"
-msgstr ""
+msgstr "Váltópénz neve"
 
 #. module: base
 #: model:ir.model.fields,field_description:base.field_res_currency__currency_unit_label
 msgid "Currency Unit"
-msgstr ""
+msgstr "Váltópénz egysége"
 
 #. module: base
 #: model:ir.model.fields,help:base.field_res_currency__currency_unit_label
 msgid "Currency Unit Name"
-msgstr ""
+msgstr "Váltópénz egységneve"
 
 #. module: base
 #: model:ir.model.fields,help:base.field_res_currency__symbol
@@ -23145,6 +23147,14 @@ msgid "The list of models that extends the current model."
 msgstr "A jelenlegi modellt túllépő modellek listái."
 
 #. module: base
+#: code:addons/base/models/ir_model.py:522
+#, python-format
+msgid ""
+"The m2o field %s is required but declares its ondelete policy as being 'set "
+"null'. Only 'restrict' and 'cascade' make sense."
+msgstr ""
+
+#. module: base
 #: model:ir.model.fields,help:base.field_ir_filters__action_id
 msgid ""
 "The menu action this filter applies to. When left empty the filter applies "
@@ -25601,7 +25611,7 @@ msgstr "e.g. Úr."
 #. module: base
 #: model_terms:ir.ui.view,arch_db:base.view_company_document_template_form
 msgid "e.g. Opening hours, bank accounts (one per line)"
-msgstr ""
+msgstr "pl.: nyitvatartási idő, bankszámlaszám (soronként egy)"
 
 #. module: base
 #: model_terms:ir.ui.view,arch_db:base.view_partner_form
@@ -25630,7 +25640,7 @@ msgstr "pl. https://www.odoo.com"
 #. module: base
 #: model:ir.module.module,shortdesc:base.module_sale_ebay
 msgid "eBay Connector"
-msgstr ""
+msgstr "eBay összekötő"
 
 #. module: base
 #: model:ir.module.module,shortdesc:base.module_website_sale

--- a/odoo/addons/base/i18n/id.po
+++ b/odoo/addons/base/i18n/id.po
@@ -21559,6 +21559,14 @@ msgid "The list of models that extends the current model."
 msgstr ""
 
 #. module: base
+#: code:addons/base/models/ir_model.py:522
+#, python-format
+msgid ""
+"The m2o field %s is required but declares its ondelete policy as being 'set "
+"null'. Only 'restrict' and 'cascade' make sense."
+msgstr ""
+
+#. module: base
 #: model:ir.model.fields,help:base.field_ir_filters__action_id
 msgid ""
 "The menu action this filter applies to. When left empty the filter applies "

--- a/odoo/addons/base/i18n/is.po
+++ b/odoo/addons/base/i18n/is.po
@@ -22938,6 +22938,14 @@ msgid "The list of models that extends the current model."
 msgstr "The list of models that extends the current model."
 
 #. module: base
+#: code:addons/base/models/ir_model.py:522
+#, python-format
+msgid ""
+"The m2o field %s is required but declares its ondelete policy as being 'set "
+"null'. Only 'restrict' and 'cascade' make sense."
+msgstr ""
+
+#. module: base
 #: model:ir.model.fields,help:base.field_ir_filters__action_id
 msgid ""
 "The menu action this filter applies to. When left empty the filter applies "

--- a/odoo/addons/base/i18n/it.po
+++ b/odoo/addons/base/i18n/it.po
@@ -18057,7 +18057,7 @@ msgstr "Il modello %s non esiste"
 #: code:addons/base/models/ir_model.py:668
 #, python-format
 msgid "Model %s does not exist!"
-msgstr "Il modello %s non esiste."
+msgstr "Il modello %s non esiste"
 
 #. module: base
 #: code:addons/base/models/ir_model.py:194
@@ -18073,7 +18073,7 @@ msgstr "Accesso modello"
 #. module: base
 #: model:ir.model,name:base.model_ir_model_constraint
 msgid "Model Constraint"
-msgstr "Limite Modello"
+msgstr "Vincolo del modello"
 
 #. module: base
 #: model:ir.actions.act_window,name:base.action_model_constraint
@@ -18081,7 +18081,7 @@ msgstr "Limite Modello"
 #: model_terms:ir.ui.view,arch_db:base.view_model_constraint_form
 #: model_terms:ir.ui.view,arch_db:base.view_model_constraint_list
 msgid "Model Constraints"
-msgstr "Vincoli modello"
+msgstr "Vincoli del modello"
 
 #. module: base
 #: model:ir.model,name:base.model_ir_model_data
@@ -18100,7 +18100,7 @@ msgstr "Descrizione modello"
 #. module: base
 #: selection:ir.translation,type:0
 msgid "Model Field"
-msgstr "Campo modello"
+msgstr "Campo del modello"
 
 #. module: base
 #: model:ir.model.fields,field_description:base.field_ir_actions_report__model
@@ -18239,7 +18239,7 @@ msgstr ""
 #. module: base
 #: model:ir.model.fields,help:base.field_ir_translation__module
 msgid "Module this term belongs to"
-msgstr "Il modulo a cui appartiene questa parola"
+msgstr "Modulo a cui appartiene questo termine"
 
 #. module: base
 #: model:ir.model.fields,field_description:base.field_ir_module_category__module_ids
@@ -18693,7 +18693,7 @@ msgstr "Numero di applicazioni"
 #. module: base
 #: model:ir.model.fields,field_description:base.field_ir_cron__numbercall
 msgid "Number of Calls"
-msgstr "Numero di Chiamate"
+msgstr "Numero di chiamate"
 
 #. module: base
 #: model:ir.model.fields,field_description:base.field_res_users__companies_count
@@ -22876,7 +22876,7 @@ msgstr "Bonifico SEPA"
 #. module: base
 #: model:ir.module.module,shortdesc:base.module_account_sepa_direct_debit
 msgid "SEPA Direct Debit"
-msgstr "Addebito Diretto SEPA"
+msgstr "Addebito diretto SEPA"
 
 #. module: base
 #: model:ir.module.module,summary:base.module_sms
@@ -23543,7 +23543,7 @@ msgstr "Condiviso"
 #. module: base
 #: selection:res.partner,type:0
 msgid "Shipping address"
-msgstr "Indirizzo di Spedizione"
+msgstr "Indirizzo di spedizione"
 
 #. module: base
 #: model:ir.module.module,shortdesc:base.module_website_sale_wishlist
@@ -24002,7 +24002,7 @@ msgstr "Indirizzo 2…"
 #: model_terms:ir.ui.view,arch_db:base.view_partner_short_form
 #: model_terms:ir.ui.view,arch_db:base.view_res_bank_form
 msgid "Street..."
-msgstr "Strada/Via…"
+msgstr "Indirizzo…"
 
 #. module: base
 #: model:ir.model.fields,field_description:base.field_res_bank__street2
@@ -24010,13 +24010,13 @@ msgstr "Strada/Via…"
 #: model:ir.model.fields,field_description:base.field_res_partner__street2
 #: model:ir.model.fields,field_description:base.field_res_users__street2
 msgid "Street2"
-msgstr "Strada/Via2"
+msgstr "Indirizzo2"
 
 #. module: base
 #: model:ir.module.module,description:base.module_payment_stripe
 #: model:ir.module.module,shortdesc:base.module_payment_stripe
 msgid "Stripe Payment Acquirer"
-msgstr "Servizio di pagamento Stripe"
+msgstr "Sistema di pagamento Stripe"
 
 #. module: base
 #: model:ir.module.module,description:base.module_payment_stripe_sca
@@ -24042,7 +24042,7 @@ msgstr ""
 #. module: base
 #: model_terms:ir.ui.view,arch_db:base.edit_menu_access
 msgid "Submenus"
-msgstr "Sottomenu"
+msgstr "Sottomenù"
 
 #. module: base
 #: model:ir.module.module,summary:base.module_hr_expense
@@ -24088,7 +24088,7 @@ msgstr "Domenica"
 #. module: base
 #: model:ir.model.fields,field_description:base.field_ir_actions_client__params
 msgid "Supplementary arguments"
-msgstr "Argomenti supplementari"
+msgstr "Argomenti aggiuntivi"
 
 #. module: base
 #: model:res.country,name:base.sr
@@ -24177,7 +24177,7 @@ msgstr "Parametri di sistema"
 #. module: base
 #: model_terms:ir.ui.view,arch_db:base.view_ir_config_search
 msgid "System Properties"
-msgstr "Proprietà di Sistema"
+msgstr "Proprietà di sistema"
 
 #. module: base
 #: model_terms:ir.ui.view,arch_db:base.view_base_module_upgrade
@@ -24206,7 +24206,7 @@ msgstr "Archivio TGZ"
 #. module: base
 #: model_terms:ir.ui.view,arch_db:base.wizard_lang_export
 msgid "TGZ format: bundles multiple PO(T) files as a single archive"
-msgstr "Formato TGZ: racchiude molti file PO(T) in un singolo archivio"
+msgstr "Formato TGZ: raggruppa in un singolo archivio file PO(T) multipli"
 
 #. module: base
 #: selection:ir.mail_server,smtp_encryption:0
@@ -25086,7 +25086,7 @@ msgstr "Il codice della nazione deve essere univoco."
 #. module: base
 #: sql_constraint:res.lang:0
 msgid "The code of the language must be unique !"
-msgstr "Il codice della lingua deve essere unico !"
+msgstr "Il codice della lingua deve essere univoco."
 
 #. module: base
 #: sql_constraint:res.country.state:0
@@ -25096,7 +25096,7 @@ msgstr "Il codice della provincia deve essere univoco per nazione."
 #. module: base
 #: sql_constraint:res.company:0
 msgid "The company name must be unique !"
-msgstr "Il nome dell'azienda deve essere univoco !"
+msgstr "Il nome dell'azienda deve essere univoco."
 
 #. module: base
 #: model:ir.model.fields,help:base.field_res_users__company_id
@@ -25126,7 +25126,7 @@ msgstr ""
 #. module: base
 #: sql_constraint:res.currency:0
 msgid "The currency code must be unique!"
-msgstr "Il codice della valuta deve essere unico !"
+msgstr "Il codice della valuta deve essere univoco."
 
 #. module: base
 #: sql_constraint:res.currency.rate:0
@@ -25240,6 +25240,14 @@ msgid "The list of models that extends the current model."
 msgstr "L'elenco dei modelli che estende il modello attuale."
 
 #. module: base
+#: code:addons/base/models/ir_model.py:522
+#, python-format
+msgid ""
+"The m2o field %s is required but declares its ondelete policy as being 'set "
+"null'. Only 'restrict' and 'cascade' make sense."
+msgstr ""
+
+#. module: base
 #: model:ir.model.fields,help:base.field_ir_filters__action_id
 msgid ""
 "The menu action this filter applies to. When left empty the filter applies "
@@ -25317,7 +25325,7 @@ msgstr "Le sole variabili predefinite sono"
 #: code:addons/model.py:121
 #, python-format
 msgid "The operation cannot be completed:"
-msgstr "L'operazione non può essere completata:"
+msgstr "Impossibile completare l'operazione:"
 
 #. module: base
 #: model:ir.model.fields,help:base.field_ir_model_fields__domain
@@ -26181,7 +26189,7 @@ msgstr "Regno Unito - Contabilità"
 #. module: base
 #: model:ir.module.module,shortdesc:base.module_l10n_uk_reports
 msgid "UK - Accounting Reports"
-msgstr "Regno unito - Rendiconti contabili"
+msgstr "Regno Unito - Rendiconti contabili"
 
 #. module: base
 #: model:ir.module.module,shortdesc:base.module_l10n_uk_reports_hmrc
@@ -26229,7 +26237,7 @@ msgstr "Isole Minori Esterne degli Stati Uniti"
 #. module: base
 #: model:ir.module.module,shortdesc:base.module_utm
 msgid "UTM Trackers"
-msgstr "Sistema di tracciamento UTM"
+msgstr "Monitoraggio UTM"
 
 #. module: base
 #: model:ir.module.module,description:base.module_mass_mailing_crm
@@ -26521,7 +26529,7 @@ msgstr "Uruguay"
 #. module: base
 #: model:ir.module.module,shortdesc:base.module_l10n_uy_reports
 msgid "Uruguay - Accounts Reports"
-msgstr "Uruguay - Report di Contabilità"
+msgstr "Uruguay - Rendiconti contabili"
 
 #. module: base
 #: model:ir.module.module,shortdesc:base.module_l10n_uy
@@ -26843,12 +26851,12 @@ msgstr "Valore binario"
 #. module: base
 #: model:ir.model.fields,field_description:base.field_ir_property__value_datetime
 msgid "Value Datetime"
-msgstr "Valore Data e Ora"
+msgstr "Valore data e ora"
 
 #. module: base
 #: model:ir.model.fields,field_description:base.field_ir_property__value_float
 msgid "Value Float"
-msgstr "Valore Decimale"
+msgstr "Valore virgola mobile"
 
 #. module: base
 #: model:ir.model.fields,field_description:base.field_ir_property__value_integer
@@ -26869,7 +26877,7 @@ msgstr "Valore di Riferimento"
 #. module: base
 #: model:ir.model.fields,field_description:base.field_ir_property__value_text
 msgid "Value Text"
-msgstr "Valore di Testo"
+msgstr "Valore testo"
 
 #. module: base
 #: model:res.country,name:base.vu
@@ -27480,13 +27488,13 @@ msgstr "Impossibile attivare il superutente."
 #: code:addons/base/models/res_partner.py:509
 #, python-format
 msgid "You cannot archive a contact linked to an internal user."
-msgstr "Impossibile archiviare un contatto collegato ad un utente interno."
+msgstr "Impossibile archiviare un contatto collegato a un utente interno."
 
 #. module: base
 #: code:addons/base/models/res_partner.py:330
 #, python-format
 msgid "You cannot create recursive Partner hierarchies."
-msgstr "Non puoi creare gerarchie ricorsive per i Partner"
+msgstr "Impossibile creare gerarchie ricorsive per il partner."
 
 #. module: base
 #: code:addons/base/models/res_company.py:243
@@ -27504,7 +27512,7 @@ msgstr "Impossibile creare viste ereditate ricorsive."
 #: code:addons/base/models/res_users.py:437
 #, python-format
 msgid "You cannot deactivate the user you're currently logged in as."
-msgstr "Non puoi disattivare l'utente con cui ti sei registrato."
+msgstr "Impossibile disattivare l'utente usato per effettuare l'accesso."
 
 #. module: base
 #: code:addons/base/models/res_lang.py:245
@@ -27513,8 +27521,8 @@ msgid ""
 "You cannot delete the language which is Active!\n"
 "Please de-activate the language first."
 msgstr ""
-"Non puoi eliminare una lingua che è ancora Attiva!\n"
-"Prima disabilitala."
+"Impossibile eliminare la lingua attiva.\n"
+"Procedere prima alla disattivazione."
 
 #. module: base
 #: code:addons/base/models/res_lang.py:243

--- a/odoo/addons/base/i18n/ja.po
+++ b/odoo/addons/base/i18n/ja.po
@@ -12,8 +12,8 @@
 # Norimichi Sugimoto <norimichi.sugimoto@tls-ltd.co.jp>, 2019
 # Martin Trigaux, 2019
 # Tim Siu Lai <tl@roomsfor.hk>, 2019
-# Yoshi Tashiro <tashiro@roomsfor.hk>, 2020
 # Hau Dao <hau@quartile.co>, 2020
+# Yoshi Tashiro <tashiro@roomsfor.hk>, 2020
 # 
 msgid ""
 msgstr ""
@@ -21,7 +21,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-12-10 14:44+0000\n"
 "PO-Revision-Date: 2018-08-24 09:14+0000\n"
-"Last-Translator: Hau Dao <hau@quartile.co>, 2020\n"
+"Last-Translator: Yoshi Tashiro <tashiro@roomsfor.hk>, 2020\n"
 "Language-Team: Japanese (https://www.transifex.com/odoo/teams/41243/ja/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -15597,7 +15597,7 @@ msgstr "翻訳読込"
 #. module: base
 #: model:ir.actions.act_window,name:base.demo_force_install_action
 msgid "Load demo data"
-msgstr ""
+msgstr "デモデータをロード"
 
 #. module: base
 #: model:ir.model.fields,field_description:base.field_res_lang__code

--- a/odoo/addons/base/i18n/ja.po
+++ b/odoo/addons/base/i18n/ja.po
@@ -22612,6 +22612,14 @@ msgid "The list of models that extends the current model."
 msgstr "現在のモデルを拡張したモデルのリスト。"
 
 #. module: base
+#: code:addons/base/models/ir_model.py:522
+#, python-format
+msgid ""
+"The m2o field %s is required but declares its ondelete policy as being 'set "
+"null'. Only 'restrict' and 'cascade' make sense."
+msgstr ""
+
+#. module: base
 #: model:ir.model.fields,help:base.field_ir_filters__action_id
 msgid ""
 "The menu action this filter applies to. When left empty the filter applies "

--- a/odoo/addons/base/i18n/ka.po
+++ b/odoo/addons/base/i18n/ka.po
@@ -21302,6 +21302,14 @@ msgid "The list of models that extends the current model."
 msgstr ""
 
 #. module: base
+#: code:addons/base/models/ir_model.py:522
+#, python-format
+msgid ""
+"The m2o field %s is required but declares its ondelete policy as being 'set "
+"null'. Only 'restrict' and 'cascade' make sense."
+msgstr ""
+
+#. module: base
 #: model:ir.model.fields,help:base.field_ir_filters__action_id
 msgid ""
 "The menu action this filter applies to. When left empty the filter applies "

--- a/odoo/addons/base/i18n/kab.po
+++ b/odoo/addons/base/i18n/kab.po
@@ -3,7 +3,7 @@
 # * base
 # 
 # Translators:
-# Muḥend Belqasem <belkacem77@gmail.com>, 2019
+# MozillaKab <belkacem77@gmail.com>, 2019
 # Martin Trigaux, 2019
 # 
 msgid ""
@@ -21344,6 +21344,14 @@ msgstr ""
 #. module: base
 #: model:ir.model.fields,help:base.field_ir_model__inherited_model_ids
 msgid "The list of models that extends the current model."
+msgstr ""
+
+#. module: base
+#: code:addons/base/models/ir_model.py:522
+#, python-format
+msgid ""
+"The m2o field %s is required but declares its ondelete policy as being 'set "
+"null'. Only 'restrict' and 'cascade' make sense."
 msgstr ""
 
 #. module: base

--- a/odoo/addons/base/i18n/km.po
+++ b/odoo/addons/base/i18n/km.po
@@ -22009,6 +22009,14 @@ msgid "The list of models that extends the current model."
 msgstr ""
 
 #. module: base
+#: code:addons/base/models/ir_model.py:522
+#, python-format
+msgid ""
+"The m2o field %s is required but declares its ondelete policy as being 'set "
+"null'. Only 'restrict' and 'cascade' make sense."
+msgstr ""
+
+#. module: base
 #: model:ir.model.fields,help:base.field_ir_filters__action_id
 msgid ""
 "The menu action this filter applies to. When left empty the filter applies "

--- a/odoo/addons/base/i18n/ko.po
+++ b/odoo/addons/base/i18n/ko.po
@@ -26778,6 +26778,14 @@ msgid "The list of models that extends the current model."
 msgstr "현재 모델 목록을 확장하십시오."
 
 #. module: base
+#: code:addons/base/models/ir_model.py:522
+#, python-format
+msgid ""
+"The m2o field %s is required but declares its ondelete policy as being 'set "
+"null'. Only 'restrict' and 'cascade' make sense."
+msgstr ""
+
+#. module: base
 #: model:ir.model.fields,help:base.field_ir_filters__action_id
 msgid ""
 "The menu action this filter applies to. When left empty the filter applies "

--- a/odoo/addons/base/i18n/lt.po
+++ b/odoo/addons/base/i18n/lt.po
@@ -21923,6 +21923,14 @@ msgid "The list of models that extends the current model."
 msgstr "Sąrašas modulių, praplėčiančių dabartinį modulį."
 
 #. module: base
+#: code:addons/base/models/ir_model.py:522
+#, python-format
+msgid ""
+"The m2o field %s is required but declares its ondelete policy as being 'set "
+"null'. Only 'restrict' and 'cascade' make sense."
+msgstr ""
+
+#. module: base
 #: model:ir.model.fields,help:base.field_ir_filters__action_id
 msgid ""
 "The menu action this filter applies to. When left empty the filter applies "

--- a/odoo/addons/base/i18n/lv.po
+++ b/odoo/addons/base/i18n/lv.po
@@ -24249,6 +24249,14 @@ msgid "The list of models that extends the current model."
 msgstr "The list of models that extends the current model."
 
 #. module: base
+#: code:addons/base/models/ir_model.py:522
+#, python-format
+msgid ""
+"The m2o field %s is required but declares its ondelete policy as being 'set "
+"null'. Only 'restrict' and 'cascade' make sense."
+msgstr ""
+
+#. module: base
 #: model:ir.model.fields,help:base.field_ir_filters__action_id
 msgid ""
 "The menu action this filter applies to. When left empty the filter applies "

--- a/odoo/addons/base/i18n/mn.po
+++ b/odoo/addons/base/i18n/mn.po
@@ -23129,6 +23129,14 @@ msgid "The list of models that extends the current model."
 msgstr "Тухайн моделийг өргөтгөсөн моделийн жагсаалт."
 
 #. module: base
+#: code:addons/base/models/ir_model.py:522
+#, python-format
+msgid ""
+"The m2o field %s is required but declares its ondelete policy as being 'set "
+"null'. Only 'restrict' and 'cascade' make sense."
+msgstr ""
+
+#. module: base
 #: model:ir.model.fields,help:base.field_ir_filters__action_id
 msgid ""
 "The menu action this filter applies to. When left empty the filter applies "

--- a/odoo/addons/base/i18n/nb.po
+++ b/odoo/addons/base/i18n/nb.po
@@ -21613,6 +21613,14 @@ msgid "The list of models that extends the current model."
 msgstr "Listen over modeller som utvider gjeldende modell."
 
 #. module: base
+#: code:addons/base/models/ir_model.py:522
+#, python-format
+msgid ""
+"The m2o field %s is required but declares its ondelete policy as being 'set "
+"null'. Only 'restrict' and 'cascade' make sense."
+msgstr ""
+
+#. module: base
 #: model:ir.model.fields,help:base.field_ir_filters__action_id
 msgid ""
 "The menu action this filter applies to. When left empty the filter applies "

--- a/odoo/addons/base/i18n/nl.po
+++ b/odoo/addons/base/i18n/nl.po
@@ -27203,6 +27203,14 @@ msgid "The list of models that extends the current model."
 msgstr "De lijst met modellen welke het huidige module uitbreiden"
 
 #. module: base
+#: code:addons/base/models/ir_model.py:522
+#, python-format
+msgid ""
+"The m2o field %s is required but declares its ondelete policy as being 'set "
+"null'. Only 'restrict' and 'cascade' make sense."
+msgstr ""
+
+#. module: base
 #: model:ir.model.fields,help:base.field_ir_filters__action_id
 msgid ""
 "The menu action this filter applies to. When left empty the filter applies "

--- a/odoo/addons/base/i18n/pl.po
+++ b/odoo/addons/base/i18n/pl.po
@@ -24771,6 +24771,14 @@ msgid "The list of models that extends the current model."
 msgstr "Lista modeli które rozszerzają używany model."
 
 #. module: base
+#: code:addons/base/models/ir_model.py:522
+#, python-format
+msgid ""
+"The m2o field %s is required but declares its ondelete policy as being 'set "
+"null'. Only 'restrict' and 'cascade' make sense."
+msgstr ""
+
+#. module: base
 #: model:ir.model.fields,help:base.field_ir_filters__action_id
 msgid ""
 "The menu action this filter applies to. When left empty the filter applies "

--- a/odoo/addons/base/i18n/pt.po
+++ b/odoo/addons/base/i18n/pt.po
@@ -22083,6 +22083,14 @@ msgid "The list of models that extends the current model."
 msgstr "A lista de modelos que extendem o modelo corrente."
 
 #. module: base
+#: code:addons/base/models/ir_model.py:522
+#, python-format
+msgid ""
+"The m2o field %s is required but declares its ondelete policy as being 'set "
+"null'. Only 'restrict' and 'cascade' make sense."
+msgstr ""
+
+#. module: base
 #: model:ir.model.fields,help:base.field_ir_filters__action_id
 msgid ""
 "The menu action this filter applies to. When left empty the filter applies "

--- a/odoo/addons/base/i18n/pt_BR.po
+++ b/odoo/addons/base/i18n/pt_BR.po
@@ -35,7 +35,8 @@
 # Fernanda Marques <fem@odoo.com>, 2020
 # Marcel Savegnago <marcel.savegnago@gmail.com>, 2020
 # Kevin Harrings <kha@odoo.com>, 2020
-# Luiz Fernando Gondin <lfpsgs@outlook.com>, 2020
+# Luiz Fernando <lfpsgs@outlook.com>, 2020
+# Guilherme Libardi <guilherme.libardig@gmail.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -43,7 +44,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-12-10 14:44+0000\n"
 "PO-Revision-Date: 2018-08-24 09:14+0000\n"
-"Last-Translator: Luiz Fernando Gondin <lfpsgs@outlook.com>, 2020\n"
+"Last-Translator: Guilherme Libardi <guilherme.libardig@gmail.com>, 2020\n"
 "Language-Team: Portuguese (Brazil) (https://www.transifex.com/odoo/teams/41243/pt_BR/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -13690,7 +13691,7 @@ msgstr "Hardware Proxy"
 #. module: base
 #: model:ir.model.fields,field_description:base.field_res_partner_bank__qr_code_valid
 msgid "Has all required arguments"
-msgstr ""
+msgstr "Possui todos os argumentos necessários"
 
 #. module: base
 #: model:ir.model.fields,field_description:base.field_report_paperformat__header_spacing
@@ -22816,6 +22817,14 @@ msgstr ""
 #: model:ir.model.fields,help:base.field_ir_model__inherited_model_ids
 msgid "The list of models that extends the current model."
 msgstr "A lista de modelos que estende o modelo atual."
+
+#. module: base
+#: code:addons/base/models/ir_model.py:522
+#, python-format
+msgid ""
+"The m2o field %s is required but declares its ondelete policy as being 'set "
+"null'. Only 'restrict' and 'cascade' make sense."
+msgstr ""
 
 #. module: base
 #: model:ir.model.fields,help:base.field_ir_filters__action_id

--- a/odoo/addons/base/i18n/ro.po
+++ b/odoo/addons/base/i18n/ro.po
@@ -20286,7 +20286,7 @@ msgstr "Adresă de livrare"
 #. module: base
 #: model:ir.module.module,shortdesc:base.module_website_sale_wishlist
 msgid "Shopper's Wishlist"
-msgstr ""
+msgstr "Lista de favorite a cumpărătorului"
 
 #. module: base
 #: model:ir.model.fields,field_description:base.field_base_module_uninstall__show_all
@@ -21953,6 +21953,14 @@ msgstr ""
 #. module: base
 #: model:ir.model.fields,help:base.field_ir_model__inherited_model_ids
 msgid "The list of models that extends the current model."
+msgstr ""
+
+#. module: base
+#: code:addons/base/models/ir_model.py:522
+#, python-format
+msgid ""
+"The m2o field %s is required but declares its ondelete policy as being 'set "
+"null'. Only 'restrict' and 'cascade' make sense."
 msgstr ""
 
 #. module: base

--- a/odoo/addons/base/i18n/ru.po
+++ b/odoo/addons/base/i18n/ru.po
@@ -8,7 +8,7 @@
 # Evgeny Kemerov <sintezz777@gmail.com>, 2018
 # Gennady Marchenko <gennadym@gmail.com>, 2018
 # Max Belyanin <maxbelyanin@gmail.com>, 2018
-# Владимир Куряев <istercul@gmail.com>, 2018
+# 6da4f49c4b78e697e34b24b2a66289f5, 2018
 # Evgeny <transingularity@gmail.com>, 2018
 # Андрей Гусев <gaussgss@gmail.com>, 2018
 # Amaro Vita <vita.amaro@gmail.com>, 2018
@@ -25514,6 +25514,14 @@ msgstr "Внутренний пользователь, который отвеч
 #: model:ir.model.fields,help:base.field_ir_model__inherited_model_ids
 msgid "The list of models that extends the current model."
 msgstr "Список моделей, расширяющих текущую модель."
+
+#. module: base
+#: code:addons/base/models/ir_model.py:522
+#, python-format
+msgid ""
+"The m2o field %s is required but declares its ondelete policy as being 'set "
+"null'. Only 'restrict' and 'cascade' make sense."
+msgstr ""
 
 #. module: base
 #: model:ir.model.fields,help:base.field_ir_filters__action_id

--- a/odoo/addons/base/i18n/sk.po
+++ b/odoo/addons/base/i18n/sk.po
@@ -22537,6 +22537,14 @@ msgid "The list of models that extends the current model."
 msgstr "Zoznam modelov ktoré rozširujú súčasný model."
 
 #. module: base
+#: code:addons/base/models/ir_model.py:522
+#, python-format
+msgid ""
+"The m2o field %s is required but declares its ondelete policy as being 'set "
+"null'. Only 'restrict' and 'cascade' make sense."
+msgstr ""
+
+#. module: base
 #: model:ir.model.fields,help:base.field_ir_filters__action_id
 msgid ""
 "The menu action this filter applies to. When left empty the filter applies "

--- a/odoo/addons/base/i18n/sl.po
+++ b/odoo/addons/base/i18n/sl.po
@@ -21949,6 +21949,14 @@ msgid "The list of models that extends the current model."
 msgstr "Seznam modelov, ki razširjajo trenutni model."
 
 #. module: base
+#: code:addons/base/models/ir_model.py:522
+#, python-format
+msgid ""
+"The m2o field %s is required but declares its ondelete policy as being 'set "
+"null'. Only 'restrict' and 'cascade' make sense."
+msgstr ""
+
+#. module: base
 #: model:ir.model.fields,help:base.field_ir_filters__action_id
 msgid ""
 "The menu action this filter applies to. When left empty the filter applies "

--- a/odoo/addons/base/i18n/so.po
+++ b/odoo/addons/base/i18n/so.po
@@ -21257,6 +21257,14 @@ msgid "The list of models that extends the current model."
 msgstr ""
 
 #. module: base
+#: code:addons/base/models/ir_model.py:522
+#, python-format
+msgid ""
+"The m2o field %s is required but declares its ondelete policy as being 'set "
+"null'. Only 'restrict' and 'cascade' make sense."
+msgstr ""
+
+#. module: base
 #: model:ir.model.fields,help:base.field_ir_filters__action_id
 msgid ""
 "The menu action this filter applies to. When left empty the filter applies "

--- a/odoo/addons/base/i18n/sr.po
+++ b/odoo/addons/base/i18n/sr.po
@@ -21282,6 +21282,14 @@ msgid "The list of models that extends the current model."
 msgstr ""
 
 #. module: base
+#: code:addons/base/models/ir_model.py:522
+#, python-format
+msgid ""
+"The m2o field %s is required but declares its ondelete policy as being 'set "
+"null'. Only 'restrict' and 'cascade' make sense."
+msgstr ""
+
+#. module: base
 #: model:ir.model.fields,help:base.field_ir_filters__action_id
 msgid ""
 "The menu action this filter applies to. When left empty the filter applies "

--- a/odoo/addons/base/i18n/sv.po
+++ b/odoo/addons/base/i18n/sv.po
@@ -14,7 +14,7 @@
 # Christelle Wehbe <libanon_cristelle@hotmail.com>, 2019
 # lasch a <bmail440@gmail.com>, 2019
 # Martin Wilderoth <martin.wilderoth@linserv.se>, 2019
-# Kristoffer Grundström <hamnisdude@gmail.com>, 2019
+# Kristoffer Grundström <lovaren@gmail.com>, 2019
 # Robert Frykelius <robert.frykelius@linserv.se>, 2019
 # Daniel Osser <danielosser@gmail.com>, 2019
 # Jakob Krabbe <jakob.krabbe@vertel.se>, 2019
@@ -21425,6 +21425,14 @@ msgstr ""
 #. module: base
 #: model:ir.model.fields,help:base.field_ir_model__inherited_model_ids
 msgid "The list of models that extends the current model."
+msgstr ""
+
+#. module: base
+#: code:addons/base/models/ir_model.py:522
+#, python-format
+msgid ""
+"The m2o field %s is required but declares its ondelete policy as being 'set "
+"null'. Only 'restrict' and 'cascade' make sense."
 msgstr ""
 
 #. module: base

--- a/odoo/addons/base/i18n/ta.po
+++ b/odoo/addons/base/i18n/ta.po
@@ -21289,6 +21289,14 @@ msgid "The list of models that extends the current model."
 msgstr ""
 
 #. module: base
+#: code:addons/base/models/ir_model.py:522
+#, python-format
+msgid ""
+"The m2o field %s is required but declares its ondelete policy as being 'set "
+"null'. Only 'restrict' and 'cascade' make sense."
+msgstr ""
+
+#. module: base
 #: model:ir.model.fields,help:base.field_ir_filters__action_id
 msgid ""
 "The menu action this filter applies to. When left empty the filter applies "

--- a/odoo/addons/base/i18n/th.po
+++ b/odoo/addons/base/i18n/th.po
@@ -21957,6 +21957,14 @@ msgid "The list of models that extends the current model."
 msgstr "The list of models that extends the current model."
 
 #. module: base
+#: code:addons/base/models/ir_model.py:522
+#, python-format
+msgid ""
+"The m2o field %s is required but declares its ondelete policy as being 'set "
+"null'. Only 'restrict' and 'cascade' make sense."
+msgstr ""
+
+#. module: base
 #: model:ir.model.fields,help:base.field_ir_filters__action_id
 msgid ""
 "The menu action this filter applies to. When left empty the filter applies "

--- a/odoo/addons/base/i18n/tr.po
+++ b/odoo/addons/base/i18n/tr.po
@@ -23663,6 +23663,14 @@ msgid "The list of models that extends the current model."
 msgstr "Mevcut modeli genişleten modellerin listesi."
 
 #. module: base
+#: code:addons/base/models/ir_model.py:522
+#, python-format
+msgid ""
+"The m2o field %s is required but declares its ondelete policy as being 'set "
+"null'. Only 'restrict' and 'cascade' make sense."
+msgstr ""
+
+#. module: base
 #: model:ir.model.fields,help:base.field_ir_filters__action_id
 msgid ""
 "The menu action this filter applies to. When left empty the filter applies "

--- a/odoo/addons/base/i18n/tr.po
+++ b/odoo/addons/base/i18n/tr.po
@@ -625,6 +625,8 @@ msgid ""
 "        App to upload and manage your documents.\n"
 "    "
 msgstr ""
+"\n"
+"Belgelerinizi yüklemek ve yönetmek için uygulama."
 
 #. module: base
 #: model:ir.module.module,summary:base.module_partner_autocomplete
@@ -659,6 +661,8 @@ msgid ""
 "        Bridge module between sale and intrastat.\n"
 "    "
 msgstr ""
+"\n"
+"Satış ve intrastat arasında köprü modülü."
 
 #. module: base
 #: model:ir.module.module,description:base.module_l10n_lt
@@ -767,6 +771,8 @@ msgid ""
 "\n"
 "        Make calls using a VOIP system"
 msgstr ""
+"\n"
+"VOIP sistemi kullanarak arama yapma"
 
 #. module: base
 #: model:ir.module.module,description:base.module_hr_expense_check
@@ -817,6 +823,8 @@ msgid ""
 "        This bridge module is auto-installed when the modules stock_barcode and quality_control are installed.\n"
 "    "
 msgstr ""
+"\n"
+"Bu köprü modülü, stock_barcode ve quality_control modülleri kurulduğunda otomatik olarak kurulur."
 
 #. module: base
 #: model:ir.module.module,description:base.module_delivery_barcode
@@ -855,6 +863,9 @@ msgid ""
 "        of another database on which a counterpart addon is installed.\n"
 "    "
 msgstr ""
+"\n"
+"Bu modül, çalışan kullanıcıların, karşı taraf eklentisinin yüklü olduğu \n"
+"başka bir veritabanının canlı operatörleriyle iletişim kurmasını sağlar."
 
 #. module: base
 #: model:ir.module.module,description:base.module_stock_zebra
@@ -874,6 +885,12 @@ msgid ""
 "        but aims to connect with all European banks later on\n"
 "    "
 msgstr ""
+"\n"
+"Bu modül banka ekstrelerini almak için myponto.com adresine bağlanır.\n"
+"\n"
+"         Şu anda, bu hizmet yalnızca Belçika bankalarına \n"
+"(BNP Paribas Fortis, KBC, CBC, KBC Brussels, Fintro, Hello Bank, ING Belgium, AXA Belgium) \n"
+"bağlanmaya izin veriyor, ancak daha sonra tüm Avrupa bankalarıyla bağlantı kurmayı hedefliyor."
 
 #. module: base
 #: model:ir.module.module,description:base.module_account_sepa_direct_debit
@@ -962,6 +979,8 @@ msgid ""
 "\n"
 "        Track equipments and maintenance requests"
 msgstr ""
+"\n"
+"Ekipmanları ve bakım taleplerini izleyin"
 
 #. module: base
 #: model:ir.module.module,summary:base.module_account_plaid
@@ -1002,6 +1021,8 @@ msgid ""
 "\n"
 "        Use myponto.com to retrieve bank statements"
 msgstr ""
+"\n"
+"Banka ekstrelerini almak için myponto.com adresini kullanın"
 
 #. module: base
 #: model:ir.module.module,description:base.module_timesheet_grid_sale
@@ -1035,6 +1056,9 @@ msgid ""
 "       Auto-complete partner companies' data\n"
 "    "
 msgstr ""
+"\n"
+"Ortak şirketlerin verilerini otomatik tamamlama\n"
+" "
 
 #. module: base
 #: model:ir.module.module,description:base.module_l10n_multilang
@@ -1058,6 +1082,8 @@ msgid ""
 "\n"
 "    Adds Quality Control to workorders.\n"
 msgstr ""
+"\n"
+"Çalışma alanlarına Kalite Kontrol ekler.\n"
 
 #. module: base
 #: model:ir.module.module,description:base.module_quality_mrp
@@ -1158,6 +1184,8 @@ msgid ""
 "    Schedule your teams across projects and estimate deadlines more accurately.\n"
 "    "
 msgstr ""
+"\n"
+"Ekiplerinizi projeler arasında planlayın ve teslim tarihlerini daha doğru bir şekilde tahmin edin."
 
 #. module: base
 #: model:ir.module.module,summary:base.module_sale_ebay
@@ -1190,6 +1218,11 @@ msgid ""
 "This module gives the details of the goods traded between the countries of\n"
 "European Union."
 msgstr ""
+"\n"
+"İntrastat raporlarına stok yönetimini ekleyen bir modül.\n"
+"============================================================\n"
+"\n"
+"Bu modül, Avrupa Birliği ülkeleri arasında ticareti yapılan malların detaylarını verir."
 
 #. module: base
 #: model:ir.module.module,description:base.module_l10n_au_aba
@@ -1503,6 +1536,12 @@ msgid ""
 " - To generate the IRAS Audit File, go to Accounting -> Reporting -> IRAS Audit File\n"
 "    "
 msgstr ""
+"\n"
+"Singapur için muhasebe raporları\n"
+"================================\n"
+"Bu modül GST İade (F5) ve IRAS Denetim Dosyasının oluşturulmasına izin verir.\n"
+"  - GST İadesini oluşturmak için Muhasebe -> Raporlama -> GST İadesi'ne gidin\n"
+"  - IRAS Denetim Dosyasını oluşturmak için Muhasebe -> Raporlama -> IRAS Denetim Dosyasına gidin"
 
 #. module: base
 #: model:ir.module.module,description:base.module_l10n_th_reports
@@ -2097,6 +2136,14 @@ msgid ""
 "When you proceed with the reconciliation, simply select the corresponding batch payment to reconcile all the payments within.\n"
 "    "
 msgstr ""
+"\n"
+"Toplu Ödemeler\n"
+"=======================================\n"
+"Toplu ödemeler gruplama ödemelerine izin verir.\n"
+"\n"
+"Bunlar, mesela alınan çeklerini bankaya tek bir toplu çek olarak yatırmadan önce yeniden gruplandırmak için kullanılır. \n"
+"Yatırılan toplam tutar banka ekstrenizde tek bir işlem olarak görünür. \n"
+"Mutabakata devam ettiğinizde, içindeki tüm ödemeleri mutabık kılmak için ilgili toplu ödemeyi seçmeniz yeterlidir."
 
 #. module: base
 #: model:ir.module.module,description:base.module_l10n_be_hr_payroll
@@ -2153,6 +2200,23 @@ msgid ""
 "No modified version is certified and supported by Odoo SA.\n"
 "    "
 msgstr ""
+"\n"
+"Belçika Kayıtlı Yazar Kasa\n"
+"================================\n"
+"\n"
+"Bu modül Satış Noktası modülünü sertifikalı bir Belçikalı kasaya dönüştürür.\n"
+"\n"
+"Daha fazla bilgi:\n"
+"   * http://www.systemedecaisseenregistreuse.be/\n"
+"   * http://www.geregistreerdkassasysteem.be/\n"
+"\n"
+"Yasal\n"
+"-----\n"
+"** pos_blackbox_be kaynaklarının kullanımı sadece odoo.com SaaS platformunda onaylanmıştır\n"
+"sürüm 11.0 için. ** pos_blackbox_be modülünü kurmadan önce Odoo SA ile irtibata geçin.\n"
+"\n"
+"Şirket içi kurulum istekleri için pos_blackbox_be'nin gizlenmiş ve onaylı bir sürümü sağlanabilir.\n"
+"Değiştirilmiş hiçbir sürüm Odoo SA tarafından onaylanmamış ve desteklenmemiştir."
 
 #. module: base
 #: model:ir.module.module,description:base.module_l10n_bo
@@ -2181,6 +2245,11 @@ msgid ""
 "Display a preview of the last chatter attachment in the form view for large\n"
 "screen devices.\n"
 msgstr ""
+"\n"
+"Posta ve işletme için köprü modülü\n"
+"=====================================\n"
+"\n"
+"Büyük ekranlı cihazlar için form görünümünde son sohbet ekinin önizlemesini görüntüleyin.\n"
 
 #. module: base
 #: model:ir.module.module,description:base.module_project_enterprise
@@ -2189,6 +2258,8 @@ msgid ""
 "Bridge module for project and enterprise\n"
 "    "
 msgstr ""
+"\n"
+"Proje ve işletme için köprü modülü"
 
 #. module: base
 #: model:ir.module.module,description:base.module_website_rating
@@ -2476,6 +2547,15 @@ msgid ""
 "sent mails with personal token for the invitation of the survey.\n"
 "    "
 msgstr ""
+"\n"
+"Harika anketler oluşturun ve cevapları görselleştirin\n"
+"==============================================\n"
+"\n"
+"Farklı kullanıcıların bazı sorularının cevaplarına veya incelemelerine bağlıdır. \n"
+"Bir anketin birden fazla sayfası olabilir. \n"
+"Her sayfada birden fazla soru olabilir ve her sorunun birden fazla yanıtı olabilir. \n"
+"Farklı kullanıcılar farklı soru cevapları verebilir ve bu ankete göre yapılır. \n"
+"Ortaklara ayrıca anketin davet edilmesi için kişisel tokenlı postalar gönderilir."
 
 #. module: base
 #: model:ir.module.module,description:base.module_website_sale_coupon
@@ -2486,6 +2566,10 @@ msgid ""
 "Coupon & promotion programs can be edited in the Catalog menu of the Website app.\n"
 "    "
 msgstr ""
+"\n"
+"Satışlarınızı artırmak için kupon ve promosyon kodları oluşturun (ücretsiz ürünler, indirimler vb.). Müşteriler bunları e-Ticaret kasasında kullanabilir.\n"
+"\n"
+"Kupon ve promosyon programları, Web Sitesi uygulamasının Katalog menüsünde düzenlenebilir."
 
 #. module: base
 #: model:ir.module.module,description:base.module_link_tracker
@@ -2791,6 +2875,8 @@ msgid ""
 "Extension to send follow-up documents by post\n"
 "    "
 msgstr ""
+"\n"
+"Takip belgelerini posta yoluyla gönderme uzantısı"
 
 #. module: base
 #: model:ir.module.module,description:base.module_hw_blackbox_be
@@ -2854,6 +2940,9 @@ msgid ""
 "Full Traceability Report Demo Data\n"
 "==================================\n"
 msgstr ""
+"\n"
+"Tam İzlenebilirlik Raporu Demo Verileri\n"
+"==================================\n"
 
 #. module: base
 #: model:ir.module.module,description:base.module_gamification
@@ -2908,6 +2997,9 @@ msgid ""
 "Those trackers can be used in Google Analytics to track clicks and visitors, or in Odoo reports to analyze the efficiency of those campaigns in terms of lead generation, related revenues (sales orders), recruitment, etc.\n"
 "    "
 msgstr ""
+"\n"
+"Sayfalarınızı pazarlama kampanyaları aracılığıyla paylaşmak için analitik izleyicileri (UTM) ile kısa bağlantılar oluşturun. \n"
+"Bu izleyiciler, tıklamaları ve ziyaretçileri izlemek için Google Analytics'te veya aday yaratmada, ilgili gelirler (satış siparişleri), işe alım vb. açısından bu kampanyaların etkinliğini analiz etmek için Odoo raporlarında kullanılabilir."
 
 #. module: base
 #: model:ir.module.module,description:base.module_website_form_project
@@ -2916,6 +3008,8 @@ msgid ""
 "Generate tasks in Project app from a form published on your website. This module requires the use of the *Form Builder* module (available in Odoo Enterprise) in order to build the form.\n"
 "    "
 msgstr ""
+"\n"
+"Web sitenizde yayınlanan bir formdan Proje uygulamasında görevler oluşturun. Bu modül, formu oluşturmak için * Form Builder * modülünün (Odoo Enterprise'da bulunur) kullanılmasını gerektirir."
 
 #. module: base
 #: model:ir.module.module,description:base.module_website_helpdesk_form
@@ -2924,6 +3018,8 @@ msgid ""
 "Generate tickets in Helpdesk app from a form published on your website. This form can be customized thanks to the *Form Builder* module (available in Odoo Enterprise).\n"
 "    "
 msgstr ""
+"\n"
+"Web sitenizde yayınlanan bir formdan Yardım Masası uygulamasında talep oluşturun. Bu form * Form Builder * modülü (Odoo Enterprise'da mevcuttur) sayesinde özelleştirilebilir."
 
 #. module: base
 #: model:ir.module.module,description:base.module_l10n_be_intrastat
@@ -2943,6 +3039,8 @@ msgid ""
 "Generates Netherlands Intrastat report for declaration based on invoices.\n"
 "    "
 msgstr ""
+"\n"
+"Faturalara dayalı beyan için Hollanda Intrastat raporu oluşturur."
 
 #. module: base
 #: model:ir.module.module,description:base.module_hr_payroll_account
@@ -3196,6 +3294,10 @@ msgid ""
 "==================\n"
 "    "
 msgstr ""
+"\n"
+"Intrastat Raporları\n"
+"==================\n"
+"    "
 
 #. module: base
 #: model:ir.module.module,description:base.module_account
@@ -3242,6 +3344,13 @@ msgid ""
 "and should not be installed on regular Odoo servers.\n"
 "\n"
 msgstr ""
+"\n"
+"IoTBox Yazılım Yükseltme\n"
+"========================\n"
+"\n"
+"Bu modül, IoTBox yazılımının uzaktan yeni bir sürüme yükseltilmesine izin verir. \n"
+"Bu modül IoTBox kurulumu ve ortamına özgüdür ve \n"
+"normal Odoo sunucularına kurulmamalıdır.\n"
 
 #. module: base
 #: model:ir.module.module,description:base.module_pos_iot
@@ -3256,6 +3365,8 @@ msgid ""
 "\n"
 "It links the module iot with the pos restaurant, so you don't have to call the  \n"
 msgstr ""
+"\n"
+"Modül iotunu pos restoranına bağlar, böylece aramaz zorunda kalmazsınız.\n"
 
 #. module: base
 #: model:ir.module.module,description:base.module_stock_landed_costs
@@ -3377,6 +3488,15 @@ msgid ""
 " * Customize your live view with help of various options.\n"
 " * Auto Storify view after event is over.\n"
 msgstr ""
+"\n"
+"Herkesi Etkinliğinizin Bir Parçası Yapın\n"
+"===================================\n"
+"\n"
+"Herkesin Twitter Duvarınıza göndermesine izin vererek etkinliğinizi etkileşimli bir deneyime dönüştürün. Kalabalığa bağlanın ve katılımcılarla kişisel bir ilişki kurun.\n"
+"  * Etkinlik için canlı Twitter duvarları oluşturun\n"
+"  * Karmaşık bir denetime gerek yoktur.\n"
+"  * Çeşitli seçenekler yardımıyla canlı görüntünüzü özelleştirin.\n"
+"  * Etkinlik bittikten sonra görünümü otomatik olarak durdur.\n"
 
 #. module: base
 #: model:ir.module.module,description:base.module_account_3way_match
@@ -3560,6 +3680,17 @@ msgid ""
 "* Incoterms: International Commercial terms\n"
 "\n"
 msgstr ""
+"\n"
+"Satış tekliflerini ve siparişleri yönetme\n"
+"==================================\n"
+"\n"
+"Bu modül, satış ve depo yönetimi uygulamaları arasında bağlantı kurar.\n"
+"\n"
+"Tercihler\n"
+"-----------\n"
+"* Nakliye: Bir kerede teslimat seçimi veya kısmi teslimat\n"
+"* Faturalandırma: Faturaların nasıl ödeneceğini seçin\n"
+"* Incoterms: Uluslararası Ticari Terimler\n"
 
 #. module: base
 #: model:ir.module.module,description:base.module_website_sale_stock
@@ -3571,6 +3702,11 @@ msgid ""
 "Then it can be made specific at the product level.\n"
 "    "
 msgstr ""
+"\n"
+"Ürünlerinizin envanterini yönetin ve e-ticaret mağazanızda kullanılabilirlik durumlarını görüntüleyin.\n"
+"Stokta kalma durumunda, başka satışları engellemeye veya satış yapmaya devam etmeye karar verebilirsiniz.\n"
+"Web sitesi ayarlarında varsayılan bir davranış seçilebilir.\n"
+"Daha sonra ürün düzeyinde spesifik hale getirilebilir."
 
 #. module: base
 #: model:ir.module.module,description:base.module_mass_mailing_event
@@ -3939,6 +4075,16 @@ msgid ""
 "\n"
 "Financial requirement contributor: Baskhuu Lodoikhuu. BumanIT LLC\n"
 msgstr ""
+"\n"
+"Moğol muhasebe raporları.\n"
+"====================================================\n"
+"-Kar ve zarar\n"
+"-Bilanço\n"
+"Nakit Akışı Tablosu\n"
+"-VAT Geri Ödeme Raporu\n"
+"-Kurumsal Gelir Vergisi Raporu\n"
+"\n"
+"Finansal gereklilik katkısı: Baskhuu Lodoikhuu. BumanIT LLC\n"
 
 #. module: base
 #: model:ir.module.module,description:base.module_l10n_nz
@@ -4024,6 +4170,11 @@ msgid ""
 "chatter messages and channel.\n"
 "    "
 msgstr ""
+"\n"
+"Odoo Bulut Bildirimleri (OCN)\n"
+"===============================\n"
+"\n"
+"Bu modül, doğrudan mesajlar, sohbet mesajları ve kanal için kayıtlı cihazlara bildirimler yapılmasını sağlar."
 
 #. module: base
 #: model:ir.module.module,description:base.module_web_dashboard
@@ -4036,6 +4187,11 @@ msgid ""
 "can embed graph and/or pivot views, and displays aggregate values.\n"
 "        "
 msgstr ""
+"\n"
+"Odoo Gösterge Tablosu Görünümü.\n"
+"========================\n"
+"\n"
+"Bu modül, yeni bir raporlama görünümü türü olan Yönetim Paneli görünümünü tanımlar. Bu görünüm, grafik ve / veya pivot görünümleri gömebilir ve toplam değerleri görüntüler."
 
 #. module: base
 #: model:ir.module.module,description:base.module_web_enterprise
@@ -4329,6 +4485,8 @@ msgid ""
 "Publish your customers as business references on your website to attract new potential prospects.\n"
 "    "
 msgstr ""
+"\n"
+"Yeni potansiyel potansiyel müşteriler çekmek için müşterilerinizi web sitenizde iş referansları olarak yayınlayın."
 
 #. module: base
 #: model:ir.module.module,description:base.module_website_hr
@@ -4345,6 +4503,8 @@ msgid ""
 "Publish your members/association directory publicly.\n"
 "    "
 msgstr ""
+"\n"
+"Üyelerinizi / ilişkilendirme dizininizi herkese açık olarak yayınlayın."
 
 #. module: base
 #: model:ir.module.module,description:base.module_sale_ebay
@@ -4387,6 +4547,13 @@ msgid ""
 "* Possibility to add a measure to the quality check with a min/max tolerance\n"
 "* Define your stages for the quality alerts\n"
 msgstr ""
+"\n"
+"Kalite Temeli\n"
+"===============\n"
+"* Üretim emirlerinde veya iş emirlerinde kalite kontrolleri oluşturacak kalite noktalarını tanımlayın (quality_mrp)\n"
+"* Kalite uyarıları bağımsız olarak veya kalite kontrolleriyle ilgili oluşturulabilir\n"
+"* Min / maks tolerans ile kalite kontrolüne ölçüm ekleme imkanı\n"
+"* Kalite uyarıları için aşamalarınızı tanımlayın\n"
 
 #. module: base
 #: model:ir.module.module,description:base.module_quality_control
@@ -4400,6 +4567,13 @@ msgid ""
 "* Possibility to add a measure to the quality check with a min/max tolerance\n"
 "* Define your stages for the quality alerts\n"
 msgstr ""
+"\n"
+"Kalite Temeli\n"
+"===============\n"
+"* Üretim emirlerinde veya iş emirlerinde kalite kontrolleri oluşturacak kalite noktalarını tanımlayın (quality_mrp)\n"
+"* Kalite uyarıları bağımsız olarak veya kalite kontrolleriyle ilgili oluşturulabilir\n"
+"* Min / maks tolerans ile kalite kontrolüne ölçüm ekleme imkanı\n"
+"* Kalite uyarıları için aşamalarınızı tanımlayın\n"
 
 #. module: base
 #: model:ir.module.module,description:base.module_sale_expense
@@ -4511,6 +4685,10 @@ msgid ""
 "Once the order is paid, the file is made available in the order confirmation page and in the customer portal.\n"
 "    "
 msgstr ""
+"\n"
+"E-Ticaret mağazanızda (ör. Web seminerleri, makaleler, e-kitaplar, video eğiticileri) satın.\n"
+"Bunu yapmak için ürünü oluşturun ve paylaşılacak dosyayı ürün formunun * Dosyalar * düğmesiyle ekleyin.\n"
+"Sipariş ödendikten sonra, dosya sipariş onay sayfasında ve müşteri portalında sunulur."
 
 #. module: base
 #: model:ir.module.module,description:base.module_website_event_sale
@@ -4519,6 +4697,8 @@ msgid ""
 "Sell event tickets through eCommerce app.\n"
 "    "
 msgstr ""
+"\n"
+"E-Ticaret uygulaması aracılığıyla etkinlik biletleri satın."
 
 #. module: base
 #: model:ir.module.module,description:base.module_digest
@@ -4527,6 +4707,9 @@ msgid ""
 "Send KPI Digests periodically\n"
 "=============================\n"
 msgstr ""
+"\n"
+"KPI Özetlerini periyodik olarak gönderme\n"
+"=============================\n"
 
 #. module: base
 #: model:ir.module.module,description:base.module_delivery_bpost
@@ -4616,6 +4799,8 @@ msgid ""
 "Show your company address/partner address on Google Maps. Configure an API key in the Website settings.\n"
 "    "
 msgstr ""
+"\n"
+"Google Haritalar'da şirket adresinizi / ortak adresinizi gösterin. Web Sitesi ayarlarında bir API anahtarı yapılandırın."
 
 #. module: base
 #: model:ir.module.module,description:base.module_sign
@@ -4645,6 +4830,14 @@ msgid ""
 "\n"
 "    "
 msgstr ""
+"\n"
+"Singapur muhasebe çizelgesi ve yerelleştirme.\n"
+"================================================== =====\n"
+"\n"
+"Bu modül, muhasebe için şunları ekler:\n"
+"  - Singapur Hesap Planı\n"
+"  - Şirket ve iş ortağı üzerindeki UEN (Benzersiz Varlık Numarası)\n"
+"  - Faturada Alan İzni Yok ve PermitNoDate"
 
 #. module: base
 #: model:ir.module.module,description:base.module_l10n_es
@@ -5012,6 +5205,8 @@ msgid ""
 "This is a base module. It holds website-related stuff for Contact model (res.partner).\n"
 "    "
 msgstr ""
+"\n"
+"Bu bir temel modüldür. Kontak modeli (res.partner) için web sitesi ile ilgili şeyler içerir."
 
 #. module: base
 #: model:ir.module.module,description:base.module_website_payment
@@ -5020,6 +5215,8 @@ msgid ""
 "This is a bridge module which integrates payment acquirers with Website app.\n"
 "    "
 msgstr ""
+"\n"
+"Bu ödeme aracı web sitesi uygulaması ile entegre bir köprü modülüdür."
 
 #. module: base
 #: model:ir.module.module,description:base.module_calendar
@@ -5056,6 +5253,10 @@ msgid ""
 "========================================================================\n"
 "    "
 msgstr ""
+"\n"
+"Bu ölçü birimlerini yönetmek için temel modüldür.\n"
+"========================================================================\n"
+"    "
 
 #. module: base
 #: model:ir.module.module,description:base.module_product
@@ -5335,6 +5536,11 @@ msgid ""
 "    - a generic chart of accounts\n"
 "    - SARS VAT Ready Structure"
 msgstr ""
+"\n"
+"Bu, ZA'da Odoo'yu çalıştırmak için gereken en son temel Güney Afrika yerelleştirmesi:\n"
+"================================================== ==============================\n"
+"     - Genel bir hesap planı\n"
+"     - SARS KDV yapısı"
 
 #. module: base
 #: model:ir.module.module,description:base.module_l10n_ro
@@ -5548,6 +5754,12 @@ msgid ""
 "Finally, the module comes with an option to display an attribute summary table in product web pages (available in Customize menu).\n"
 "    "
 msgstr ""
+"\n"
+"Bu modül, e-ticaret mağazanıza bir karşılaştırma aracı ekler, böylece alışveriş yapanlarınız ürünleri özelliklerine göre kolayca karşılaştırabilir. Satın alma kararlarını önemli ölçüde hızlandıracak.\n"
+"\n"
+"Ürün özelliklerini yapılandırmak için Web Sitesi ayarlarında * Özellikler ve Varyantlar * seçeneğini etkinleştirin. Bu, ürün formuna özel bir bölüm ekleyecektir. Yapılandırmada, bu modül, alışverişcinin karşılaştırma tablosunu yapılandırmak için ürün özelliklerine bir kategori alanı ekler.\n"
+"\n"
+"Son olarak, modül, ürün web sayfalarında bir özellik özeti tablosu görüntüleme seçeneğiyle birlikte gelir (Özelleştir menüsünde bulunur)."
 
 #. module: base
 #: model:ir.module.module,description:base.module_website_sale_dashboard
@@ -5558,6 +5770,10 @@ msgid ""
 "It also provides new tools to analyse your data.\n"
 "    "
 msgstr ""
+"\n"
+"Bu modül, Web Sitesi uygulamasına yeni bir pano görünümü ekler.\n"
+"Bu yeni görünüm türü, çevrimiçi satışlarınızla ilgili hızlı bir genel bakış elde etmenizi sağlayan bazı temel istatistikler, bir grafik ve bir pivot alt görünümü içerir.\n"
+"Ayrıca verilerinizi analiz etmek için yeni araçlar sağlar."
 
 #. module: base
 #: model:ir.module.module,description:base.module_sale_crm
@@ -5696,6 +5912,8 @@ msgid ""
 "This module allows ecommerce users to enter their UPS account number and delivery fees will be charged on that account number.\n"
 "    "
 msgstr ""
+"\n"
+"Bu modül, e-ticaret kullanıcılarının UPS hesap numaralarını girmelerine izin verir ve bu hesap numarasından teslimat ücretleri alınır."
 
 #. module: base
 #: model:ir.module.module,description:base.module_base_automation
@@ -5711,6 +5929,15 @@ msgid ""
 "trigger an automatic reminder email.\n"
 "    "
 msgstr ""
+"\n"
+"Bu modül, herhangi bir nesne için eylem kurallarının uygulanmasına izin verir.\n"
+"================================================== ==========\n"
+"\n"
+"Çeşitli ekranlar için eylemleri otomatik olarak tetiklemek için otomatik işlemleri kullanın.\n"
+"\n"
+"** Örnek: ** Belirli bir kullanıcı tarafından oluşturulan potansiyel müşteri otomatik olarak belirli bir değere ayarlanabilir\n"
+"Satış Ekibi veya 14 gün sonra hala durumu bekleyen bir fırsat\n"
+"otomatik hatırlatma e-postasını tetikler."
 
 #. module: base
 #: model:ir.module.module,description:base.module_l10n_us_check_printing
@@ -5733,6 +5960,22 @@ msgid ""
 "- Check on bottom: ADP standard (https://www.checkdepot.net/checks/checkorder/laser_bottomcheck.htm)\n"
 "    "
 msgstr ""
+"\n"
+"Bu modül, ödemelerinizin önceden yazdırılmış çek kağıdına yazdırılmasını sağlar.\n"
+"Çıktıyı (düzen, saplama bilgileri, vb.) Şirket ayarlarında yapılandırabilir ve günlük ayarlarında çek numaralandırmasını (numarasız önceden yazdırılmış kontrol kullanıyorsanız) yönetebilirsiniz.\n"
+"\n"
+"Desteklenen formatlar\n"
+"-----------------\n"
+"Bu modül en yaygın üç kontrol biçimini destekler ve checkdepot.net adresindeki bağlantılı kontrollerle birlikte çalışır.\n"
+"\n"
+"Tüm kontrolleri şu adresten görüntüle: https://www.checkdepot.net/checks/laser/Odoo.htm\n"
+"\n"
+"Aşağıdakiler arasından seçim yapabilirsiniz:\n"
+"\n"
+"- Üstte kontrol edin: Quicken / QuickBooks standardı (https://www.checkdepot.net/checks/checkorder/laser_topcheck.htm)\n"
+"- Ortada kontrol edin: Peachtree standardı (https://www.checkdepot.net/checks/checkorder/laser_middlecheck.htm)\n"
+"- Altta kontrol edin: ADP standardı \n"
+"(https://www.checkdepot.net/checks/checkorder/laser_bottomcheck.htm)"
 
 #. module: base
 #: model:ir.module.module,description:base.module_l10n_ca_check_printing
@@ -5750,6 +5993,17 @@ msgid ""
 "- Check on bottom: ADP standard\n"
 "    "
 msgstr ""
+"\n"
+"Bu modül, ödemelerinizin önceden yazdırılmış çeklere yazdırılmasını sağlar.\n"
+"Çıktıyı (düzen, taslaklar, kağıt biçimi, vb.) Şirket ayarlarında yapılandırabilir ve günlük ayarlarında çek numaralandırmasını (numarasız önceden yazdırılmış kontrol kullanıyorsanız) yönetebilirsiniz.\n"
+"Kanada Ödeme Birliği'ne göre \n"
+"(https://www.payments.ca/sites/default/files/standard_006_complete_0.pdf)\n"
+"\n"
+"Desteklenen formatlar\n"
+"-----------------\n"
+"- Üstte kontrol edin: Quicken / QuickBooks standardı\n"
+"- Ortada kontrol edin: Peachtree standardı\n"
+"- Altta kontrol edin: ADP standardı"
 
 #. module: base
 #: model:ir.module.module,description:base.module_website_crm_partner_assign
@@ -5770,6 +6024,19 @@ msgid ""
 "\n"
 "    "
 msgstr ""
+"\n"
+"Bu modül, bayilerinizi / ortaklarınızı web sitenizde yayınlamanıza ve gelen adayları / fırsatları onlara iletmenize olanak tanır.\n"
+"\n"
+"\n"
+"** Bir ortak yayınlayın **\n"
+"\n"
+"Bir iş ortağını yayınlamak için, iletişim formlarında (İş Ortağı Atama bölümünde) bir * Düzey * belirleyin ve * Yayınla * düğmesini tıklayın.\n"
+"\n"
+"** İleri potansiyel müşteriler **\n"
+"\n"
+"Yönlendirme uçları bir seferde bir veya birkaç uç için yapılabilir. İşlem, aday / fırsat formu görünümünün * Atanan İş Ortağı * bölümünde ve liste görünümünün * Eylem * menüsünde bulunur.\n"
+"\n"
+"Otomatik atama, iş ortağı düzeylerinin ağırlığından ve coğrafi konumlandırmadan anlaşılır. İş ortakları, çevrelerinde bulunan olası satışları elde eder."
 
 #. module: base
 #: model:ir.module.module,description:base.module_website_gengo
@@ -5778,6 +6045,8 @@ msgid ""
 "This module allows to send website content to Gengo translation service in a single click. Gengo then gives back the translated terms in the destination language.\n"
 "    "
 msgstr ""
+"\n"
+"Bu modül, tek bir tıklamayla web sitesi içeriğini Gengo çeviri hizmetine göndermenizi sağlar. Gengo daha sonra tercüme edilen terimleri hedef dilde verir."
 
 #. module: base
 #: model:ir.module.module,description:base.module_membership
@@ -5895,6 +6164,9 @@ msgid ""
 "On a simple click, your visitors can subscribe to mailing lists managed in the Email Marketing app.\n"
 "    "
 msgstr ""
+"\n"
+"Bu modül, web sitenizin herhangi bir sayfasına bırakılacak bir posta listesi widget'ı ile yeni bir yapı taşı getiriyor.\n"
+"Ziyaretçileriniz basit bir tıklamayla E-posta Pazarlama uygulamasında yönetilen posta listelerine abone olabilir."
 
 #. module: base
 #: model:ir.module.module,description:base.module_sale
@@ -5939,6 +6211,9 @@ msgid ""
 "by enabling cohort view for registered attendees.\n"
 "    "
 msgstr ""
+"\n"
+"Bu modül, kayıtlı katılımcılar için kohort görünümünü etkinleştirerek, \n"
+"olay kayıt düzeninin analiz edilmesine yardımcı olur."
 
 #. module: base
 #: model:ir.module.module,description:base.module_base_setup
@@ -6063,6 +6338,8 @@ msgid ""
 "This module overrides community website features and introduces enterprise look and feel.\n"
 "    "
 msgstr ""
+"\n"
+"Bu modül, topluluk web sitesi özelliklerini geçersiz kılar ve kurumsal görünüm ve his sunar."
 
 #. module: base
 #: model:ir.module.module,description:base.module_purchase_mrp
@@ -6103,6 +6380,8 @@ msgid ""
 "\n"
 "This module provides management of your IoT Boxes inside Odoo.\n"
 msgstr ""
+"\n"
+"Bu modül Odoo içindeki IoT Kutularınızın yönetimini sağlar.\n"
 
 #. module: base
 #: model:ir.module.module,description:base.module_iap
@@ -6284,6 +6563,9 @@ msgid ""
 "============================\n"
 "    "
 msgstr ""
+"\n"
+"Ukrayna - Hesap planı.\n"
+"============================"
 
 #. module: base
 #: model:ir.module.module,description:base.module_l10n_ae
@@ -6317,6 +6599,9 @@ msgid ""
 "Use budgets to compare actual with expected revenues and costs\n"
 "--------------------------------------------------------------\n"
 msgstr ""
+"\n"
+"Gerçekleşeni beklenen gelir ve maliyetlerle karşılaştırmak için bütçeleri kullanın\n"
+"--------------------------------------------------------------\n"
 
 #. module: base
 #: model:ir.module.module,description:base.module_sales_team
@@ -6326,6 +6611,10 @@ msgid ""
 "===========================================================================\n"
 " "
 msgstr ""
+"\n"
+"Bu uygulamayı kullanarak Satış Takımlarını CRM ve / veya Satış ile yönetebilirsiniz\n"
+"===========================================================================\n"
+" "
 
 #. module: base
 #: model:ir.module.module,description:base.module_base_vat
@@ -6425,6 +6714,8 @@ msgid ""
 "Visitors can join public mail channels managed in the Discuss app in order to get regular updates or reach out with your community.\n"
 "    "
 msgstr ""
+"\n"
+"Ziyaretçiler, düzenli güncellemeler almak veya topluluğunuzla iletişim kurmak için Tartışma uygulamasında yönetilen genel posta kanallarına katılabilir."
 
 #. module: base
 #: model:ir.module.module,description:base.module_stock_account
@@ -6567,6 +6858,8 @@ msgid ""
 " This is the base module to manage chart of accounting and localization for "
 "Hong Kong "
 msgstr ""
+"Bu, Hong Kong için muhasebe ve yerelleştirme tablosunu yönetmek için temel "
+"modüldür"
 
 #. module: base
 #: code:addons/model.py:148
@@ -6714,6 +7007,8 @@ msgid ""
 "- Create/update: a mandatory field is not set.\n"
 "- Delete: another model requires the record being deleted. If possible, archive it instead."
 msgstr ""
+"- Oluştur / güncelle: Zorunlu bir alan ayarlanmamış.\n"
+"- Sil: Başka bir model kaydın silinmesini gerektirir. Mümkünse arşivleyin."
 
 #. module: base
 #: model_terms:ir.ui.view,arch_db:base.report_irmodeloverview
@@ -6813,7 +7108,7 @@ msgstr "7. %j              ==&gt; 340"
 #. module: base
 #: model_terms:ir.ui.view,arch_db:base.res_lang_form
 msgid "8. %S              ==&gt; 20"
-msgstr ""
+msgstr "8. %S              ==&gt; 20"
 
 #. module: base
 #: model_terms:ir.ui.view,arch_db:base.res_lang_form
@@ -6971,6 +7266,8 @@ msgid ""
 "<span class=\"o_form_label\">Click on Update below to start the "
 "process...</span>"
 msgstr ""
+"<span class=\"o_form_label\">İşlemi başlatmak için aşağıdaki Güncelle'yi "
+"tıklayın...</span>"
 
 #. module: base
 #: model_terms:ir.ui.view,arch_db:base.view_base_language_install
@@ -6978,6 +7275,8 @@ msgid ""
 "<span class=\"o_form_label\">The selected language has been successfully installed.\n"
 "You must change the preferences of the user to view the changes.</span>"
 msgstr ""
+"<span class=\"o_form_label\">Seçilen dil başarıyla yüklendi.\n"
+"Değişiklikleri görüntülemek için kullanıcının tercihlerini değiştirmeniz gerekir.</span>"
 
 #. module: base
 #: model_terms:ir.ui.view,arch_db:base.view_base_module_upgrade_install
@@ -6985,6 +7284,7 @@ msgid ""
 "<span class=\"o_form_label\">The selected modules have been updated / "
 "installed !</span>"
 msgstr ""
+"<span class=\"o_form_label\">Seçilen modüller güncellendi / kuruldu!</span>"
 
 #. module: base
 #: model_terms:ir.ui.view,arch_db:base.view_base_module_upgrade_install
@@ -6992,6 +7292,8 @@ msgid ""
 "<span class=\"o_form_label\">We suggest to reload the menu tab to see the "
 "new menus (Ctrl+T then Ctrl+R).\"</span>"
 msgstr ""
+"<span class=\"o_form_label\">Yeni menüleri görmek için menü sekmesini "
+"yeniden yüklemenizi öneririz (Ctrl + T sonra Ctrl + R). \"</span>"
 
 #. module: base
 #: model_terms:ir.ui.view,arch_db:base.res_config_settings_view_form
@@ -7005,7 +7307,7 @@ msgstr ""
 #. module: base
 #: model_terms:ir.ui.view,arch_db:base.demo_force_install_form
 msgid "<span class=\"text-white text-uppercase\">Danger Zone</span>"
-msgstr ""
+msgstr "<span class=\"text-white text-uppercase\">Tehlikeli Bölge</span>"
 
 #. module: base
 #: model_terms:ir.ui.view,arch_db:base.sequence_view
@@ -7146,7 +7448,7 @@ msgstr "<strong>Seq</strong>"
 #. module: base
 #: model_terms:ir.ui.view,arch_db:base.view_users_form
 msgid "<strong>The contact linked to this user is still active</strong>"
-msgstr ""
+msgstr "<strong>Bu kontağa bağlı kullanıcı hala etkin</strong>"
 
 #. module: base
 #: model_terms:ir.ui.view,arch_db:base.view_base_module_upgrade
@@ -7510,7 +7812,7 @@ msgstr "Özel durumlar oluşturmak için bir modül."
 #. module: base
 #: model:ir.module.module,description:base.module_test_lint
 msgid "A module to test Odoo code with various linters."
-msgstr ""
+msgstr "Çeşitli linterlerle Odoo kodunu test etmek için bir modül."
 
 #. module: base
 #: model:ir.module.module,description:base.module_test_impex
@@ -7525,7 +7827,7 @@ msgstr "API yi test etmek için bir modül."
 #. module: base
 #: model:ir.module.module,description:base.module_test_rpc
 msgid "A module to test the RPC requests."
-msgstr ""
+msgstr "RPC isteklerini test etmek için bir modül."
 
 #. module: base
 #: model:ir.module.module,description:base.module_test_uninstall
@@ -7547,6 +7849,8 @@ msgstr "Varlıklar Paketi mekanizmasını doğrulayan bir modül."
 msgid ""
 "A module to verify the inheritance using _inherits in non-original modules."
 msgstr ""
+"Orijinal olmayan modüllerde _inherits kullanarak devralmayı doğrulayan bir "
+"modül."
 
 #. module: base
 #: model:ir.module.module,description:base.module_test_inherits
@@ -7716,7 +8020,7 @@ msgstr "Hesap Sahibinin Adı"
 #. module: base
 #: model:ir.module.module,shortdesc:base.module_account_invoice_extract
 msgid "Account Invoice Extract"
-msgstr ""
+msgstr "Hesap Fatura Özeti"
 
 #. module: base
 #: model:ir.model.fields,field_description:base.field_res_company__account_no
@@ -7914,7 +8218,7 @@ msgstr "Eylem Penceresi"
 #. module: base
 #: model:ir.model,name:base.model_ir_actions_act_window_close
 msgid "Action Window Close"
-msgstr ""
+msgstr "İşlem Penceresi Kapat"
 
 #. module: base
 #: model:ir.model,name:base.model_ir_actions_act_window_view
@@ -7963,7 +8267,7 @@ msgstr "Aktivite"
 #: model:ir.model.fields,field_description:base.field_ir_sequence__number_next_actual
 #: model:ir.model.fields,field_description:base.field_ir_sequence_date_range__number_next_actual
 msgid "Actual Next Number"
-msgstr ""
+msgstr "Gerçek Sonraki Numara"
 
 #. module: base
 #: selection:ir.actions.server,state:0
@@ -7973,7 +8277,7 @@ msgstr "Takipçi Ekle"
 #. module: base
 #: model:ir.module.module,summary:base.module_mail_bot
 msgid "Add OdooBot in discussions"
-msgstr ""
+msgstr "Tartışmalara OdooBot ekleyin"
 
 #. module: base
 #: model:ir.module.module,summary:base.module_transifex
@@ -8339,6 +8643,7 @@ msgid ""
 "All the emails and documents sent to this contact will be translated in this"
 " language."
 msgstr ""
+"Bu kişiye gönderilen tüm e-postalar ve belgeler bu dilde çevrilecektir."
 
 #. module: base
 #: model:ir.module.module,summary:base.module_hr_holidays
@@ -8353,7 +8658,7 @@ msgstr "Kasiyerin makbuzları tekrar yazdırmasına izin ver."
 #. module: base
 #: model:ir.module.module,summary:base.module_ocn_client
 msgid "Allow push notification to devices"
-msgstr ""
+msgstr "Cihazlara anında bildirime izin ver"
 
 #. module: base
 #: model:ir.module.module,summary:base.module_website_sale_comparison
@@ -8365,12 +8670,12 @@ msgstr ""
 #. module: base
 #: model:ir.module.module,summary:base.module_website_sale_wishlist
 msgid "Allow shoppers to enlist products"
-msgstr ""
+msgstr "Alışveriş yapanların ürünleri kaydettirmesine izin ver"
 
 #. module: base
 #: model:ir.module.module,summary:base.module_website_mail_channel
 msgid "Allow visitors to join public mail channels"
-msgstr ""
+msgstr "Ziyaretçilerin herkese açık posta kanallarına katılmasına izin ver"
 
 #. module: base
 #: model_terms:ir.ui.view,arch_db:base.view_users_form
@@ -8380,7 +8685,7 @@ msgstr "İzin Verilmiş Şirket"
 #. module: base
 #: model:ir.module.module,summary:base.module_stock_barcode_quality_control
 msgid "Allows the usage of quality checks within the barcode views"
-msgstr ""
+msgstr "Barkod görünümlerinde kalite kontrollerinin kullanılmasına izin verir"
 
 #. module: base
 #: model:ir.module.module,summary:base.module_sale_coupon_delivery
@@ -8659,7 +8964,7 @@ msgstr "Aruba"
 #. module: base
 #: model:ir.module.module,summary:base.module_hr_appraisal
 msgid "Assess your employees"
-msgstr ""
+msgstr "Çalışanlarınızı seçin"
 
 #. module: base
 #: model:ir.module.module,shortdesc:base.module_account_asset
@@ -8685,7 +8990,7 @@ msgstr "En az bir dil etkin olmalıdır."
 #. module: base
 #: model_terms:ir.actions.act_window,help:base.action_attachment
 msgid "Attach a new document"
-msgstr ""
+msgstr "Yeni bir belge ekleyin"
 
 #. module: base
 #: model_terms:ir.ui.view,arch_db:base.view_attachment_search
@@ -8729,7 +9034,7 @@ msgstr "Katılımcılar"
 #. module: base
 #: model:ir.module.module,summary:base.module_website_mass_mailing
 msgid "Attract visitors to subscribe to mailing lists"
-msgstr ""
+msgstr "Posta listelerine abone olmak için ziyaretçileri çekin"
 
 #. module: base
 #: model:res.country,name:base.au
@@ -8875,7 +9180,7 @@ msgstr "B1  15  707 x 1000 mm"
 #. module: base
 #: selection:report.paperformat,format:0
 msgid "B10    16  31 x 44 mm"
-msgstr ""
+msgstr "B10    16  31 x 44 mm"
 
 #. module: base
 #: selection:report.paperformat,format:0
@@ -9017,7 +9322,7 @@ msgstr "Barkod"
 #. module: base
 #: model:ir.module.module,shortdesc:base.module_stock_barcode_quality_control
 msgid "Barcode Quality bridge module"
-msgstr ""
+msgstr "Barkod Kalitesi köprü modülü"
 
 #. module: base
 #: model:ir.module.module,shortdesc:base.module_hw_scanner
@@ -9038,13 +9343,13 @@ msgstr "Mobilde Barkod taraması"
 #: code:addons/base/models/ir_qweb_fields.py:607
 #, python-format
 msgid "Barcode symbology"
-msgstr ""
+msgstr "Barkod sembolojisi"
 
 #. module: base
 #: code:addons/base/models/ir_qweb_fields.py:607
 #, python-format
 msgid "Barcode type, eg: UPCA, EAN13, Code128"
-msgstr ""
+msgstr "Barkod türü, örneğin:UPCA, EAN13, Code128"
 
 #. module: base
 #: model:ir.module.module,summary:base.module_barcodes
@@ -9069,7 +9374,7 @@ msgstr "Temel Alan"
 #: code:addons/base/models/res_lang.py:240
 #, python-format
 msgid "Base Language 'en_US' can not be deleted."
-msgstr ""
+msgstr "Temel Dil 'en_US' silinemez."
 
 #. module: base
 #: selection:ir.model,state:0
@@ -9107,7 +9412,7 @@ msgstr "Temel görünüm"
 #: model:ir.cron,cron_name:base.autovacuum_job
 #: model:ir.cron,name:base.autovacuum_job
 msgid "Base: Auto-vacuum internal data"
-msgstr ""
+msgstr "Temel: Dahili verileri otomatik çekme"
 
 #. module: base
 #: model:ir.module.module,summary:base.module_web_grid
@@ -9117,12 +9422,12 @@ msgstr "Odoo için Temel 2D Tablo görünümü"
 #. module: base
 #: model:ir.module.module,summary:base.module_web_cohort
 msgid "Basic Cohort view for odoo"
-msgstr ""
+msgstr "Odoo için Temel Kohort görünümü"
 
 #. module: base
 #: model:ir.module.module,summary:base.module_quality
 msgid "Basic Feature for Quality"
-msgstr ""
+msgstr "Kalite için Temel Özellik"
 
 #. module: base
 #: model:ir.module.module,summary:base.module_iap
@@ -9134,6 +9439,7 @@ msgstr ""
 #: model:ir.module.module,summary:base.module_iot
 msgid "Basic models and helpers to support Internet of Things."
 msgstr ""
+"Nesnelerin İnterneti'ni desteklemek için temel modeller ve yardımcılar."
 
 #. module: base
 #: model:ir.module.module,shortdesc:base.module_account_batch_payment
@@ -9240,7 +9546,7 @@ msgstr "Bütan"
 #. module: base
 #: model:ir.module.module,summary:base.module_website_delivery_ups
 msgid "Bill to your UPS account number"
-msgstr ""
+msgstr "UPS hesap numaranıza faturalandırma"
 
 #. module: base
 #: selection:ir.property,type:0
@@ -9314,7 +9620,7 @@ msgstr "Bootswatch Tema"
 #. module: base
 #: model:ir.module.module,description:base.module_theme_bootswatch
 msgid "Bootswatch themes"
-msgstr ""
+msgstr "Bootswatch temaları"
 
 #. module: base
 #: model:res.country,name:base.ba
@@ -9360,7 +9666,7 @@ msgstr "Websitesini kullanarak yardım masası modülleri için köprü modülü
 #. module: base
 #: model:ir.module.module,summary:base.module_project_enterprise
 msgid "Bridge module for project and enterprise"
-msgstr ""
+msgstr "Proje ve işletme için köprü modülü"
 
 #. module: base
 #: model:res.country,name:base.io
@@ -9391,17 +9697,17 @@ msgstr "Otomatik mail kampanyası oluştur"
 #. module: base
 #: model:ir.module.module,summary:base.module_website_form_editor
 msgid "Build custom web forms"
-msgstr ""
+msgstr "Özel web formları oluşturma"
 
 #. module: base
 #: model:ir.module.module,summary:base.module_sale_quotation_builder
 msgid "Build great quotation templates"
-msgstr ""
+msgstr "Mükemmel teklif şablonları oluşturun"
 
 #. module: base
 #: model:ir.module.module,summary:base.module_board
 msgid "Build your own dashboards"
-msgstr ""
+msgstr "Kendi gösterge panolarınızı oluşturun"
 
 #. module: base
 #: model:res.country,name:base.bg
@@ -9427,7 +9733,7 @@ msgstr "İle"
 #: code:addons/base/models/ir_qweb_fields.py:280
 #, python-format
 msgid "By default the widget uses the field informations"
-msgstr ""
+msgstr "Widget varsayılan olarak alan bilgilerini kullanır"
 
 #. module: base
 #: model:res.partner.industry,full_name:base.res_partner_industry_C
@@ -9457,7 +9763,7 @@ msgstr "CRM Canlı Sohbet"
 #. module: base
 #: model:ir.module.module,shortdesc:base.module_crm_enterprise
 msgid "CRM enterprise"
-msgstr ""
+msgstr "CRM kuruluşu"
 
 #. module: base
 #: selection:base.language.export,format:0
@@ -9529,7 +9835,7 @@ msgstr "Kanada - Muhasebe"
 #. module: base
 #: model:ir.module.module,shortdesc:base.module_l10n_ca_check_printing
 msgid "Canadian Checks Layout"
-msgstr ""
+msgstr "Kanada Çek Düzeni"
 
 #. module: base
 #: model_terms:ir.ui.view,arch_db:base.base_onboarding_company_form
@@ -9577,7 +9883,7 @@ msgstr "Yükseltme İptal"
 #: code:addons/models.py:2118
 #, python-format
 msgid "Cannot aggregate field %r."
-msgstr ""
+msgstr "%r alanı toplanamıyor."
 
 #. module: base
 #: code:addons/base/models/ir_translation.py:256
@@ -9590,6 +9896,7 @@ msgstr ""
 #, python-format
 msgid "Cannot deactivate a language that is currently used by users."
 msgstr ""
+"Şu anda kullanıcılar tarafından kullanılan bir dil devre dışı bırakılamaz."
 
 #. module: base
 #: code:addons/base/models/res_config.py:388
@@ -9633,12 +9940,12 @@ msgstr "Orta Afrika Cumhuriyeti"
 #. module: base
 #: model:ir.module.module,summary:base.module_hr
 msgid "Centralize employee information"
-msgstr ""
+msgstr "Çalışan bilgilerini merkezileştirin"
 
 #. module: base
 #: model:ir.module.module,summary:base.module_contacts
 msgid "Centralize your address book"
-msgstr ""
+msgstr "Adres defterinizi merkezileştirin"
 
 #. module: base
 #: model:res.country,name:base.td
@@ -9715,7 +10022,7 @@ msgstr "Website ziyaretçilerinizle konuşun"
 #. module: base
 #: model:ir.module.module,summary:base.module_mail
 msgid "Chat, mail gateway and private channels"
-msgstr ""
+msgstr "Sohbet, posta ağ geçidi ve özel kanallar"
 
 #. module: base
 #: model:ir.module.module,shortdesc:base.module_account_check_printing
@@ -9832,22 +10139,22 @@ msgstr "Çin"
 #. module: base
 #: model:ir.module.module,shortdesc:base.module_l10n_cn
 msgid "China - Accounting"
-msgstr ""
+msgstr "Çin - Muhasebe"
 
 #. module: base
 #: model:ir.module.module,shortdesc:base.module_l10n_cn_city
 msgid "China - City Data"
-msgstr ""
+msgstr "Çin - Şehir Verileri"
 
 #. module: base
 #: model:ir.module.module,shortdesc:base.module_l10n_cn_small_business
 msgid "China - Small Business CoA"
-msgstr ""
+msgstr "Çin - Küçük İşletme CoA"
 
 #. module: base
 #: model:ir.module.module,shortdesc:base.module_l10n_cn_standard
 msgid "China - Standard CoA"
-msgstr ""
+msgstr "Çin - Standart CoA"
 
 #. module: base
 #: code:addons/base/models/ir_actions_report.py:740
@@ -10000,7 +10307,7 @@ msgstr "Kolombiyalı muhasebe ve vergi önceden yapılandırma"
 #. module: base
 #: model:ir.module.module,summary:base.module_l10n_co_edi
 msgid "Colombian Localization for EDI documents"
-msgstr ""
+msgstr "EDI belgeleri için Kolombiya Yerelleştirmesi"
 
 #. module: base
 #: model:ir.module.module,summary:base.module_l10n_co_edi_ubl_2_1
@@ -10146,7 +10453,7 @@ msgstr "Şirket Özellikleri"
 #. module: base
 #: model:ir.model,name:base.model_ir_property
 msgid "Company Property"
-msgstr ""
+msgstr "Şirket mülkiyeti"
 
 #. module: base
 #: model:ir.model.fields,field_description:base.field_res_company__company_registry
@@ -10171,6 +10478,8 @@ msgid ""
 "Company used for the original currency (only used for t-esc). By default use"
 " the user company"
 msgstr ""
+"Orijinal para birimi için kullanılan şirket (yalnızca t-esc için "
+"kullanılır). Varsayılan olarak kullanıcı şirketini kullanın"
 
 #. module: base
 #: model:ir.module.module,shortdesc:base.module_project_timesheet_forecast_sale
@@ -10207,6 +10516,7 @@ msgstr "Hesapla"
 #: model:ir.module.module,summary:base.module_sale_subscription_taxcloud
 msgid "Compute taxes with TaxCloud after automatic invoice creation."
 msgstr ""
+"Otomatik fatura oluşturulduktan sonra TaxCloud ile vergileri hesaplayın."
 
 #. module: base
 #: model:ir.module.module,summary:base.module_website_sale_taxcloud_delivery
@@ -10247,7 +10557,7 @@ msgstr "Yapılandır"
 #. module: base
 #: model:ir.model,name:base.model_res_config_installer
 msgid "Config Installer"
-msgstr ""
+msgstr "Config Installer"
 
 #. module: base
 #: model:ir.model,name:base.model_res_config_settings
@@ -10462,7 +10772,7 @@ msgstr "Destekleyenler"
 #. module: base
 #: model:ir.module.module,summary:base.module_quality_control
 msgid "Control the quality of your products"
-msgstr ""
+msgstr "Ürünlerinizin kalitesini kontrol edin"
 
 #. module: base
 #: model:res.country,name:base.ck
@@ -10560,7 +10870,7 @@ msgstr "Ülke İl/Eyaleti"
 #. module: base
 #: model:ir.module.module,shortdesc:base.module_website_sale_coupon
 msgid "Coupons & Promotions for eCommerce"
-msgstr ""
+msgstr "E-Ticaret için Kuponlar ve Promosyonlar"
 
 #. module: base
 #: model:ir.model.fields,field_description:base.field_ir_model_access__perm_create
@@ -10596,7 +10906,7 @@ msgstr "Menü Oluştur"
 #. module: base
 #: model:ir.model,name:base.model_wizard_ir_model_menu_create
 msgid "Create Menu Wizard"
-msgstr ""
+msgstr "Menü Oluşturma Sihirbazı"
 
 #. module: base
 #: selection:ir.actions.server,state:0
@@ -10657,17 +10967,17 @@ msgstr "Adres defterinizde yeni bir müşteri oluşturun"
 #. module: base
 #: model_terms:ir.actions.act_window,help:base.res_partner_industry_action
 msgid "Create a new industry"
-msgstr ""
+msgstr "Yeni bir endüstri yaratın"
 
 #. module: base
 #: model_terms:ir.actions.act_window,help:base.action_partner_supplier_form
 msgid "Create a new vendor in your address book"
-msgstr ""
+msgstr "Adres defterinizde yeni bir satıcı oluşturun"
 
 #. module: base
 #: model:ir.module.module,summary:base.module_web_studio
 msgid "Create and customize your Odoo apps"
-msgstr ""
+msgstr "Odoo uygulamalarınızı oluşturun ve özelleştirin"
 
 #. module: base
 #: model_terms:ir.actions.act_window,help:base.action_res_company_form
@@ -10704,7 +11014,7 @@ msgstr ""
 #. module: base
 #: model:ir.module.module,summary:base.module_survey
 msgid "Create surveys and analyze answers"
-msgstr ""
+msgstr "Anketler oluşturun ve cevapları analiz edin"
 
 #. module: base
 #: model:ir.model.fields,field_description:base.field_ir_actions_server__crud_model_id
@@ -11207,6 +11517,8 @@ msgstr "Tarih Formatı"
 #, python-format
 msgid "Date to compare with the field value, by default use the current date."
 msgstr ""
+"Alan değeriyle karşılaştırılacak tarih, varsayılan olarak geçerli tarihi "
+"kullanın."
 
 #. module: base
 #: code:addons/base/models/ir_qweb_fields.py:511
@@ -11235,6 +11547,8 @@ msgid ""
 "Date used for the original currency (only used for t-esc). by default use "
 "the current date."
 msgstr ""
+"Orijinal para birimi için kullanılan tarih (yalnızca t-esc için kullanılır)."
+" varsayılan olarak geçerli tarihi kullanın."
 
 #. module: base
 #: selection:ir.property,type:0
@@ -11415,11 +11729,13 @@ msgid ""
 "Demo data should only be used on test databases!\n"
 "                             Once they are loaded, they cannot be removed!"
 msgstr ""
+"Demo verileri sadece test veritabanlarında kullanılmalıdır!\n"
+"                             Yüklendikten sonra kaldırılamaz!"
 
 #. module: base
 #: model:ir.model,name:base.model_ir_demo_failure
 msgid "Demo failure"
-msgstr ""
+msgstr "Demo hatası"
 
 #. module: base
 #: model:res.country,name:base.cd
@@ -11495,6 +11811,8 @@ msgid ""
 "Design great quotation templates with building blocks to significantly boost"
 " your success rate."
 msgstr ""
+"Başarı oranınızı önemli ölçüde artırmak için yapı taşlarıyla mükemmel teklif"
+" şablonları tasarlayın."
 
 #. module: base
 #: model:ir.module.module,summary:base.module_mass_mailing
@@ -11765,13 +12083,13 @@ msgstr "Yalnızca zamanı göster"
 #: code:addons/base/models/ir_qweb_fields.py:634
 #, python-format
 msgid "Display the country image if the field is present on the record"
-msgstr ""
+msgstr "Alan kayıtta mevcutsa ülke görüntüsünü göster"
 
 #. module: base
 #: code:addons/base/models/ir_qweb_fields.py:633
 #, python-format
 msgid "Display the phone icons even if no_marker is True"
-msgstr ""
+msgstr "No_marker True olsa bile telefon simgelerini görüntüleme"
 
 #. module: base
 #: code:addons/base/models/ir_qweb_fields.py:634
@@ -11794,7 +12112,7 @@ msgstr ""
 #. module: base
 #: model:ir.module.module,summary:base.module_event_enterprise
 msgid "Displays cohort analysis on attendees."
-msgstr ""
+msgstr "Katılımcılar üzerinde kohort analizi görüntüler."
 
 #. module: base
 #: model:res.country,name:base.dj
@@ -11804,7 +12122,7 @@ msgstr "Cibuti"
 #. module: base
 #: model_terms:ir.ui.view,arch_db:base.onboarding_container
 msgid "Do you want to remove this configuration panel?"
-msgstr ""
+msgstr "Bu yapılandırma panelini kaldırmak istiyor musunuz?"
 
 #. module: base
 #: model:res.partner.title,name:base.res_partner_title_doctor
@@ -11912,7 +12230,7 @@ msgstr "Dominik Cumhuriyeti - muhasebe"
 #: code:addons/base/models/ir_qweb_fields.py:631
 #, python-format
 msgid "Don't display the font awesome marker"
-msgstr ""
+msgstr "Yazı tipi müthiş işaretçisini görüntüleme"
 
 #. module: base
 #: selection:ir.actions.todo,state:0
@@ -12180,7 +12498,7 @@ msgstr "Her model eşşiz olmalı!"
 #. module: base
 #: model:ir.module.module,shortdesc:base.module_delivery_easypost
 msgid "Easypost Shipping"
-msgstr ""
+msgstr "Easypost Nakliye"
 
 #. module: base
 #: model:res.country,name:base.ec
@@ -12215,6 +12533,9 @@ msgid ""
 "partner is a customer without access or with a limited access created for "
 "sharing data."
 msgstr ""
+"Her iki müşteri (kullanıcı değil), paylaşılan kullanıcı. Mevcut iş "
+"ortağının, erişimi olmayan veya veri paylaşımı için sınırlı erişimi olan bir"
+" müşteri olduğu belirtilir."
 
 #. module: base
 #: model:res.country,name:base.sv
@@ -12268,7 +12589,7 @@ msgstr ""
 #. module: base
 #: model:ir.module.module,shortdesc:base.module_l10n_co_edi
 msgid "Electronic invoicing for Colombia with Carvajal"
-msgstr ""
+msgstr "Kolombiya için Carvajal ile elektronik faturalama"
 
 #. module: base
 #: model:ir.module.module,shortdesc:base.module_l10n_co_edi_ubl_2_1
@@ -12367,11 +12688,15 @@ msgid ""
 "* Traceability report\n"
 "* Cost Structure report (mrp_account)"
 msgstr ""
+"MRP için kurumsal uzantı\n"
+"İş emri planlaması. Üretim emri / iş merkezine göre gruplandırılmış Gantt görünümleriyle planlamayı kontrol edin\n"
+"* İzlenebilirlik raporu\n"
+"* Maliyet Yapısı raporu (mrp_account)"
 
 #. module: base
 #: model:ir.module.module,summary:base.module_website
 msgid "Enterprise website builder"
-msgstr ""
+msgstr "Kurumsal web sitesi oluşturucu"
 
 #. module: base
 #: model:res.partner.industry,name:base.res_partner_industry_R
@@ -12485,7 +12810,7 @@ msgstr "Etkinlik Organizasyonu"
 #. module: base
 #: model:ir.module.module,shortdesc:base.module_event_enterprise
 msgid "Events Organization Add-on"
-msgstr ""
+msgstr "Etkinlik Organizasyonu Eklentisi"
 
 #. module: base
 #: model:ir.module.module,shortdesc:base.module_event_sale
@@ -12584,6 +12909,9 @@ msgid ""
 "images to use in Odoo. An Unsplash search bar is added to the image library "
 "modal."
 msgstr ""
+"Unsplash.com'un ücretsiz yüksek çözünürlüklü görüntü kütüphanesini keşfedin "
+"ve Odoo'da kullanılacak görüntüleri bulun. Resim kitaplığı yöntemine bir "
+"Unsplash arama çubuğu eklenir."
 
 #. module: base
 #: model:ir.model.fields,field_description:base.field_ir_exports_line__export_id
@@ -12625,7 +12953,7 @@ msgstr "Çevirileri Dışa Aktar"
 #. module: base
 #: model:ir.module.module,summary:base.module_l10n_au_aba
 msgid "Export payments as ABA Credit Transfer files"
-msgstr ""
+msgstr "Ödemeleri ABA Kredi Transferi dosyaları olarak dışa aktarma"
 
 #. module: base
 #: model:ir.module.module,summary:base.module_account_sepa
@@ -12666,7 +12994,7 @@ msgstr "Uzantı Görünümü"
 #. module: base
 #: model:ir.module.module,summary:base.module_snailmail_account_reports_followup
 msgid "Extension to send follow-up documents by post"
-msgstr ""
+msgstr "Takip belgelerini posta yoluyla gönderme uzantısı"
 
 #. module: base
 #: model:ir.model.fields,field_description:base.field_ir_actions_act_url__xml_id
@@ -12879,7 +13207,7 @@ msgstr "Ek Araçlar"
 #. module: base
 #: model:ir.module.module,summary:base.module_account_invoice_extract
 msgid "Extract data from invoice scans to fill them automatically"
-msgstr ""
+msgstr "Otomatik olarak doldurmak için fatura taramalarından veri ayıklayın"
 
 #. module: base
 #: model:res.partner.industry,name:base.res_partner_industry_U
@@ -12903,7 +13231,7 @@ msgstr ""
 #. module: base
 #: model:ir.actions.server,name:base.demo_failure_action
 msgid "Failed to install demo data for some modules, demo disabled"
-msgstr ""
+msgstr "Bazı modüller için demo verileri yüklenemedi, demo devre dışı"
 
 #. module: base
 #: model:ir.model.fields,field_description:base.field_ir_demo_failure_wizard__failures_count
@@ -12944,7 +13272,7 @@ msgstr "Fedex Kargo"
 #. module: base
 #: model:ir.module.module,summary:base.module_l10n_fr_fec
 msgid "Fichier d'Échange Informatisé (FEC) for France"
-msgstr ""
+msgstr "Fransa için Fichier d'Échange Informatisé (FEC)"
 
 #. module: base
 #: model:ir.module.module,description:base.module_l10n_fr_fec
@@ -13090,7 +13418,7 @@ msgstr "Alanlar"
 #. module: base
 #: model:ir.model,name:base.model_ir_fields_converter
 msgid "Fields Converter"
-msgstr ""
+msgstr "Alan Dönüştürücü"
 
 #. module: base
 #: model_terms:ir.ui.view,arch_db:base.view_model_form
@@ -13284,7 +13612,7 @@ msgstr "Folio 27  210 x 330 mm"
 #. module: base
 #: model:ir.model,name:base.model_format_address_mixin
 msgid "Fomat Address"
-msgstr ""
+msgstr "Adresi Biçimlendir"
 
 #. module: base
 #: model:res.partner.industry,name:base.res_partner_industry_I
@@ -13492,7 +13820,7 @@ msgstr "Başlangıç"
 #. module: base
 #: model:ir.module.module,summary:base.module_sale_management
 msgid "From quotations to invoices"
-msgstr ""
+msgstr "Tekliflerden faturalara"
 
 #. module: base
 #: model_terms:ir.ui.view,arch_db:base.ir_access_view_search
@@ -13524,7 +13852,7 @@ msgstr "Tam Ekran"
 #: model:ir.module.module,shortdesc:base.module_purchase_mrp_workorder_quality
 #: model:ir.module.module,summary:base.module_purchase_mrp_workorder_quality
 msgid "Full Traceability Report Demo Data"
-msgstr ""
+msgstr "Tam İzlenebilirlik Raporu Demo Verileri"
 
 #. module: base
 #: model:ir.model.fields,field_description:base.field_ir_logging__func
@@ -13644,12 +13972,12 @@ msgstr "Bir iletişim formundan adaylar oluştur"
 #. module: base
 #: model:ir.module.module,summary:base.module_sale_subscription
 msgid "Generate recurring invoices and manage renewals"
-msgstr ""
+msgstr "Yinelenen faturalar oluşturun ve yenilemeleri yönetin"
 
 #. module: base
 #: model:ir.module.module,summary:base.module_website_links
 msgid "Generate trackable & short URLs"
-msgstr ""
+msgstr "İzlenebilir ve kısa URL'ler oluşturun"
 
 #. module: base
 #: model_terms:ir.ui.view,arch_db:base.ir_property_view_search
@@ -13675,6 +14003,11 @@ msgid ""
 "\n"
 "OFX and QIF imports are available in Enterprise version."
 msgstr ""
+"Banka İfadelerini Alma Genel Sihirbazı.\n"
+"\n"
+"(Bu modülde herhangi bir içe aktarma biçimi yoktur.)\n"
+"\n"
+"OFX ve QIF içe aktarma işlemleri Enterprise sürümünde mevcuttur."
 
 #. module: base
 #: model:ir.module.module,description:base.module_website_form
@@ -13720,12 +14053,12 @@ msgstr "Almanya SKR04 - Muhasebe"
 #. module: base
 #: model:ir.module.module,summary:base.module_website_sale_dashboard
 msgid "Get a new dashboard view in the Website App"
-msgstr ""
+msgstr "Web Sitesi Uygulamasında yeni bir gösterge tablosu görünümü edinin"
 
 #. module: base
 #: model:ir.module.module,summary:base.module_website_enterprise
 msgid "Get the enterprise look and feel"
-msgstr ""
+msgstr "Kurumsal görünümü ve hissi elde edin"
 
 #. module: base
 #: model:res.country,name:base.gh
@@ -13756,6 +14089,9 @@ msgid ""
 "                         Group-specific rules grant additional permissions, but are constrained within the bounds of global ones.\n"
 "                         The first group rules restrict further the global rules, but can be relaxed by additional group rules."
 msgstr ""
+"Genel kurallar (gruba özgü olmayan) kısıtlamalar olup, atlanamaz.\n"
+"                          Gruba özgü kurallar ek izinler verir, ancak genel kuralların sınırları dahilinde sınırlandırılmıştır.\n"
+"                          İlk grup kuralları, genel kuralları daha da kısıtlar, ancak ek grup kuralları tarafından rahatlatılabilir."
 
 #. module: base
 #: model_terms:ir.ui.view,arch_db:base.view_rule_form
@@ -13763,6 +14099,8 @@ msgid ""
 "Global rules are combined together with a logical AND operator, and with the"
 " result of the following steps"
 msgstr ""
+"Global kurallar, mantıksal bir AND operatörü ile ve aşağıdaki adımların "
+"sonucu ile birleştirilir"
 
 #. module: base
 #: code:addons/base/models/res_config.py:742
@@ -13944,7 +14282,7 @@ msgstr "Kontak Grubu"
 #. module: base
 #: model_terms:ir.ui.view,arch_db:base.view_rule_form
 msgid "Group-specific rules are combined together with a logical OR operator"
-msgstr ""
+msgstr "Gruba özgü kurallar bir mantıksal OR operatörü ile birleştirilir"
 
 #. module: base
 #: model:ir.actions.act_window,name:base.action_res_groups
@@ -14184,7 +14522,7 @@ msgstr "Zaman çizelgelerini yönetmenize yardımcı olur."
 #. module: base
 #: model:ir.module.category,description:base.module_category_user_type
 msgid "Helps you manage users."
-msgstr ""
+msgstr "Kullanıcıları yönetmenize yardımcı olur."
 
 #. module: base
 #: model:ir.module.category,description:base.module_category_event_management
@@ -14199,7 +14537,7 @@ msgstr "Değerlemelerinizi yönetmenize yardımcı olur."
 #. module: base
 #: model:ir.module.category,description:base.module_category_hr_contract
 msgid "Helps you manage your contracts."
-msgstr ""
+msgstr "Sözleşmelerinizi yönetmenize yardımcı olur."
 
 #. module: base
 #: model:ir.module.category,description:base.module_category_human_resources
@@ -14280,7 +14618,7 @@ msgstr ""
 #. module: base
 #: model:ir.module.category,description:base.module_category_sign
 msgid "Helps you sign and complete your documents easily."
-msgstr ""
+msgstr "Belgelerinizi kolayca imzalamanıza ve tamamlamanıza yardımcı olur."
 
 #. module: base
 #: model_terms:ir.ui.view,arch_db:base.wizard_lang_export
@@ -14687,6 +15025,8 @@ msgid ""
 "If user belongs to several groups, the results from step 2 are combined with"
 " logical OR operator"
 msgstr ""
+"Kullanıcı birden fazla gruba aitse, 2. adımdaki sonuçlar mantıksal VEYA "
+"operatörü ile birleştirilir"
 
 #. module: base
 #: model_terms:ir.actions.act_window,help:base.action_country_state
@@ -15207,7 +15547,7 @@ msgstr "Geçersiz 'gruplama' parametresi"
 #: code:addons/models.py:2120
 #, python-format
 msgid "Invalid aggregation function %r."
-msgstr ""
+msgstr "Geçersiz toplama işlevi %r."
 
 #. module: base
 #: code:addons/base/models/ir_fields.py:330
@@ -15235,7 +15575,7 @@ msgstr "Geçersiz alan %s.%s"
 #: code:addons/models.py:2110
 #, python-format
 msgid "Invalid field specification %r."
-msgstr ""
+msgstr "Geçersiz alan özellikleri %r."
 
 #. module: base
 #: sql_constraint:ir.ui.view:0
@@ -15249,7 +15589,7 @@ msgstr ""
 #. module: base
 #: sql_constraint:ir.ui.view:0
 msgid "Invalid key: QWeb view should have a key"
-msgstr ""
+msgstr "Geçersiz anahtar: QWeb görünümünde bir anahtar olmalıdır"
 
 #. module: base
 #: code:addons/base/models/ir_actions.py:140
@@ -15338,7 +15678,7 @@ msgstr "Faturalar ve Ödemeler"
 #. module: base
 #: model:ir.module.module,summary:base.module_documents_account
 msgid "Invoices from Documents"
-msgstr ""
+msgstr "Belgelerden Faturalar"
 
 #. module: base
 #: model:ir.module.module,shortdesc:base.module_account
@@ -15358,7 +15698,7 @@ msgstr "Faturalama Yönetimi"
 #. module: base
 #: model:ir.module.module,shortdesc:base.module_hw_posbox_homepage
 msgid "IoT Box Homepage"
-msgstr ""
+msgstr "IoT Kutusu Ana Sayfası"
 
 #. module: base
 #: model:ir.module.module,shortdesc:base.module_quality_mrp_iot
@@ -15368,7 +15708,7 @@ msgstr ""
 #. module: base
 #: model:ir.module.module,shortdesc:base.module_hw_posbox_upgrade
 msgid "IoTBox Software Upgrader"
-msgstr ""
+msgstr "IoTBox Yazılım Yükseltme"
 
 #. module: base
 #: model:res.country,name:base.ir
@@ -15441,7 +15781,7 @@ msgstr "İtalya - Muhasebe"
 #. module: base
 #: model:ir.module.module,shortdesc:base.module_l10n_it_edi
 msgid "Italy - E-invoicing"
-msgstr ""
+msgstr "İtalya - E-faturalama"
 
 #. module: base
 #: model:res.partner.industry,full_name:base.res_partner_industry_J
@@ -15507,7 +15847,7 @@ msgstr "K FİNANSAL VE SİGORTA FAALİYETLERİ"
 #. module: base
 #: model:ir.module.module,shortdesc:base.module_digest
 msgid "KPI Digests"
-msgstr ""
+msgstr "KPI Özetleri"
 
 #. module: base
 #: selection:ir.actions.act_window.view,view_mode:0
@@ -16023,6 +16363,8 @@ msgid ""
 "Let the system try to select the right account and/or product for your "
 "vendor bills"
 msgstr ""
+"Sistemin, satıcı faturalarınız için doğru hesabı ve / veya ürünü seçmeye "
+"çalışmasına izin verin"
 
 #. module: base
 #: model_terms:ir.ui.view,arch_db:base.onboarding_step
@@ -16116,18 +16458,18 @@ msgstr "Alan kullanımı linki"
 #. module: base
 #: model:ir.module.module,summary:base.module_pos_iot
 msgid "Link your PoS configuration with an IoT Box"
-msgstr ""
+msgstr "PoS yapılandırmanızı bir IoT Kutusu ile bağlayın"
 
 #. module: base
 #: model:ir.module.module,summary:base.module_pos_restaurant_iot
 msgid "Link your PoS configuration with an IoT Box for the restaurant"
-msgstr ""
+msgstr "PoS yapılandırmanızı restoran için bir IoT Kutusu ile bağlayın"
 
 #. module: base
 #: code:addons/base/models/ir_qweb_fields.py:629
 #, python-format
 msgid "List of contact fields to display in the widget"
-msgstr ""
+msgstr "Widget'ta görüntülenecek kişi alanlarının listesi"
 
 #. module: base
 #: model:ir.model.fields,help:base.field_ir_model_fields__modules
@@ -16798,6 +17140,8 @@ msgid ""
 "Methods that start with `get_default_` are deprecated. Override `get_values`"
 " instead(Method %s)"
 msgstr ""
+"`Get_default_` ile başlayan yöntemler kullanımdan kaldırılmıştır. Bunun "
+"yerine \"get_values\" değerini geçersiz kıl (Yöntem %s)"
 
 #. module: base
 #: code:addons/base/models/res_config.py:605
@@ -16806,6 +17150,8 @@ msgid ""
 "Methods that start with `set_` are deprecated. Override `set_values` instead"
 " (Method %s)"
 msgstr ""
+"`Set_` ile başlayan yöntemler kullanımdan kaldırılmıştır. Bunun yerine "
+"\"set_values\" değerini geçersiz kıl (Yöntem %s)"
 
 #. module: base
 #: model:ir.module.module,summary:base.module_l10n_mx_edi
@@ -19333,7 +19679,7 @@ msgstr "DPI Çıkış"
 #: code:addons/models.py:2132
 #, python-format
 msgid "Output name %r is used twice."
-msgstr ""
+msgstr "Çıkış adı %r iki kez kullanılıyor."
 
 #. module: base
 #: model:ir.model.fields,field_description:base.field_base_language_import__overwrite
@@ -19592,7 +19938,7 @@ msgstr "Yol"
 #: code:addons/base/models/ir_qweb_fields.py:224
 #, python-format
 msgid "Pattern to format"
-msgstr ""
+msgstr "Biçimlendirilecek desen"
 
 #. module: base
 #: model:ir.module.module,shortdesc:base.module_account_payment
@@ -19736,7 +20082,7 @@ msgstr "Pivot"
 #. module: base
 #: model:ir.module.module,description:base.module_l10n_pt
 msgid "Plano de contas SNC para Portugal"
-msgstr ""
+msgstr "Portekiz için SNC hesapları planı"
 
 #. module: base
 #: code:addons/base/models/ir_mail_server.py:165
@@ -19745,6 +20091,8 @@ msgid ""
 "Please configure an email on the current user to simulate sending an email "
 "message via this outgoing server"
 msgstr ""
+"Lütfen bu giden sunucu üzerinden bir e-posta mesajı göndermeyi simüle etmek "
+"için mevcut kullanıcı üzerinde bir e-posta yapılandırın"
 
 #. module: base
 #: model_terms:ir.ui.view,arch_db:base.demo_force_install_form
@@ -19752,6 +20100,8 @@ msgid ""
 "Please confirm that you want to <b>irreversibly</b> make this database a "
 "demo database."
 msgstr ""
+"Lütfen bu veritabanını <b>geri döndürülemez</b> bir şekilde bir demo "
+"veritabanı yapmak istediğinizi onaylayın."
 
 #. module: base
 #: code:addons/base/models/ir_model.py:1231

--- a/odoo/addons/base/i18n/uk.po
+++ b/odoo/addons/base/i18n/uk.po
@@ -27380,6 +27380,14 @@ msgid "The list of models that extends the current model."
 msgstr "Список моделей, що розширюють поточну."
 
 #. module: base
+#: code:addons/base/models/ir_model.py:522
+#, python-format
+msgid ""
+"The m2o field %s is required but declares its ondelete policy as being 'set "
+"null'. Only 'restrict' and 'cascade' make sense."
+msgstr ""
+
+#. module: base
 #: model:ir.model.fields,help:base.field_ir_filters__action_id
 msgid ""
 "The menu action this filter applies to. When left empty the filter applies "

--- a/odoo/addons/base/i18n/vi.po
+++ b/odoo/addons/base/i18n/vi.po
@@ -12,7 +12,7 @@
 # Martin Trigaux, 2019
 # fanha99 <fanha99@hotmail.com>, 2019
 # Thang Duong Bao <nothingctrl@gmail.com>, 2019
-# Chinh Chinh <trinhttp@trobz.com>, 2019
+# Trinh Tran Thi Phuong <trinhttp@trobz.com>, 2019
 # Dao Nguyen <trucdao.uel@gmail.com>, 2019
 # Nancy Momoland <thanhnguyen.icsc@gmail.com>, 2019
 # Duy BQ <duybq86@gmail.com>, 2020
@@ -25831,6 +25831,14 @@ msgstr "Tài khoản người dùng nội bộ có liên kết với liên lạc
 #: model:ir.model.fields,help:base.field_ir_model__inherited_model_ids
 msgid "The list of models that extends the current model."
 msgstr "Danh sách các model mà mở rộng model hiện hành."
+
+#. module: base
+#: code:addons/base/models/ir_model.py:522
+#, python-format
+msgid ""
+"The m2o field %s is required but declares its ondelete policy as being 'set "
+"null'. Only 'restrict' and 'cascade' make sense."
+msgstr ""
 
 #. module: base
 #: model:ir.model.fields,help:base.field_ir_filters__action_id

--- a/odoo/addons/base/i18n/zh_CN.po
+++ b/odoo/addons/base/i18n/zh_CN.po
@@ -30,7 +30,6 @@
 # 老窦 北京 <2662059195@qq.com>, 2018
 # Lisa Zhang <lzh@odoo.com>, 2018
 # Shane Tsoi <sso@odoo.com>, 2018
-# Henry Zhou <zhouhenry@live.com>, 2018
 # ChinaMaker <liuct@chinamaker.net>, 2018
 # KWOKYUK CHEUNG <cheungkwokyuk@gmail.com>, 2018
 # 海飞 Lu <330472962@qq.com>, 2018
@@ -70,6 +69,7 @@
 # Jerry Pan <panjianyu@inspur.com>, 2019
 # liAnGjiA <liangjia@qq.com>, 2020
 # as co02 <asco02@163.com>, 2020
+# Henry Zhou <zhouhenry@live.com>, 2020
 # 
 msgid ""
 msgstr ""
@@ -77,7 +77,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-12-10 14:44+0000\n"
 "PO-Revision-Date: 2018-08-24 09:14+0000\n"
-"Last-Translator: as co02 <asco02@163.com>, 2020\n"
+"Last-Translator: Henry Zhou <zhouhenry@live.com>, 2020\n"
 "Language-Team: Chinese (China) (https://www.transifex.com/odoo/teams/41243/zh_CN/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -18956,14 +18956,7 @@ msgstr "浏览数量"
 #. module: base
 #: model_terms:ir.actions.act_window,help:base.open_module_tree
 msgid "No website module found!"
-msgstr ""
-"红尘来呀来\n"
-"\n"
-"去呀去 都是一场梦\n"
-"\n"
-"红尘来呀来\n"
-"\n"
-"去呀去也空！"
+msgstr "没发现网站模块！"
 
 #. module: base
 #: model:ir.model.fields,field_description:base.field_ir_model_data__noupdate
@@ -26426,6 +26419,14 @@ msgstr "负责此联系人的内部用户。"
 #: model:ir.model.fields,help:base.field_ir_model__inherited_model_ids
 msgid "The list of models that extends the current model."
 msgstr "扩展当前模型清单。"
+
+#. module: base
+#: code:addons/base/models/ir_model.py:522
+#, python-format
+msgid ""
+"The m2o field %s is required but declares its ondelete policy as being 'set "
+"null'. Only 'restrict' and 'cascade' make sense."
+msgstr ""
 
 #. module: base
 #: model:ir.model.fields,help:base.field_ir_filters__action_id

--- a/odoo/addons/base/i18n/zh_TW.po
+++ b/odoo/addons/base/i18n/zh_TW.po
@@ -25772,6 +25772,14 @@ msgid "The list of models that extends the current model."
 msgstr "擴展目前模型的模型清單。"
 
 #. module: base
+#: code:addons/base/models/ir_model.py:522
+#, python-format
+msgid ""
+"The m2o field %s is required but declares its ondelete policy as being 'set "
+"null'. Only 'restrict' and 'cascade' make sense."
+msgstr ""
+
+#. module: base
 #: model:ir.model.fields,help:base.field_ir_filters__action_id
 msgid ""
 "The menu action this filter applies to. When left empty the filter applies "

--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -554,6 +554,16 @@ class IrModelFields(models.Model):
                     'message': _("The table %r if used for other, possibly incompatible fields.") % self.relation_table,
                 }}
 
+    @api.onchange('required', 'ttype', 'on_delete')
+    def _onchange_required(self):
+        for rec in self:
+            if rec.ttype == 'many2one' and rec.required and rec.on_delete == 'set null':
+                return {'warning': {'title': _("Warning"), 'message': _(
+                    "The m2o field %s is required but declares its ondelete policy "
+                    "as being 'set null'. Only 'restrict' and 'cascade' make sense."
+                    % (rec.name)
+                )}}
+
     def _get(self, model_name, name):
         """ Return the (sudoed) `ir.model.fields` record with the given model and name.
         The result may be an empty recordset if the model is not found.

--- a/odoo/addons/base/models/ir_translation.py
+++ b/odoo/addons/base/models/ir_translation.py
@@ -752,7 +752,7 @@ class IrTranslation(models.Model):
             self.insert_missing(fld, rec)
 
         action = {
-            'name': 'Translate',
+            'name': _('Translate'),
             'res_model': 'ir.translation',
             'type': 'ir.actions.act_window',
             'view_mode': 'tree',

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -591,16 +591,11 @@ class ChromeBrowser():
     def _find_websocket(self):
         version = self._json_command('version')
         self._logger.info('Browser version: %s', version['Browser'])
-        try:
-            infos = self._json_command('')[0]  # Infos about the first tab
-        except IndexError:
-            self._logger.warning('No tab found in Chrome')
-            self.stop()
-            raise unittest.SkipTest('No tab found in Chrome')
+        infos = self._json_command('', get_key=0)  # Infos about the first tab
         self.ws_url = infos['webSocketDebuggerUrl']
         self._logger.info('Chrome headless temporary user profile dir: %s', self.user_data_dir)
 
-    def _json_command(self, command, timeout=3):
+    def _json_command(self, command, timeout=3, get_key=None):
         """
         Inspect dev tools with get
         Available commands:
@@ -614,21 +609,31 @@ class ChromeBrowser():
         """
         self._logger.info("Issuing json command %s", command)
         command = os.path.join('json', command).strip('/')
+        url = werkzeug.urls.url_join('http://%s:%s/' % (HOST, self.devtools_port), command)
+        self._logger.info('Url : %s', url)
+        delay = 0.1
         while timeout > 0:
             try:
-                url = werkzeug.urls.url_join('http://%s:%s/' % (HOST, self.devtools_port), command)
-                self._logger.info('Url : %s', url)
                 r = requests.get(url, timeout=3)
                 if r.ok:
-                    return r.json()
-                return {'status_code': r.status_code}
+                    res = r.json()
+                    if get_key is None:
+                        return res
+                    else:
+                        return res[get_key]
             except requests.ConnectionError:
-                time.sleep(0.1)
-                timeout -= 0.1
+                message = 'Connection Error while trying to connect to Chrome debugger'
             except requests.exceptions.ReadTimeout:
+                message = 'Connection Timeout while trying to connect to Chrome debugger'
                 break
-        self._logger.error('Could not connect to chrome debugger')
-        raise unittest.SkipTest("Cannot connect to chrome headless")
+            except (KeyError, IndexError):
+                message = 'Key "%s" not found in json result "%s" after connecting to Chrome debugger' % (get_key, res)
+            time.sleep(delay)
+            timeout -= delay
+            delay = delay * 1.5
+        self._logger.error(message)
+        self.stop()
+        raise unittest.SkipTest("Error during Chrome headless connection")
 
     def _open_websocket(self):
         self.ws = websocket.create_connection(self.ws_url)


### PR DESCRIPTION
**[FIX] website: All menu translations on Website**

Currently, if we have multiple menus that its parent is not the `main_menu` the translation is no going to be loaded on the website.
When the parent of a menu is not `website.main_menu` and with the conditions that right now are set `root_menu.parent_id IS NULL` and `o_menu.parent_id = default_menu.id`  the translation will not be set.

For example, we have the following menus:
    -  Menu_1 = Default Menu (`website.main_menu` )
    - Menu_2 = Services  (parent_id = Menu_1)
    - Menu_3 = About Us   (parent_id = Menu_1)
    - Menu_4 = Apps    (parent_id = Menu_2)

Without the change, the translations of the menus "Services" AND "About us" will be set but not the translation for the menu Apps because its parent instead of being the Menu_1(Default menu) is the Menu_2 ("Services") and the parent of its parent is not NULL but the Menu_2.

**AFTER**
I did a Dummy [PR](https://github.com/odoo/odoo/pull/50883) on Odoo where I added 3 menus to the website "Services", "Apps" and "About us". The parent of "Services" and "About us" is `website.main_menu` and the parent od the menu "Apps" is "Services"

And the following results were: "Services" and "About us" were translated to "Servicios" and "Acerca de Nosotros" respectively  but the menu "Apps" was not translated to "Aplicaciones"
![Task 39008 - Runbot Dummy not translated](https://user-images.githubusercontent.com/26889951/81455416-cbc22480-9154-11ea-82c3-e81538ee5d5e.png)
[Runbot](https://2572447-50883-444836.runbot23.odoo.com/es_ES/?db=2572447-50883-444836-all)

On the search for the translations with the current SQL sentence, we only found the "Services" and "About us" menus.
![Website Menu Translations original SQL](https://user-images.githubusercontent.com/26889951/81453832-37ee5980-9150-11ea-987d-9458db18d5a8.jpg)

**BEFORE**
With this change, the translations of all the website menus of the modules will be set, and not only the ones that its `parent_id` is the default_menu.

![Task 39008 - Dummy Translated](https://user-images.githubusercontent.com/26889951/81458631-f0bc9480-9160-11ea-9fd0-a2053d6f713c.png)
On the search for the translations with the new SQL sentence, the Apps menu is found.
![Task 39008 - New Sentence SQL](https://user-images.githubusercontent.com/26889951/81603421-ee8e4c00-9393-11ea-9f00-8a6f64c4d518.png)


opw-2209864

Signed-off-by: Carmen Miranda (CarmenMiranda) <carmen@vauxoo.com>
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr