### PR TITLE
[FIX] product: Price on pricelist with pricelists inside of it

### DIFF
--- a/addons/product/models/product_pricelist.py
+++ b/addons/product/models/product_pricelist.py
@@ -153,7 +153,9 @@ class Pricelist(models.Model):
             'AND (item.pricelist_id = %s) '
             'AND (item.date_start IS NULL OR item.date_start<=%s) '
             'AND (item.date_end IS NULL OR item.date_end>=%s)'
-            'ORDER BY item.applied_on, item.min_quantity desc, categ.complete_name desc, item.id desc',
+            'AND (item.active = TRUE)'
+            'ORDER BY item.applied_on, item.min_quantity desc, item.sequence asc, categ.complete_name desc, '
+            'item.id desc',
             (prod_tmpl_ids, prod_ids, categ_ids, self.id, date, date))
         # NOTE: if you change `order by` on that query, make sure it matches
         # _order from model to avoid inconstencies and undeterministic issues.
@@ -180,7 +182,7 @@ class Pricelist(models.Model):
 
             # if Public user try to access standard price from website sale, need to call price_compute.
             # TDE SURPRISE: product can actually be a template
-            price = product.price_compute('list_price')[product.id]
+            price = 0.0
 
             price_uom = self.env['uom.uom'].browse([qty_uom_id])
             for rule in items:
@@ -208,8 +210,11 @@ class Pricelist(models.Model):
                         continue
 
                 if rule.base == 'pricelist' and rule.base_pricelist_id:
-                    price_tmp = rule.base_pricelist_id._compute_price_rule([(product, qty, partner)], date, uom_id)[product.id][0]  # TDE: 0 = price, 1 = rule
+                    price_tmp = rule.base_pricelist_id.with_context(other_pricelist=True)._compute_price_rule(
+                        [(product, qty, partner)])[product.id][0]  # TDE: 0 = price, 1 = rule
                     price = rule.base_pricelist_id.currency_id._convert(price_tmp, self.currency_id, self.env.user.company_id, date, round=False)
+                    if not price:
+                        continue
                 else:
                     # if base option is public price take sale price else cost price of product
                     # price_compute returns the price in the context UoM, i.e. qty_uom_id
@@ -226,6 +231,11 @@ class Pricelist(models.Model):
                 else:
                     cur = product.currency_id
                 price = cur._convert(price, self.currency_id, self.env.user.company_id, date, round=False)
+
+            if (not price and not self.env.context.get('other_pricelist')
+               and not (suitable_rule and suitable_rule.compute_price == 'percentage'
+                        and suitable_rule.percent_price != 100)):
+                price = product.price_compute('list_price')[product.id]
 
             results[product.id] = (price, suitable_rule and suitable_rule.id or False)
 
@@ -364,11 +374,15 @@ class ResCountryGroup(models.Model):
 class PricelistItem(models.Model):
     _name = "product.pricelist.item"
     _description = "Pricelist Item"
-    _order = "applied_on, min_quantity desc, categ_id desc, id desc"
+    _order = "applied_on, min_quantity desc, sequence asc, categ_id desc, id desc"
     # NOTE: if you change _order on this model, make sure it matches the SQL
     # query built in _compute_price_rule() above in this file to avoid
     # inconstencies and undeterministic issues.
 
+    active = fields.Boolean(
+        default=True,
+        help="Lines in Archived status will not apply on the Purchase/Sale.")
+    sequence = fields.Integer(default=5)
     product_tmpl_id = fields.Many2one(
         'product.template', 'Product Template', ondelete='cascade',
         help="Specify a template if this rule only applies to one product template. Keep empty otherwise.")

--- a/addons/product/models/product_pricelist.py
+++ b/addons/product/models/product_pricelist.py
@@ -553,10 +553,12 @@ class PricelistItem(models.Model):
                 return False
 
         if self.base == 'pricelist' and self.base_pricelist_id:
-            price_tmp = self.base_pricelist_id._compute_price_rule(
+            price_tmp = self.base_pricelist_id.with_context(other_pricelist=True)._compute_price_rule(
                 [(product, qty, partner)], date, uom_id)[product.id][0]  # TDE: 0 = price, 1 = rule
             price = self.base_pricelist_id.currency_id._convert(
                 price_tmp, self.pricelist_id.currency_id, self.env.user.company_id, date, round=False)
+            if not price:
+                return False
         else:
             # if base option is public price take sale price else cost price of product
             # price_compute returns the price in the context UoM, i.e. qty_uom_id

--- a/addons/product/models/product_pricelist.py
+++ b/addons/product/models/product_pricelist.py
@@ -186,43 +186,12 @@ class Pricelist(models.Model):
 
             price_uom = self.env['uom.uom'].browse([qty_uom_id])
             for rule in items:
-                if rule.min_quantity and qty_in_product_uom < rule.min_quantity:
+                price_tmp = rule._check_pricelist_rule(
+                    product, qty, uom_id, partner, date, qty_in_product_uom, price_uom)
+                if price_tmp is False:
                     continue
-                if is_product_template:
-                    if rule.product_tmpl_id and product.id != rule.product_tmpl_id.id:
-                        continue
-                    if rule.product_id and not (product.product_variant_count == 1 and product.product_variant_id.id == rule.product_id.id):
-                        # product rule acceptable on template if has only one variant
-                        continue
-                else:
-                    if rule.product_tmpl_id and product.product_tmpl_id.id != rule.product_tmpl_id.id:
-                        continue
-                    if rule.product_id and product.id != rule.product_id.id:
-                        continue
-
-                if rule.categ_id:
-                    cat = product.categ_id
-                    while cat:
-                        if cat.id == rule.categ_id.id:
-                            break
-                        cat = cat.parent_id
-                    if not cat:
-                        continue
-
-                if rule.base == 'pricelist' and rule.base_pricelist_id:
-                    price_tmp = rule.base_pricelist_id.with_context(other_pricelist=True)._compute_price_rule(
-                        [(product, qty, partner)])[product.id][0]  # TDE: 0 = price, 1 = rule
-                    price = rule.base_pricelist_id.currency_id._convert(price_tmp, self.currency_id, self.env.user.company_id, date, round=False)
-                    if not price:
-                        continue
-                else:
-                    # if base option is public price take sale price else cost price of product
-                    # price_compute returns the price in the context UoM, i.e. qty_uom_id
-                    price = product.price_compute(rule.base)[product.id]
-
-                if price is not False:
-                    price = rule._compute_price(price, price_uom, product, quantity=qty, partner=partner)
-                    suitable_rule = rule
+                price = price_tmp
+                suitable_rule = rule
                 break
             # Final price conversion into pricelist currency
             if suitable_rule and suitable_rule.compute_price != 'fixed' and suitable_rule.base != 'pricelist':
@@ -550,4 +519,49 @@ class PricelistItem(models.Model):
             if self.price_max_margin:
                 price_max_margin = convert_to_price_uom(self.price_max_margin)
                 price = min(price, price_limit + price_max_margin)
+        return price
+
+    def _check_pricelist_rule(self, product, qty, uom_id, partner, date, qty_in_product_uom, price_uom):
+        """Method to check if the item is a suitable one for the quantity that is going to be need it, a certain
+        product, uom and partner, if all the conditions are pas we are returning the rule's price for the product.
+        If the rule isn't suitable we are returning a False value.
+        """
+        self.ensure_one()
+        if self.min_quantity and qty_in_product_uom < self.min_quantity:
+            return False
+
+        if product._name == "product.template":
+            if self.product_tmpl_id and product.id != self.product_tmpl_id.id:
+                return False
+            if self.product_id and not (
+               product.product_variant_count == 1 and product.product_variant_id.id == self.product_id.id):
+                # product rule acceptable on template if has only one variant
+                return False
+        else:
+            if self.product_tmpl_id and product.product_tmpl_id.id != self.product_tmpl_id.id:
+                return False
+            if self.product_id and product.id != self.product_id.id:
+                return False
+
+        if self.categ_id:
+            cat = product.categ_id
+            while cat:
+                if cat.id == self.categ_id.id:
+                    break
+                cat = cat.parent_id
+            if not cat:
+                return False
+
+        if self.base == 'pricelist' and self.base_pricelist_id:
+            price_tmp = self.base_pricelist_id._compute_price_rule(
+                [(product, qty, partner)], date, uom_id)[product.id][0]  # TDE: 0 = price, 1 = rule
+            price = self.base_pricelist_id.currency_id._convert(
+                price_tmp, self.pricelist_id.currency_id, self.env.user.company_id, date, round=False)
+        else:
+            # if base option is public price take sale price else cost price of product
+            # price_compute returns the price in the context UoM, i.e. qty_uom_id
+            price = product.price_compute(self.base)[product.id]
+
+        if price is not False:
+            price = self._compute_price(price, price_uom, product, quantity=qty, partner=partner)
         return price

--- a/addons/product/views/product_pricelist_views.xml
+++ b/addons/product/views/product_pricelist_views.xml
@@ -35,6 +35,7 @@
                             <field name="min_quantity"/>
                             <field name="date_start"/>
                             <field name="date_end"/>
+                            <field name="sequence"/>
                         </group>
                     </group>
                     <separator string="Price Computation"/>
@@ -153,6 +154,7 @@
                             <separator string="Pricelist Items"/>
                             <field name="item_ids" nolabel="1" context="{'default_base':'list_price'}">
                                 <tree string="Pricelist Items">
+                                    <field name="sequence" widget="handle"/>
                                     <field name="name" string="Applicable On"/>
                                     <field name="min_quantity"/>
                                     <field name="date_start"/>


### PR DESCRIPTION
Based on
-

https://github.com/Vauxoo/odoo/pull/372

Explain
-

When you have a global pricelist and inside of it, you have an item 'applied on' 'Global' and a pricelist 'A' with product A,
and another item also with 'applied on' 'Global' with a pricelist 'B' with product B.
And you make a sale order with the global pricelist and you add both products, the only product that is going to have the price set with the pricelist B or A it depends which item is first.

With this change, it will check in all items of the global pricelist until it finds the price or it will set the price on the product.

Notice
-
As this PR is being used in Stable branches not development pushes that have not been tested will done to this one.

