### PR TITLE
[IMP] base_automation: Return early if there are not base.automation to process 

### DIFF
--- a/addons/base_automation/models/base_automation.py
+++ b/addons/base_automation/models/base_automation.py
@@ -203,6 +203,8 @@ class BaseAutomation(models.Model):
             def create(self, vals, **kw):
                 # retrieve the action rules to possibly execute
                 actions = self.env['base.automation']._get_actions(self, ['on_create', 'on_create_or_write'])
+                if not actions:
+                    return create.origin(self, vals, **kw)
                 # call original method
                 record = create.origin(self.with_env(actions.env), vals, **kw)
                 # check postconditions, and execute actions on the records that satisfy them
@@ -222,6 +224,8 @@ class BaseAutomation(models.Model):
             def _write(self, vals, **kw):
                 # retrieve the action rules to possibly execute
                 actions = self.env['base.automation']._get_actions(self, ['on_write', 'on_create_or_write'])
+                if not (actions and self):
+                    return _write.origin(self, vals, **kw)
                 records = self.with_env(actions.env)
                 # check preconditions on records
                 pre = {action: action._filter_pre(records) for action in actions}


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Installing base_automation module the methods: create, write.
are patched.
So, they will be used  for all models.
It is important to save resources as possible.

The patched methods in base.automation read the original data
before to change so run all base.automation records.

But What about if there are not base.automation records?
So, we can save an extra read for all models

The same to pre-filter and post-filter
It adds a return early in order to skip this extra task when it will be useless.

Current behavior before PR:
Methods create, write, read for all models even if there not base.automation records.

Desired behavior after PR is merged:
Methods create, write, read the original data before to change to return early.

-- I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
