### PR TITLE
[REM] base: Removed login_key constraint to avoid errors on log

### DIFF
--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -257,10 +257,6 @@ class Users(models.Model):
     name = fields.Char(related='partner_id.name', inherited=True, readonly=False)
     email = fields.Char(related='partner_id.email', inherited=True, readonly=False)
 
-    _sql_constraints = [
-        ('login_key', 'UNIQUE (login)',  'You can not have two users with the same login !')
-    ]
-
     def init(self):
         cr = self.env.cr
 


### PR DESCRIPTION
When we execute `-u all` to update all modules, Odoo loads the
constraints as it goes through the modules, without taking into account
that the constraints might be removed or updated in a child module.

In this case the `base` module adds a constraint to make the `login`
field unique. Later, the `website` module replaces this constraint by
making unique the combination of `login` and `website_id`, to allow
users to register in the different websites.

The first time, and while there are no users registered on multiple
websites, this doesn't raise any issues. After any users registers in
multiple websites, when we try to run `-u all` again, `base` will try to
recreate the constraint with its original definition, but it will fail
as there are already multiple users with the same `login` (but on
different websites).

This patch is removing in the original definition of the constraint,
leaving the work on the `website` module to create it with the new
definition, and avoid the error when running `-u all`.

More here:
 - https://github.com/odoo/odoo/issues/40740#issuecomment-636517123

Odoo tried to fixed here:
 - https://github.com/odoo/odoo/pull/30334
But it is not working

In the OPW task:
 - https://www.odoo.com/my/task/2312592
They replied the following message:

    After internal discussion, we do not plan
    to support SQL constraint override in the near future.
    Supporting all cases (especially relaxing a constraint in
    various inherited modules) can become unnecessarily complex
    for the added value.

Even if you inherit the method `_add_sql_constraints` this didn't work
Since that Odoo does not have a way to load a module before to `base` one

This patch is required in DeployV since that a `-u all` is executed
in staging instance and the error is used to change the state of the build.

It will help to avoid to make a constraint that will not be used.
