### PR TITLE
[ADD] product: New Key on the method `_compute_price_rule`

### DIFF
--- a/addons/product/models/product_pricelist.py
+++ b/addons/product/models/product_pricelist.py
@@ -153,7 +153,9 @@ class Pricelist(models.Model):
             'AND (item.pricelist_id = %s) '
             'AND (item.date_start IS NULL OR item.date_start<=%s) '
             'AND (item.date_end IS NULL OR item.date_end>=%s)'
-            'ORDER BY item.applied_on, item.min_quantity desc, categ.complete_name desc, item.id desc',
+            'AND (item.active = TRUE)'
+            'ORDER BY item.applied_on, item.min_quantity desc, item.sequence asc, categ.complete_name desc, '
+            'item.id desc',
             (prod_tmpl_ids, prod_ids, categ_ids, self.id, date, date))
         # NOTE: if you change `order by` on that query, make sure it matches
         # _order from model to avoid inconstencies and undeterministic issues.
@@ -180,7 +182,7 @@ class Pricelist(models.Model):
 
             # if Public user try to access standard price from website sale, need to call price_compute.
             # TDE SURPRISE: product can actually be a template
-            price = product.price_compute('list_price')[product.id]
+            price = 0.0
 
             price_uom = self.env['uom.uom'].browse([qty_uom_id])
             for rule in items:
@@ -208,8 +210,11 @@ class Pricelist(models.Model):
                         continue
 
                 if rule.base == 'pricelist' and rule.base_pricelist_id:
-                    price_tmp = rule.base_pricelist_id._compute_price_rule([(product, qty, partner)], date, uom_id)[product.id][0]  # TDE: 0 = price, 1 = rule
+                    price_tmp = rule.base_pricelist_id.with_context(other_pricelist=True)._compute_price_rule(
+                        [(product, qty, partner)])[product.id][0]  # TDE: 0 = price, 1 = rule
                     price = rule.base_pricelist_id.currency_id._convert(price_tmp, self.currency_id, self.env.user.company_id, date, round=False)
+                    if not price:
+                        continue
                 else:
                     # if base option is public price take sale price else cost price of product
                     # price_compute returns the price in the context UoM, i.e. qty_uom_id
@@ -226,6 +231,11 @@ class Pricelist(models.Model):
                 else:
                     cur = product.currency_id
                 price = cur._convert(price, self.currency_id, self.env.user.company_id, date, round=False)
+
+            if (not price and not self.env.context.get('other_pricelist')
+               and not (suitable_rule and suitable_rule.compute_price == 'percentage'
+                        and suitable_rule.percent_price != 100)):
+                price = product.price_compute('list_price')[product.id]
 
             results[product.id] = (price, suitable_rule and suitable_rule.id or False)
 
@@ -364,11 +374,15 @@ class ResCountryGroup(models.Model):
 class PricelistItem(models.Model):
     _name = "product.pricelist.item"
     _description = "Pricelist Item"
-    _order = "applied_on, min_quantity desc, categ_id desc, id desc"
+    _order = "applied_on, min_quantity desc, sequence asc, categ_id desc, id desc"
     # NOTE: if you change _order on this model, make sure it matches the SQL
     # query built in _compute_price_rule() above in this file to avoid
     # inconstencies and undeterministic issues.
 
+    active = fields.Boolean(
+        default=True,
+        help="Lines in Archived status will not apply on the Purchase/Sale.")
+    sequence = fields.Integer(default=5)
     product_tmpl_id = fields.Many2one(
         'product.template', 'Product Template', ondelete='cascade',
         help="Specify a template if this rule only applies to one product template. Keep empty otherwise.")

--- a/addons/product/views/product_pricelist_views.xml
+++ b/addons/product/views/product_pricelist_views.xml
@@ -35,6 +35,7 @@
                             <field name="min_quantity"/>
                             <field name="date_start"/>
                             <field name="date_end"/>
+                            <field name="sequence"/>
                         </group>
                     </group>
                     <separator string="Price Computation"/>
@@ -153,6 +154,7 @@
                             <separator string="Pricelist Items"/>
                             <field name="item_ids" nolabel="1" context="{'default_base':'list_price'}">
                                 <tree string="Pricelist Items">
+                                    <field name="sequence" widget="handle"/>
                                     <field name="name" string="Applicable On"/>
                                     <field name="min_quantity"/>
                                     <field name="date_start"/>


### PR DESCRIPTION
Creating a new key 'rule_%i' (%i == product.id) to send the rule that give us the rule where we obtain the price.

For example: If we have a priceslit "A" with an item (item_1) that have the price set (supplierinfo or fixed), and we have a pricelist "B" with the pricelist "A" set as item (item_2). 
The suitable rule here will be "item_2" but we want to know the exact rule that it gave us the price which was the "item_1".

So in this new key, we are returning as tuple the rule "item_1" and a 0 (to avoid problems on others methods were this method is called).

But if we don't have this example and we only have the pricelist "A" we are returning the suitable rule which in this case will be the "item_1".




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
