### PR TITLE
[IMP] models.py: Method search_read propagate kwargs to read method

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -4289,7 +4289,7 @@ class BaseModel(MetaModel('DummyModel', (object,), {'_register': False})):
     resolve_o2m_commands_to_record_dicts = resolve_2many_commands
 
     @api.model
-    def search_read(self, domain=None, fields=None, offset=0, limit=None, order=None):
+    def search_read(self, domain=None, fields=None, offset=0, limit=None, order=None, **read_kwargs):
         """
         Performs a ``search()`` followed by a ``read()``.
 
@@ -4298,6 +4298,8 @@ class BaseModel(MetaModel('DummyModel', (object,), {'_register': False})):
         :param offset: Number of records to skip, see ``offset`` parameter in ``search()``. Defaults to 0.
         :param limit: Maximum number of records to return, see ``limit`` parameter in ``search()``. Defaults to no limit.
         :param order: Columns to sort result, see ``order`` parameter in ``search()``. Defaults to no sort.
+        :param read_kwargs: All read keywords arguments used to call read(..., **read_kwargs) method
+            E.g. you can use search_read(..., load='') in order to avoid computing name_get 
         :return: List of dictionaries containing the asked fields.
         :rtype: List of dictionaries.
 
@@ -4319,7 +4321,7 @@ class BaseModel(MetaModel('DummyModel', (object,), {'_register': False})):
             del context['active_test']
             records = records.with_context(context)
 
-        result = records.read(fields)
+        result = records.read(fields, **read_kwargs)
         if len(result) <= 1:
             return result
 


### PR DESCRIPTION
Currently the method `read` uses by default the parameter `load='classic_read')`
  - `self.read(fields, load='classic_read')`

So, it computes `name_get` for all m2o fields for all records in `self`.

If you want to avoid computing the `name_get` to save time and process
You can use an empty string in load parameter:
 - e.g. `self.read(..., load='')`

The method `self.search_read` call to `search` and `read` methods
but `search_read` method is not possible to assign `load=''` argument
(or other arguments of the method `read`)
 - e.g. `self.search_read(..., load='')`

So, you need to use 2 lines of code:
records = self.search(...)
records.read(..., load='')

This commit changes `search_read` method to receive all keyword arguments of the method `read`
So, you can use `self.search_read(..., load='')` and the `read` parameter will be propagated

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
