### PR TITLE
[FIX] stock_landed_costs: Allowing to use stock moves in landed costs

### DIFF
--- a/addons/stock_landed_costs/models/stock_landed_cost.py
+++ b/addons/stock_landed_costs/models/stock_landed_cost.py
@@ -170,7 +170,7 @@ class LandedCost(models.Model):
 
         digits = dp.get_precision('Product Price')(self._cr)
         towrite_dict = {}
-        for cost in self.filtered(lambda cost: cost.picking_ids):
+        for cost in self.filtered(lambda cost: cost.picking_ids or cost.move_ids or cost.production_ids or cost.unbuild_ids):
             total_qty = 0.0
             total_cost = 0.0
             total_weight = 0.0


### PR DESCRIPTION
Explanation
-

As Customer was moved to version 11.0 from version 8.0. It changed from
using average cost method to fifo cost method by doing so it stopped
using stock_landed_costs_average module.

stock_landed_costs_average module in addons-vauxoo has a feature that was
partially tranfered to stock_landed_segmentation module by adding the
field move_ids in the stock.landed.cost model but the method that
provided the feature of using that field was not.

`Method compute_landed_cost Overriding`
https://github.com/Vauxoo/addons-vauxoo/blob/011920897192a720d7645a7d34a537922de51aff/stock_landed_costs_average/model/stock_landed_costs.py#L536-L537

Fast Forward, Customer has being for long time not using the feature but
now requires it to add value to the moves on a new feature that is
available in version 11.0, Unbuild Orders. And it turns out that method
that can use the move is there:

https://github.com/Vauxoo/addons-vauxoo/blob/011920897192a720d7645a7d34a537922de51aff/stock_landed_segmentation/models/stock_landed_costs.py#L138-L139

But the method which could pass those values was missing.

Thus here were using this commit/patch to allow it to fetch it.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
