### PR TITLE
[REF] website_sale_options: add return early in _cart_find_product_line - VX#46340

### DIFF
--- a/addons/website_sale_options/models/sale_order.py
+++ b/addons/website_sale_options/models/sale_order.py
@@ -24,6 +24,8 @@ class SaleOrder(models.Model):
         optional_product_ids = set(kwargs.get('optional_product_ids', []))
 
         lines = lines.filtered(lambda line: line.linked_line_id.id == linked_line_id)
+        # For customers where they are not use linked_line_id and product_optional_rel
+        return lines
         if optional_product_ids:
             # only match the lines with the same chosen optional products on the existing lines
             lines = lines.filtered(lambda line: optional_product_ids == set(line.mapped('option_line_ids.product_id.id')))


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

When customers don't use `linked_line_id` field in `sale.order.line` and `optional_product_ids` (table name: product_optional_rel) in `product.product`, it's not neccesary to filter for those fields and we can do a return early and avoid heavy queries.

Current behavior before PR:
Heavy queries executed even if field or table related are empty.

Desired behavior after PR is merged:
Heavy queries related to `linked_line_id` field in `sale.order.line` and `optional_product_ids` in `product.product` aren't executed.

Fix https://github.com/ircodoo/ircanada/issues/595

--I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
