### PR TITLE
[FIX] purchase,stock: Don't access orderpoint's related and not store…

### DIFF
--- a/addons/purchase/models/stock.py
+++ b/addons/purchase/models/stock.py
@@ -175,7 +175,7 @@ class Orderpoint(models.Model):
     def _quantity_in_progress(self):
         res = super(Orderpoint, self)._quantity_in_progress()
         for poline in self.env['purchase.order.line'].search([('state','in',('draft','sent','to approve')),('orderpoint_id','in',self.ids)]):
-            res[poline.orderpoint_id.id] += poline.product_uom._compute_quantity(poline.product_qty, poline.orderpoint_id.product_uom, round=False)
+            res[poline.orderpoint_id.id] += poline.product_uom._compute_quantity(poline.product_qty, poline.orderpoint_id.product_id.uom_id, round=False)
         return res
 
     def action_view_purchase(self):

--- a/addons/stock/models/procurement.py
+++ b/addons/stock/models/procurement.py
@@ -366,23 +366,23 @@ class ProcurementGroup(models.Model):
                             op_product_virtual = product_quantity[orderpoint.product_id.id]['virtual_available']
                             if op_product_virtual is None:
                                 continue
-                            if float_compare(op_product_virtual, orderpoint.product_min_qty, precision_rounding=orderpoint.product_uom.rounding) <= 0:
+                            if float_compare(op_product_virtual, orderpoint.product_min_qty, precision_rounding=orderpoint.product_id.uom_id.rounding) <= 0:
                                 qty = max(orderpoint.product_min_qty, orderpoint.product_max_qty) - op_product_virtual
                                 remainder = orderpoint.qty_multiple > 0 and qty % orderpoint.qty_multiple or 0.0
 
-                                if float_compare(remainder, 0.0, precision_rounding=orderpoint.product_uom.rounding) > 0:
+                                if float_compare(remainder, 0.0, precision_rounding=orderpoint.product_id.uom_id.rounding) > 0:
                                     qty += orderpoint.qty_multiple - remainder
 
-                                if float_compare(qty, 0.0, precision_rounding=orderpoint.product_uom.rounding) <= 0:
+                                if float_compare(qty, 0.0, precision_rounding=orderpoint.product_id.uom_id.rounding) <= 0:
                                     continue
 
                                 qty -= substract_quantity[orderpoint.id]
-                                qty_rounded = float_round(qty, precision_rounding=orderpoint.product_uom.rounding)
+                                qty_rounded = float_round(qty, precision_rounding=orderpoint.product_id.uom_id.rounding)
                                 if qty_rounded > 0:
                                     values = orderpoint._prepare_procurement_values(qty_rounded, **group['procurement_values'])
                                     try:
                                         with self._cr.savepoint():
-                                            self.env['procurement.group'].run(orderpoint.product_id, qty_rounded, orderpoint.product_uom, orderpoint.location_id,
+                                            self.env['procurement.group'].run(orderpoint.product_id, qty_rounded, orderpoint.product_id.uom_id, orderpoint.location_id,
                                                                               orderpoint.name, orderpoint.name, values)
                                     except UserError as error:
                                         self.env['procurement.rule']._log_next_activity(orderpoint.product_id, error.name)

--- a/addons/stock/models/stock_warehouse.py
+++ b/addons/stock/models/stock_warehouse.py
@@ -825,7 +825,7 @@ class Orderpoint(models.Model):
     @api.constrains('product_id')
     def _check_product_uom(self):
         ''' Check if the UoM has the same category as the product standard UoM '''
-        if any(orderpoint.product_id.uom_id.category_id != orderpoint.product_uom.category_id for orderpoint in self):
+        if any(orderpoint.product_id.uom_id.category_id != orderpoint.product_id.uom_id.category_id for orderpoint in self):
             raise ValidationError(_('You have to select a product unit of measure in the same category than the default unit of measure of the product'))
 
     @api.onchange('warehouse_id')
@@ -848,7 +848,7 @@ class Orderpoint(models.Model):
             days += self.product_id._select_seller(
                 quantity=product_qty,
                 date=fields.Date.to_string(start_date),
-                uom_id=self.product_uom).delay or 0.0
+                uom_id=self.product_id.uom_id).delay or 0.0
         date_planned = start_date + relativedelta.relativedelta(days=days)
         return date_planned.strftime(DEFAULT_SERVER_DATETIME_FORMAT)
 


### PR DESCRIPTION
…d field

Due to an issue in the ORM, this field is not always retrieved correctly
from cache. The usual process is:
1. Try to retrieve the value
2. If not present, retrieve from database and try again
3. If still not present, it means the value is actually not present

The issue is, when this field is accessed, step 2 needs to be performed
twice (and it actually exists), in order for the value to be retrieved
correctly.

This issue is evident when the scheduler is run and there are pending
purchase orders, because it needs to convert the PO's UoM into
product's UoM.

To solve the above, the related field is not accessed directly, but the
original field is used.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
