### PR TITLE
[REF] sql_db: Add traceback stack if there is a exeception running a query

### DIFF
--- a/odoo/sql_db.py
+++ b/odoo/sql_db.py
@@ -13,6 +13,7 @@ from functools import wraps
 import itertools
 import logging
 import time
+import traceback
 import uuid
 
 import psycopg2
@@ -225,7 +226,9 @@ class Cursor(object):
             res = self._obj.execute(query, params)
         except Exception as e:
             if self._default_log_exceptions if log_exceptions is None else log_exceptions:
-                _logger.error("bad query: %s\nERROR: %s", ustr(self._obj.query or query), e)
+                tcbk = traceback.extract_stack()
+                tcbk_str = "Traceback (most recent call last):\n%s" % "\n,".join(map(lambda a: repr(a), tcbk))
+                _logger.error("bad query: %s\nERROR: %s\n%s", ustr(self._obj.query or query), e, tcbk_str)
             raise
 
         # simple query count is always computed


### PR DESCRIPTION
e.g. output:
 - ![Screen Shot 2020-05-22 at 15 14 11](https://user-images.githubusercontent.com/6644187/82706299-e8735780-9c3e-11ea-9014-57a168b444a3.png)


UPDATED:
 - [REF] sql_db.py: Making sentry tags to group by query and trace stack