### PR TITLE
[FIX] account: `_create_tax_basis_move` is not setting default type

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -4450,6 +4450,7 @@ class AccountPartialReconcile(models.Model):
                               'for this company: "%s" \nConfigure it in Accounting/Configuration/Settings') %
                             (self.company_id.name))
         move_vals = {
+            'type': 'entry',
             'journal_id': self.company_id.tax_cash_basis_journal_id.id,
             'tax_cash_basis_rec_id': self.id,
             'ref': self.credit_move_id.move_id.name if self.credit_move_id.payment_id else self.debit_move_id.move_id.name,


### PR DESCRIPTION
Main
-
[FIX] account: `_create_tax_basis_move` method is not setting default
type in the Journal Entry.
This was dug out when running some unit tests related to a CABA process.

Task
-
[Task#41135](https://www.vauxoo.com/web#id=41135&action=470&model=project.task&view_type=form&menu_id=317)

Related to
-

This is related to the [migration of Gandalf to version 13](https://git.vauxoo.com/vauxoo/gandalf/-/merge_requests/23).


PR to Odoo
-

https://github.com/odoo/odoo/pull/57467

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
