### PR TITLE
[ADD] bus: add logger to know PID - VX#46446

### DIFF
--- a/addons/bus/models/bus.py
+++ b/addons/bus/models/bus.py
@@ -160,6 +160,7 @@ class ImDispatch(object):
             conn = cr._cnx
             cr.execute("listen imbus")
             cr.commit();
+            _logger.info("Bus.loop listen imbus on db postgres conn backend_pid %s. conn %s", conn.get_backend_pid(), conn)
             while True:
                 if select.select([conn], [], [], TIMEOUT) == ([], [], []):
                     pass


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Add logger in bus.loop to know PID and connection postgresql

Current behavior before PR:
No loggers created in bus.loop

Desired behavior after PR is merged:
Logger in bus.loop with PID

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
