### PR TITLE
[REF] website: Speedup website (when a theme is installed)

### DIFF
--- a/addons/website/models/ir_attachment.py
+++ b/addons/website/models/ir_attachment.py
@@ -2,7 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import logging
-from odoo import fields, models, api
+from odoo import fields, models, api, tools
 from odoo.exceptions import UserError
 from odoo.tools.translate import _
 _logger = logging.getLogger(__name__)
@@ -41,3 +41,9 @@ class Attachment(models.Model):
         extra_domain = (extra_domain or []) + website.website_domain()
         order = ('website_id, %s' % order) if order else 'website_id'
         return super(Attachment, self).get_attachment_by_key(key, extra_domain, order)
+
+    def init(self):
+        res = super(Attachment, self).init()
+        # ir_http._xmlid_to_obj is using this index for multi-website
+        tools.create_index(self._cr, 'ir_attachment_key_website_idx', self._table, ['key', 'website_id'])
+        return res


### PR DESCRIPTION
### Description of the issue/feature this PR addresses:
After install a website theme the webpage is slower

It is because a new query is executed to get website attachments (1)

This query is so slow and it is executed each time the website is opened

### Current behavior before PR:
Running the following query:
```sql
    EXPLAIN (ANALYZE, VERBOSE, BUFFERS)
    SELECT id FROM ir_attachment WHERE active=True AND key = 'SOMETHING' AND website=1
```

The result before index:
```sql
    Seq Scan on ir_attachment ...
    Execution Time: 21.320 ms
```

### Desired behavior after PR is merged:
The result after index (key, website):
```sql
    Bitmap Heap Scan on ir_attachment ...
    Execution Time: 0.111 ms
```

192x faster

The website must be as fast as possible so this index make sense

(1) https://github.com/odoo/odoo/blob/d00a832952a0b9d2276a1f057ee10152b0c7f5bc/addons/website/models/ir_http.py#L332

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
