### PR TITLE
[FIX] purchase,stock: Don't access orderpoint's related and not stored field

### DIFF
--- a/addons/purchase/models/stock.py
+++ b/addons/purchase/models/stock.py
@@ -175,7 +175,7 @@ class Orderpoint(models.Model):
     def _quantity_in_progress(self):
         res = super(Orderpoint, self)._quantity_in_progress()
         for poline in self.env['purchase.order.line'].search([('state','in',('draft','sent','to approve')),('orderpoint_id','in',self.ids)]):
-            res[poline.orderpoint_id.id] += poline.product_uom._compute_quantity(poline.product_qty, poline.orderpoint_id.product_uom, round=False)
+            res[poline.orderpoint_id.id] += poline.product_uom._compute_quantity(poline.product_qty, poline.orderpoint_id.product_id.uom_id, round=False)
         return res
 
     def action_view_purchase(self):


### PR DESCRIPTION
Due to an issue in the ORM, this field is not always retrieved correctly
from cache. The usual process is:
1. Try to retrieve the value
2. If not present, retrieve from database and try again
3. If still not present, it means the value is actually not present

The issue is, when this field is accessed, step 2 needs to be performed
twice (and it actually exists), in order for the value to be retrieved
correctly.

This issue is evident when the scheduler is run and there are pending
purchase orders, because it needs to convert the PO's UoM into
product's UoM.

To solve the above, the related field is not accessed directly, but the
original field is used.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
