### PR TITLE
[IMP] models.py: Backporting changes done on method exists() on v13.0…

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -4338,15 +4338,7 @@ class BaseModel(MetaModel('DummyModel', (object,), {'_register': False})):
         query = """SELECT id FROM "%s" WHERE id IN %%s""" % self._table
         self._cr.execute(query, [tuple(ids)])
         ids = [r[0] for r in self._cr.fetchall()]
-        existing = self.browse(ids + new_ids)
-        if len(existing) < len(self):
-            # mark missing records in cache with a failed value
-            exc = MissingError(
-                _("Record does not exist or has been deleted.")
-                + '\n\n({} {}, {} {})'.format(_('Records:'), (self - existing).ids[:6], _('User:'), self._uid)
-            )
-            self.env.cache.set_failed(self - existing, self._fields.values(), exc)
-        return existing
+        return self.browse(ids + new_ids)
 
     @api.multi
     def _check_recursion(self, parent=None):


### PR DESCRIPTION
… to avoid raising an error when a record doesn't exists which also didn't show which model was that record from, which were applied on commit 9920f20e4c7753bc17bea71dea3a90f7de687196.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
