### PR TITLE
[REF] base_vat_autocomplete: This module is not used and it has errors with libraries so avoid installing

### DIFF
--- a/addons/base_vat_autocomplete/__manifest__.py
+++ b/addons/base_vat_autocomplete/__manifest__.py
@@ -17,5 +17,5 @@ Auto-Complete Addresses based on VAT numbers
         'views/res_partner_views.xml',
         'views/res_company_view.xml',
     ],
-    'auto_install': True
+    'auto_install': False
 }


### PR DESCRIPTION
FYI to be used as patches.txt

Kind of issues that we can avoid since that the customer is not using the feature:
https://github.com/odoo/odoo/pull/24395