### PR TITLE
[FIX] l10n_mx: accounts in template were updated.

### DIFF
--- a/addons/l10n_mx/__manifest__.py
+++ b/addons/l10n_mx/__manifest__.py
@@ -8,7 +8,7 @@
 
 {
     "name": "Mexico - Accounting",
-    "version": "2.0",
+    "version": "2.1",
     "author": "Vauxoo",
     'category': 'Localization',
     "description": """

--- a/addons/l10n_mx/migrations/12.0.2.1/pre-migration.py
+++ b/addons/l10n_mx/migrations/12.0.2.1/pre-migration.py
@@ -1,0 +1,21 @@
+from odoo import SUPERUSER_ID, api
+
+
+def mx_update_account_type(cr):
+    with api.Environment.manage():
+        env = api.Environment(cr, SUPERUSER_ID, {})
+        account = env.ref('l10n_mx.cuenta108_01', False)
+        if account and account.user_type_id == env.ref('account.data_account_type_receivable'):
+            account.write({'user_type_id': env.ref('account.data_account_type_current_assets').id})
+        account = env.ref('l10n_mx.cuenta108_02', False)
+        if account and account.user_type_id == env.ref('account.data_account_type_receivable'):
+            account.write({'user_type_id': env.ref('account.data_account_type_current_assets').id})
+        account = env.ref('l10n_mx.cuenta801_01', False)
+        if account and account.user_type_id == env.ref('account.data_unaffected_earnings'):
+            account.write({'user_type_id': env.ref('account.data_account_type_expenses').id})
+
+
+def migrate(cr, version):
+    if not version:
+        return
+    mx_update_account_type(cr)


### PR DESCRIPTION
In the commit
https://github.com/odoo/odoo/commit/632cc5417796ff375d47767fd7cdb358a5d4ce94
was changed the account type in some accounts, and that was correct. But
the account.account.template in Odoo is not updated on instances with
l10n_mx installed. Then when is created a new company for Mexico and is
installed the Mexican chart template fails because the type was not
updated.

Fixes error with double account to unaffected earnings

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr


More info:

[Error Instalación Localización (#10279)](https://www.vauxoo.com/web#id=10279&action=367&active_id=1&model=helpdesk.ticket&view_type=form&menu_id=249)