### PR TITLE
[FIX] account: missing sudo at resolve_2many_commands

### DIFF
--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -568,7 +568,7 @@ class account_payment(models.Model):
     @api.model
     def default_get(self, fields):
         rec = super(account_payment, self).default_get(fields)
-        invoice_defaults = self.resolve_2many_commands('invoice_ids', rec.get('invoice_ids'))
+        invoice_defaults = self.sudo().resolve_2many_commands('invoice_ids', rec.get('invoice_ids'))
         if invoice_defaults and len(invoice_defaults) == 1:
             invoice = invoice_defaults[0]
             rec['communication'] = invoice['reference'] or invoice['name'] or invoice['number']


### PR DESCRIPTION
Main
-

[FIX] account: account.payment as resolve_2many_commands is resolving
data from the invoice, and no specific fields are passed to fetch the
data that is actually required and when you have other models in the
Invoice Model for which the user does not have permissions. It is
raising errors because of the lack of permissions but those objects in
the invoice you are not willing to provide any permission because those
records are not relevant for the user making the payment.

Odoo's PR
-
https://github.com/odoo/odoo/pull/53772

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
