### PR TITLE
[IMP] website_sale: inheritability.

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -242,6 +242,8 @@ class WebsiteSale(ProductConfiguratorController):
         else:
             categs = Category.search([('parent_id', '=', False)] + request.website.website_domain())
 
+        categs = categs.with_context(lang=None, prefetch_fields=False)
+        categs.read(['name', 'parent_id', 'child_id'])  # prefetch the cache with fields used
         parent_category_ids = []
         if category:
             url = "/shop/category/%s" % slug(category)

--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -259,7 +259,7 @@ class WebsiteSale(ProductConfiguratorController):
         products = search_product[offset: offset + ppg]
 
         ProductAttribute = request.env['product.attribute']
-        if products and ProductAttribute.search_count([]):
+        if products and ProductAttribute.search([], limit=1, order='id'):
             attributes = ProductAttribute.search([
                 ('attribute_line_ids.value_ids', '!=', False),
                 ('attribute_line_ids.product_tmpl_id', 'in', search_product.ids)

--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -257,7 +257,7 @@ class WebsiteSale(ProductConfiguratorController):
         products = search_product[offset: offset + ppg]
 
         ProductAttribute = request.env['product.attribute']
-        if products:
+        if products and ProductAttribute.search_count([]):
             attributes = ProductAttribute.search([
                 ('attribute_line_ids.value_ids', '!=', False),
                 ('attribute_line_ids.product_tmpl_id', 'in', search_product.ids)

--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -269,6 +269,7 @@ class WebsiteSale(ProductConfiguratorController):
 
         values = {
             'search': search,
+            'search_product': search_product,
             'category': category,
             'attrib_values': attrib_values,
             'attrib_set': attrib_set,

--- a/addons/website_sale_comparison/controllers/main.py
+++ b/addons/website_sale_comparison/controllers/main.py
@@ -37,6 +37,9 @@ class WebsiteSaleProductComparison(WebsiteSale):
     @http.route(['/shop/get_product_data'], type='json', auth="public", website=True)
     def get_product_data(self, product_ids, cookies=None):
         ret = {}
+        # added this validation to avoid the launch of unecessary queries
+        if not product_ids:
+            return ret
         pricelist_context, pricelist = self._get_pricelist_context()
         prods = request.env['product.product'].with_context(pricelist_context, display_default_code=False).search([('id', 'in', product_ids)])
         compute_currency = self._get_compute_currency(pricelist, prods[:1].product_tmpl_id)

--- a/addons/website_sale_comparison/static/src/js/website_sale_comparison.js
+++ b/addons/website_sale_comparison/static/src/js/website_sale_comparison.js
@@ -142,11 +142,13 @@ var ProductComparison = Widget.extend(ProductConfiguratorMixin, {
                 cookies: JSON.parse(utils.get_cookie('comparelist_product_ids') || '[]'),
             },
         }).then(function (data) {
-            self.comparelist_product_ids = JSON.parse(data.cookies);
-            delete data.cookies;
-            _.each(data, function (product) {
-                self.product_data[product.product.id] = product;
-            });
+            if (!$.isEmptyObject(data)) {
+                self.comparelist_product_ids = JSON.parse(data.cookies);
+                delete data.cookies;
+                _.each(data, function (product) {
+                    self.product_data[product.product.id] = product;
+                });
+            }
         });
     },
     /**


### PR DESCRIPTION
- Added the `search_product` variable to the return of the `shop`
method, this improves the overall inheritability of the controller
allowing to add criterias to the recordset of products that were
already included in the basic search avoiding to search them again
every time someone needs to inherit the controller.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
