### PR TITLE
NO-MERGE [SEUDO-FIX] base: qweb IndexError - vx#12275

### DIFF
--- a/odoo/addons/base/models/qweb.py
+++ b/odoo/addons/base/models/qweb.py
@@ -339,7 +339,7 @@ class QWeb(object):
 
         # return the wrapped function
 
-        def _compiled_fn(self, append, values):
+        def _compiled_fn(self, append, values, attemp=0):
             log = {'last_path_node': None}
             new = self.default_values()
             new.update(values)
@@ -347,6 +347,15 @@ class QWeb(object):
                 return compiled(self, append, new, options, log)
             except (QWebException, TransactionRollbackError) as e:
                 raise e
+            except IndexError as ie:
+                if attemp <= 3:
+                    # TODO: Seudo-fix vx#12275
+                    # I don't know why just the first time is reproducing that error
+                    # This ugly-patch is fixing it for now
+                    # but it is not the final solution
+                    # but we need go production right now!
+                    attemp += 1
+                    _compiled_fn(self, append, values, attemp=attemp)
             except Exception as e:
                 path = log['last_path_node']
                 element, document = self.get_template(template, options)


### PR DESCRIPTION
Printing a report PDF the first time the following error is reproduced:

```txt
    Odoo Server Error
    Traceback (most recent call last):
    File "/home/odoo/instance/odoo/odoo/addons/base/models/qweb.py", line 347, in _compiled_fn
        return compiled(self, append, new, options, log)
    File "<template>", line 1, in template_account_report_invoice_document_489
    File "<template>", line 2, in body_call_content_488
    File "src/lxml/lxml.etree.pyx", line 1192, in lxml.etree._Element.__nonzero__ (src/lxml/lxml.etree.c:54887)
    File "/usr/lib/python3.6/warnings.py", line 99, in _showwarnmsg
        msg.file, msg.line)
    File "/usr/local/lib/python3.6/dist-packages/PyPDF2/pdf.py", line 1069, in _showwarning
        file.write(formatWarning(message, category, filename, lineno, line))
    File "/usr/local/lib/python3.6/dist-packages/PyPDF2/utils.py", line 69, in formatWarning
        file = filename.replace("/", "\\").rsplit("\\", 1)[1] # find the file name
    IndexError: list index out of range

    During handling of the above exception, another exception occurred:

    Traceback (most recent call last):
    File "/home/odoo/instance/odoo/addons/web/controllers/main.py", line 1679, in report_download
        response = self.report_routes(reportname, docids=docids, converter=converter)
    File "/home/odoo/instance/odoo/odoo/http.py", line 519, in response_wrap
        response = f(*args, **kw)
    File "/home/odoo/instance/odoo/addons/web/controllers/main.py", line 1620, in report_routes
        pdf = report.with_context(context).render_qweb_pdf(docids, data=data)[0]
    File "/home/odoo/instance/odoo/odoo/addons/base/models/ir_actions_report.py", line 727, in render_qweb_pdf
        html = self.with_context(context).render_qweb_html(res_ids, data=data)[0]
    File "/home/odoo/instance/extra_addons/enterprise/web_studio/models/ir_actions_report.py", line 18, in render_qweb_html
        return super(IrActionsReport, self).render_qweb_html(docids, data)
    File "/home/odoo/instance/odoo/odoo/addons/base/models/ir_actions_report.py", line 767, in render_qweb_html
        return self.render_template(self.report_name, data), 'html'
    File "/home/odoo/instance/odoo/odoo/addons/base/models/ir_actions_report.py", line 540, in render_template
        return view_obj.render_template(template, values)
    File "/home/odoo/instance/odoo/odoo/addons/base/models/ir_ui_view.py", line 1338, in render_template
        return self.browse(self.get_view_id(template)).render(values, engine)
    File "/home/odoo/instance/odoo/addons/website/models/ir_ui_view.py", line 314, in render
        return super(View, self).render(values, engine=engine, minimal_qcontext=minimal_qcontext)
    File "/home/odoo/instance/odoo/addons/web_editor/models/ir_ui_view.py", line 29, in render
        return super(IrUiView, self).render(values=values, engine=engine, minimal_qcontext=minimal_qcontext)
    File "/home/odoo/instance/odoo/odoo/addons/base/models/ir_ui_view.py", line 1347, in render
        return self.env[engine].render(self.id, qcontext)
    File "/home/odoo/instance/extra_addons/enterprise/web_studio/models/ir_qweb.py", line 43, in render
        return super(IrQWeb, self).render(template, values=values, **options)
    File "/home/odoo/instance/odoo/odoo/addons/base/models/ir_qweb.py", line 59, in render
        result = super(IrQWeb, self).render(id_or_xml_id, values=values, **context)
    File "/home/odoo/instance/odoo/odoo/addons/base/models/qweb.py", line 275, in render
        self.compile(template, options)(self, body.append, values or {})
    File "/home/odoo/instance/odoo/odoo/addons/base/models/qweb.py", line 349, in _compiled_fn
        raise e
    File "/home/odoo/instance/odoo/odoo/addons/base/models/qweb.py", line 347, in _compiled_fn
        return compiled(self, append, new, options, log)
    File "<template>", line 1, in template_970_337
    File "<template>", line 2, in body_call_content_336
    File "<template>", line 3, in foreach_335
    File "/home/odoo/instance/odoo/odoo/addons/base/models/qweb.py", line 354, in _compiled_fn
        raise QWebException("Error to render compiling AST", e, path, node and etree.tostring(node[0], encoding='unicode'), name)
    odoo.addons.base.models.qweb.QWebException: list index out of range
    Traceback (most recent call last):
    File "/home/odoo/instance/odoo/odoo/addons/base/models/qweb.py", line 347, in _compiled_fn
        return compiled(self, append, new, options, log)
    File "<template>", line 1, in template_account_report_invoice_document_489
    File "<template>", line 2, in body_call_content_488
    File "src/lxml/lxml.etree.pyx", line 1192, in lxml.etree._Element.__nonzero__ (src/lxml/lxml.etree.c:54887)
    File "/usr/lib/python3.6/warnings.py", line 99, in _showwarnmsg
        msg.file, msg.line)
    File "/usr/local/lib/python3.6/dist-packages/PyPDF2/pdf.py", line 1069, in _showwarning
        file.write(formatWarning(message, category, filename, lineno, line))
    File "/usr/local/lib/python3.6/dist-packages/PyPDF2/utils.py", line 69, in formatWarning
        file = filename.replace("/", "\\").rsplit("\\", 1)[1] # find the file name
    IndexError: list index out of range

    Error to render compiling AST
    IndexError: list index out of range
    Template: account.report_invoice_document
    Path: /templates/t/t/div/table[2]/tbody/tr/td[2]/span
    Node: <span t-if="xml"><p t-esc="xml.get('LugarExpedicion')"/></span>
```

I have connected directly to odoo port (without nginx)
Using workers=0 (without workers)

Opening the invoice id 239645 and printing the invoice with or without payments
You will reproduce the error

Reboot the odoo-bin service and you can reproduce it again.
Just the first time or after too many times.

I have created the following odoorpc script:

```python
    INVOICE_ID = 239645

    odoo = odoorpc.ODOO(SERVER, port=PORT)
    odoo.login(DB_NAME, USER, PASSWD)
    env = odoo.env

    for i in range(20):
        report1 = odoo.report.download('account.report_invoice_with_payments', [INVOICE_ID])
        report2 = odoo.report.download('account.report_invoice', [INVOICE_ID])
        # print(type(report1), type(report2))
        time.sleep(1)
```

Running it after a reboot it is reproducing the error
But running the same script 2 times is not reproducing it

If you reboot again, so you can reproduce it again WTF

So, I just added the following a pdb in the following line:
 - https://github.com/odoo/odoo/blob/2443d21184e7f4481ad98cd2de24b6b96a572008/odoo/addons/base/models/qweb.py#L351

In order to catch the parameters where it is raising the error.

The weird part is that running the same method again, the error is not reproduced:
  - `compiled(self, append, new, options, log)`

I know WTF!

I don't know what is the reason of this issue, but this ugly SO UGLY patch is the fast solution I found

[vx#12275](https://www.vauxoo.com/web#id=12275&action=367&active_id=1&model=helpdesk.ticket&view_type=form&menu_id=249)

It will be used just for absa as patches.txt