### PR TITLE
[IMP] account: set element names for easier xpaths

### DIFF
--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -167,7 +167,7 @@
                             </div>
                         </div>
                     </div>
-                    <p t-if="o.type in ('out_invoice', 'in_refund')">
+                    <p t-if="o.type in ('out_invoice', 'in_refund')" name="payment_communication">
                         Please use the following communication for your payment : <b><span t-field="o.invoice_payment_ref"/></b>
                     </p>
                     <p t-if="o.narration" name="comment">


### PR DESCRIPTION
Description of the issue/feature this PR addresses: Make it easier to xpath to an element in the invoice report adding a name.

Current behavior before PR:

Some elements are not easy to reach with an xpath and are more risky then they should be.
There where two elements with the name note, which is no longer the case after this PR.
Desired behavior after PR is merged: You can do an xpath to the element itself which is safer and cleaner.

E.g: <xpath expr=//p[@name="payment_communication"]" position="replace">...</xpath>

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr