### PR TITLE
[FIX] account: Do not try to reconcile a CABA Entry line if already reconciled

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -1886,7 +1886,7 @@ class AccountPartialReconcile(models.Model):
                                 'partner_id': line.partner_id.id,
                                 'journal_id': newly_created_move.journal_id.id,
                             })
-                            if line.account_id.reconcile:
+                            if line.account_id.reconcile and not line.reconciled:
                                 #setting the account to allow reconciliation will help to fix rounding errors
                                 to_clear_aml |= line
                                 to_clear_aml.reconcile()


### PR DESCRIPTION
Odoo PR
-
https://github.com/odoo/odoo/pull/55713

Backport of
-
https://github.com/odoo/odoo/pull/33585

Main
-----

For Huge Amount Invoices with small residual being paid and the Invoice and the initial payment which almost paid, the invoice in full can render the reconciliation of the Tax Entry Lines as fully reconciled. And when the small part to be reconciled is tried to be closed a traceback is raised because the line being reconciled in CABA entry is dimmed as reconciled.

Conclusion
----------

There are cases where invoices with tiny residuals in multi-currency cannot be processed and fully paid, because there are CABA entry lines being created and computed as reconciled.

Description
-----------

In case of multi-currency transactions where CABA Journal Entries are involved, there could be
a case where ,in Mexican Localization, so far, a small entry line cannot be reconciled with their counterpart because the previous counterparts are already reconciled. (Though this is still unproved in a lab, i.e. UnitTest, can be seen in the wild, i.e. Customer's Production Instance) 

The following is a hypothetical case yet to be proven. `Yet this has been spotted several times on the wild`

        Test to validate tax effectively receivable

        My company currency is MXN.
        Invoice issued two days ago in USD at a rate => 1MXN = 0.80 USD.
        Booked like:
            Receivable          1450                1160    USD
                Revenue                 1250       -1000    USD
                Taxes to Collect         200        -160    USD (Hypothetical Fully Reconciled with A1)
        Payment issued today in USD at a rate => 1 MXN = 1.25 USD.
        Booked like:
            Bank                 927.99                1159.99    USD
                Receivable               927.99       -1159.99    USD

        And a Tax Cash Basis Entry is generated for the ratio being paid
        Booked like:
            Tax Base Account     800                1000.00    USD (sometimes this base can be rounded up and instead of being 999.99 it ends up as 1000.00 which leads to taxes to be as fully reconciled)
                Tax Base Account         800       -1000.00    USD
            Taxes to Collect     128                 160    USD (Hypothetical Fully Reconciled with A1)
                Taxes to Paid            128        -160    USD

        I will neglect to depict here the FX Journal Entry for Tax to Collect account for the hypothetical reconciliation A1. And any other FX Journal Entries.

        At this moment Invoice has a USD 0.01 residual which on same date will be tried to write-off manually.

            Write-off              0.01                   0.01    USD
                Receivable                 0.01          -0.01    USD

        At this moment Invoice has a USD 0.01 residual which on same date will be tried to write-off manually.
        This small amount will create while running in run-time following CABA Journal Entry:
            Tax Base Account     0.01                0.01    USD (sometimes this base can be rounded up and instead of being 0.00 it ends up as 0.01 which leads to taxes to be created and be tried to reconcile)
                Tax Base Account         0.01       -0.01    USD
            Taxes to Collect     0.01                 0.01    USD (Hypothetical This will be tried to reconcile with the items in Full Reconciliation A1 but raise an error)
                Taxes to Paid            0.01        -0.01    USD


This PR is related to the way reconciliation is performed as shown in https://github.com/odoo/odoo/pull/41512

This is shown to at https://github.com/odoo/odoo/issues/37469

OPW
---
2177558

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
