### PR TITLE
[FIX] website: Proper management of validation errors in frontend

### DIFF
--- a/addons/website/static/src/js/content/website_root.js
+++ b/addons/website/static/src/js/content/website_root.js
@@ -262,9 +262,9 @@ var WebsiteRoot = BodyManager.extend({
         })
         .fail(function (err, data) {
             return new Dialog(self, {
-                title: data.data ? data.data.arguments[0] : "",
+                title: data.data ? data.data.arguments[0] : err.data.name,
                 $content: $('<div/>', {
-                    html: (data.data ? data.data.arguments[1] : data.statusText)
+                    html: (data.data ? data.data.arguments[1] : err.data.message)
                         + '<br/>'
                         + _.str.sprintf(
                             _t('It might be possible to edit the relevant items or fix the issue in <a href="%s">the classic Odoo interface</a>'),

--- a/doc/cla/corporate/vauxoo.md
+++ b/doc/cla/corporate/vauxoo.md
@@ -49,3 +49,4 @@ Arturo Flores arturo@vauxoo.com https://github.com/umiphos
 Deivis Laya deivis@vauxoo.com https://github.com/deivislaya
 Yennifer Santiago yennifer@vauxoo.com https://github.com/ysantiago
 Alejandro Santillan asantillan@vauxoo.com https://github.com/R4Alex
+Williams Estrada williams@vauxoo.com https://github.com/WR-96


### PR DESCRIPTION
### Description of the issue/feature this PR addresses:
[FIX] website: Proper management of validation errors in frontend

### Current behavior before PR:
We can suppose the case where we need to put any kind of validation,
constraint or error, at the moment of publishing an element on the
website the error message shown doesn't include the original text of
the corresponding validation but it shows the text 'undefined' instead
of a human-readable text.
![photo_2020-10-14_14-36-51](https://user-images.githubusercontent.com/19438757/96075313-62b3ab00-0e70-11eb-98e7-4bfc41c82be7.jpg)

### Desired behavior after PR is merged:
After this change instead of showing the 'undefined' text the 'raise'
message returned by the server is correctly displayed, with an
appropriate title that allows the user to know what kind of validation
error is actually failing, making it easier to take a decision to the user.

![Screenshot_2020-10-14_22-54](https://user-images.githubusercontent.com/19438757/96075368-81b23d00-0e70-11eb-8a1a-df06490f0562.png)

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr


Odoo PR: https://github.com/odoo/odoo/pull/60041