### PR TITLE
[IMP] account_edi: improve how we handle attachments for the email

### DIFF
--- a/addons/account_edi/models/mail_template.py
+++ b/addons/account_edi/models/mail_template.py
@@ -6,6 +6,13 @@ from odoo import api, models
 class MailTemplate(models.Model):
     _inherit = "mail.template"
 
+    def _get_edi_attachments(self, attachment_id, record_data):
+        if not attachment_id:
+            return record_data
+        record_data.setdefault('attachments', [])
+        record_data['attachments'].append((attachment_id.name, attachment_id.datas))
+        return record_data
+
     def generate_email(self, res_ids, fields):
         res = super().generate_email(res_ids, fields)
 
@@ -26,10 +33,6 @@ class MailTemplate(models.Model):
                 # wizard.
                 if doc.edi_format_id._is_embedding_to_invoice_pdf_needed():
                     continue
-
-                attachment = doc.attachment_id
-                if attachment:
-                    record_data.setdefault('attachments', [])
-                    record_data['attachments'].append((attachment.name, attachment.datas))
+                record_data = self._get_edi_attachments(doc, record_data)
 
         return res

--- a/addons/bus/static/src/js/crosstab_bus.js
+++ b/addons/bus/static/src/js/crosstab_bus.js
@@ -327,9 +327,7 @@ var CrossTabBus = Longpolling.extend({
         }
         // update channels
         else if (key === this._generateKey('channels')) {
-            var channels = value;
-            _.each(_.difference(this._channels, channels), this.deleteChannel.bind(this));
-            _.each(_.difference(channels, this._channels), this.addChannel.bind(this));
+            this._channels = value;
         }
         // update options
         else if (key === this._generateKey('options')) {

--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -1401,21 +1401,21 @@ class Lead(models.Model):
         """ Handle salesman recipients that can convert leads into opportunities
         and set opportunities as won / lost. """
         groups = super(Lead, self)._notify_get_groups(msg_vals=msg_vals)
-        msg_vals = msg_vals or {}
+        local_msg_vals = dict(msg_vals or {})
 
         self.ensure_one()
         if self.type == 'lead':
-            convert_action = self._notify_get_action_link('controller', controller='/lead/convert', **msg_vals)
+            convert_action = self._notify_get_action_link('controller', controller='/lead/convert', **local_msg_vals)
             salesman_actions = [{'url': convert_action, 'title': _('Convert to opportunity')}]
         else:
-            won_action = self._notify_get_action_link('controller', controller='/lead/case_mark_won', **msg_vals)
-            lost_action = self._notify_get_action_link('controller', controller='/lead/case_mark_lost', **msg_vals)
+            won_action = self._notify_get_action_link('controller', controller='/lead/case_mark_won', **local_msg_vals)
+            lost_action = self._notify_get_action_link('controller', controller='/lead/case_mark_lost', **local_msg_vals)
             salesman_actions = [
                 {'url': won_action, 'title': _('Won')},
                 {'url': lost_action, 'title': _('Lost')}]
 
         if self.team_id:
-            custom_params = dict(msg_vals, res_id=self.team_id.id, model=self.team_id._name)
+            custom_params = dict(local_msg_vals, res_id=self.team_id.id, model=self.team_id._name)
             salesman_actions.append({
                 'url': self._notify_get_action_link('view', **custom_params),
                 'title': _('Sales Team Settings')

--- a/addons/google_calendar/utils/google_calendar.py
+++ b/addons/google_calendar/utils/google_calendar.py
@@ -58,7 +58,7 @@ class GoogleCalendarService():
 
     @requires_auth_token
     def insert(self, values, token=None, timeout=TIMEOUT):
-        url = "/calendar/v3/calendars/primary/events"
+        url = "/calendar/v3/calendars/primary/events?sendUpdates=all"
         headers = {'Content-type': 'application/json', 'Authorization': 'Bearer %s' % token}
         if not values.get('id'):
             values['id'] = uuid4().hex
@@ -67,13 +67,13 @@ class GoogleCalendarService():
 
     @requires_auth_token
     def patch(self, event_id, values, token=None, timeout=TIMEOUT):
-        url = "/calendar/v3/calendars/primary/events/%s" % event_id
+        url = "/calendar/v3/calendars/primary/events/%s?sendUpdates=all" % event_id
         headers = {'Content-type': 'application/json', 'Authorization': 'Bearer %s' % token}
         self.google_service._do_request(url, json.dumps(values), headers, method='PUT', timeout=timeout)
 
     @requires_auth_token
     def delete(self, event_id, token=None, timeout=TIMEOUT):
-        url = "/calendar/v3/calendars/primary/events/%s" % event_id
+        url = "/calendar/v3/calendars/primary/events/%s?sendUpdates=all" % event_id
         headers = {'Content-type': 'application/json'}
         params = {'access_token': token}
         try:

--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -1220,15 +1220,15 @@ class HolidaysRequest(models.Model):
         """ Handle HR users and officers recipients that can validate or refuse holidays
         directly from email. """
         groups = super(HolidaysRequest, self)._notify_get_groups(msg_vals=msg_vals)
-        msg_vals = msg_vals or {}
+        local_msg_vals = dict(msg_vals or {})
 
         self.ensure_one()
         hr_actions = []
         if self.state == 'confirm':
-            app_action = self._notify_get_action_link('controller', controller='/leave/validate', **msg_vals)
+            app_action = self._notify_get_action_link('controller', controller='/leave/validate', **local_msg_vals)
             hr_actions += [{'url': app_action, 'title': _('Approve')}]
         if self.state in ['confirm', 'validate', 'validate1']:
-            ref_action = self._notify_get_action_link('controller', controller='/leave/refuse', **msg_vals)
+            ref_action = self._notify_get_action_link('controller', controller='/leave/refuse', **local_msg_vals)
             hr_actions += [{'url': ref_action, 'title': _('Refuse')}]
 
         holiday_user_group_id = self.env.ref('hr_holidays.group_hr_holidays_user').id

--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -670,15 +670,15 @@ class HolidaysAllocation(models.Model):
         """ Handle HR users and officers recipients that can validate or refuse holidays
         directly from email. """
         groups = super(HolidaysAllocation, self)._notify_get_groups(msg_vals=msg_vals)
-        msg_vals = msg_vals or {}
+        local_msg_vals = dict(msg_vals or {})
 
         self.ensure_one()
         hr_actions = []
         if self.state == 'confirm':
-            app_action = self._notify_get_action_link('controller', controller='/allocation/validate', **msg_vals)
+            app_action = self._notify_get_action_link('controller', controller='/allocation/validate', **local_msg_vals)
             hr_actions += [{'url': app_action, 'title': _('Approve')}]
         if self.state in ['confirm', 'validate', 'validate1']:
-            ref_action = self._notify_get_action_link('controller', controller='/allocation/refuse', **msg_vals)
+            ref_action = self._notify_get_action_link('controller', controller='/allocation/refuse', **local_msg_vals)
             hr_actions += [{'url': ref_action, 'title': _('Refuse')}]
 
         holiday_user_group_id = self.env.ref('hr_holidays.group_hr_holidays_user').id

--- a/addons/mail/data/mail_data.xml
+++ b/addons/mail/data/mail_data.xml
@@ -239,7 +239,7 @@
             <t t-set="access_action" t-value="record.with_context(force_website=True).get_access_action()"/>
             <t t-set="is_online" t-value="access_action and access_action['type'] == 'ir.actions.act_url'"/>
             <t t-set="base_url" t-value="record.get_base_url()"/>
-            <t t-set="share_url" t-value="record._get_share_url(redirect=True, signup_partner=True)"/>
+            <t t-set="share_url" t-value="record._get_share_url(redirect=True, signup_partner=notification_is_customer, share_token=notification_is_customer)"/>
             <t t-set="access_url" t-value="is_online and share_url and base_url + share_url or ''"/>
             <t t-set="access_name">
                 View <t t-esc="model_description or 'document'"/>

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -2602,6 +2602,8 @@ class MailThread(models.AbstractModel):
 
         # fill group_data with default_values if they are not complete
         for group_name, group_func, group_data in groups:
+            group_data.setdefault('notification_group_name', group_name)
+            group_data.setdefault('notification_is_customer', False)
             group_data.setdefault('has_button_access', True)
             group_button_access = group_data.setdefault('button_access', {})
             group_button_access.setdefault('url', access_link)

--- a/addons/mail/static/src/components/attachment/attachment.js
+++ b/addons/mail/static/src/components/attachment/attachment.js
@@ -94,10 +94,18 @@ class Attachment extends Component {
         if (this.detailsMode === 'card') {
             size = '38x38';
         } else {
-            size = '160x160';
+            // The size of background-image depends on the props.imageSize
+            // to sync with width and height of `.o_Attachment_image`.
+            if (this.props.imageSize === "large") {
+                size = '400x400';
+            } else if (this.props.imageSize === "medium") {
+                size = '200x200';
+            } else if (this.props.imageSize === "small") {
+                size = '100x100';
+            }
         }
         // background-size set to override value from `o_image` which makes small image stretched
-        return `background-image:url(/web/image/${this.attachment.id}/${size}/?crop=true); background-size: auto;`;
+        return `background-image:url(/web/image/${this.attachment.id}/${size}); background-size: auto;`;
     }
 
     //--------------------------------------------------------------------------

--- a/addons/mail/static/src/components/attachment/attachment.scss
+++ b/addons/mail/static/src/components/attachment/attachment.scss
@@ -71,7 +71,8 @@
 
     &.o-details-overlay {
         position: relative;
-
+        // small, medium and large size styles should be sync with
+        // the size of the background-image and `.o_Attachment_image`.
         &.o-small {
             min-width: 100px;
             min-height: 100px;

--- a/addons/mail/static/src/components/attachment/attachment_tests.js
+++ b/addons/mail/static/src/components/attachment/attachment_tests.js
@@ -107,8 +107,8 @@ QUnit.test('simplest layout + deletable', async function (assert) {
         async mockRPC(route, args) {
             if (route.includes('web/image/750')) {
                 assert.ok(
-                    route.includes('/160x160'),
-                    "should fetch image with 160x160 pixels ratio");
+                    route.includes('/200x200'),
+                    "should fetch image with 200x200 pixels ratio");
                 assert.step('fetch_image');
             }
             return this._super(...arguments);

--- a/addons/point_of_sale/static/src/js/Screens/OrderManagementScreen/OrderManagementScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/OrderManagementScreen/OrderManagementScreen.js
@@ -13,7 +13,7 @@ odoo.define('point_of_sale.OrderManagementScreen', function (require) {
     class OrderManagementScreen extends ControlButtonsMixin(IndependentToOrderScreen) {
         constructor() {
             super(...arguments);
-            useListener('close-screen', this.close);
+            useListener('close-screen', this._close);
             useListener('set-numpad-mode', this._setNumpadMode);
             useListener('click-order', this._onClickOrder);
             useListener('next-page', this._onNextPage);
@@ -78,6 +78,16 @@ odoo.define('point_of_sale.OrderManagementScreen', function (require) {
         _onClickOrder({ detail: clickedOrder }) {
             if (!clickedOrder || clickedOrder.locked) {
                 this.orderManagementContext.selectedOrder = clickedOrder;
+                let currentPOSOrder = this.env.pos.get_order();
+                if (clickedOrder.attributes.client){
+                    currentPOSOrder.set_client(clickedOrder.attributes.client);
+                }
+                if (clickedOrder.fiscal_position){
+                    currentPOSOrder.fiscal_position = clickedOrder.fiscal_position;
+                }
+                if (clickedOrder.pricelist){
+                    currentPOSOrder.set_pricelist(clickedOrder.pricelist);
+                }
             } else {
                 this._setOrder(clickedOrder);
             }
@@ -90,6 +100,15 @@ odoo.define('point_of_sale.OrderManagementScreen', function (require) {
             if (order === this.env.pos.get_order()) {
                 this.close();
             }
+        }
+        _close() {
+            let currentOrder = this.env.pos.get_order();
+            if (currentOrder){
+                currentOrder.set_client(false);
+                currentOrder.fiscal_position = false;
+                currentOrder.set_pricelist(this.env.pos.default_pricelist);
+            }
+            this.close();
         }
     }
     OrderManagementScreen.template = 'OrderManagementScreen';

--- a/addons/portal/models/portal_mixin.py
+++ b/addons/portal/models/portal_mixin.py
@@ -32,7 +32,7 @@ class PortalMixin(models.AbstractModel):
             self.sudo().write({'access_token': str(uuid.uuid4())})
         return self.access_token
 
-    def _get_share_url(self, redirect=False, signup_partner=False, pid=None):
+    def _get_share_url(self, redirect=False, signup_partner=False, pid=None, share_token=True):
         """
         Build the url of the record  that will be sent by mail and adds additional parameters such as
         access_token to bypass the recipient's rights,
@@ -50,7 +50,7 @@ class PortalMixin(models.AbstractModel):
             'model': self._name,
             'res_id': self.id,
         }
-        if hasattr(self, 'access_token'):
+        if share_token and hasattr(self, 'access_token'):
             params['access_token'] = self._portal_ensure_token()
         if pid:
             params['pid'] = pid
@@ -77,6 +77,7 @@ class PortalMixin(models.AbstractModel):
                     'button_access': {
                         'url': access_link,
                     },
+                    'notification_is_customer': True,
                 })
             ]
         else:

--- a/addons/portal/models/portal_mixin.py
+++ b/addons/portal/models/portal_mixin.py
@@ -63,13 +63,13 @@ class PortalMixin(models.AbstractModel):
     def _notify_get_groups(self, msg_vals=None):
         access_token = self._portal_ensure_token()
         groups = super(PortalMixin, self)._notify_get_groups(msg_vals=msg_vals)
-        msg_vals = msg_vals or {}
+        local_msg_vals = dict(msg_vals or {})
 
         if access_token and 'partner_id' in self._fields and self['partner_id']:
             customer = self['partner_id']
-            msg_vals['access_token'] = self.access_token
-            msg_vals.update(customer.signup_get_auth_param()[customer.id])
-            access_link = self._notify_get_action_link('view', **msg_vals)
+            local_msg_vals['access_token'] = self.access_token
+            local_msg_vals.update(customer.signup_get_auth_param()[customer.id])
+            access_link = self._notify_get_action_link('view', **local_msg_vals)
 
             new_group = [
                 ('portal_customer', lambda pdata: pdata['id'] == customer.id, {

--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -1215,7 +1215,7 @@ class Task(models.Model):
         access button to portal users and portal customers. If they are notified
         they should probably have access to the document. """
         groups = super(Task, self)._notify_get_groups(msg_vals=msg_vals)
-        msg_vals = msg_vals or {}
+        local_msg_vals = dict(msg_vals or {})
         self.ensure_one()
 
         project_user_group_id = self.env.ref('project.group_project_user').id
@@ -1227,7 +1227,7 @@ class Task(models.Model):
         new_group = ('group_project_user', group_func, {})
 
         if not self.user_id and not self.stage_id.fold:
-            take_action = self._notify_get_action_link('assign', **msg_vals)
+            take_action = self._notify_get_action_link('assign', **local_msg_vals)
             project_actions = [{'url': take_action, 'title': _('I take it')}]
             new_group[2]['actions'] = project_actions
 

--- a/addons/sale/data/mail_data.xml
+++ b/addons/sale/data/mail_data.xml
@@ -56,7 +56,8 @@
     </data>
     <!-- Template and notification section -->
     <data noupdate="1">
-        <template id="mail_notification_paynow_online" inherit_id="mail.mail_notification_paynow" name="Quotation: Sign and Pay mail notification template">
+        <template id="mail_notification_paynow_online" inherit_id="mail.mail_notification_paynow"
+            name="Quotation: Sign and Pay mail notification template">
             <xpath expr="//t[@t-set='access_name']" position="after">
                 <t t-if="record._name == 'sale.order'">
                     <t t-set="is_transaction_pending" t-value="record.get_portal_last_transaction().state == 'pending'"/>

--- a/addons/sale/models/sale.py
+++ b/addons/sale/models/sale.py
@@ -1083,19 +1083,6 @@ Reason(s) of this behavior could be:
         self.ensure_one()
         return '%s %s' % (self.type_name, self.name)
 
-    def _get_share_url(self, redirect=False, signup_partner=False, pid=None):
-        """Override for sales order.
-
-        If the SO is in a state where an action is required from the partner,
-        return the URL with a login token. Otherwise, return the URL with a
-        generic access token (no login).
-        """
-        self.ensure_one()
-        if self.state not in ['sale', 'done']:
-            auth_param = url_encode(self.partner_id.signup_get_auth_param()[self.partner_id.id])
-            return self.get_portal_url(query_string='&%s' % auth_param)
-        return super(SaleOrder, self)._get_share_url(redirect, signup_partner, pid)
-
     def _get_payment_type(self, tokenize=False):
         self.ensure_one()
         return 'form_save' if tokenize else 'form'

--- a/addons/sale/views/sale_views.xml
+++ b/addons/sale/views/sale_views.xml
@@ -582,6 +582,7 @@
                                     <field name="product_uom_qty"/>
                                     <field name="product_uom" groups="uom.group_uom"/>
                                     <field name="price_subtotal"/>
+                                    <field name="price_total"/>
                                     <field name="price_tax" invisible="1"/>
                                     <field name="price_total" invisible="1"/>
                                     <field name="price_unit"/>
@@ -603,7 +604,9 @@
                                                         <div class="col-4">
                                                             <strong>
                                                                 <span class="float-right text-right">
-                                                                    <t t-esc="record.price_subtotal.value"/>
+                                                                    <t t-set="line_price" t-value="record.price_subtotal.value" groups="account.group_show_line_subtotals_tax_excluded"/>
+                                                                    <t t-set="line_price" t-value="record.price_total.value" groups="account.group_show_line_subtotals_tax_included"/>
+                                                                    <t t-esc="line_price"/>
                                                                 </span>
                                                             </strong>
                                                         </div>

--- a/addons/website_sale/models/sale_order.py
+++ b/addons/website_sale/models/sale_order.py
@@ -245,21 +245,21 @@ class SaleOrder(models.Model):
             # update line
             no_variant_attributes_price_extra = [ptav.price_extra for ptav in order_line.product_no_variant_attribute_value_ids]
             values = self.with_context(no_variant_attributes_price_extra=tuple(no_variant_attributes_price_extra))._website_product_id_change(self.id, product_id, qty=quantity)
+            order = self.sudo().browse(self.id)
             if self.pricelist_id.discount_policy == 'with_discount' and not self.env.context.get('fixed_price'):
-                order = self.sudo().browse(self.id)
                 product_context.update({
                     'partner': order.partner_id,
                     'quantity': quantity,
                     'date': order.date_order,
                     'pricelist': order.pricelist_id.id,
                 })
-                product_with_context = self.env['product.product'].with_context(product_context).with_company(order.company_id.id)
-                product = product_with_context.browse(product_id)
-                values['price_unit'] = self.env['account.tax']._fix_tax_included_price_company(
-                    order_line._get_display_price(product),
-                    order_line.product_id.taxes_id,
-                    order_line.tax_id,
-                    self.company_id
+            product_with_context = self.env['product.product'].with_context(product_context).with_company(order.company_id.id)
+            product = product_with_context.browse(product_id)
+            values['price_unit'] = self.env['account.tax']._fix_tax_included_price_company(
+                order_line._get_display_price(product),
+                order_line.product_id.taxes_id,
+                order_line.tax_id,
+                self.company_id
                 )
 
             order_line.write(values)

--- a/addons/website_sale/tests/test_website_sale_product_attribute_value_config.py
+++ b/addons/website_sale/tests/test_website_sale_product_attribute_value_config.py
@@ -3,6 +3,7 @@
 
 from odoo.addons.sale.tests.test_sale_product_attribute_value_config import TestSaleProductAttributeValueCommon
 from odoo.tests import tagged
+from odoo.addons.website.tools import MockRequest
 
 
 @tagged('post_install', '-at_install')
@@ -130,3 +131,61 @@ class TestWebsiteSaleProductAttributeValueConfig(TestSaleProductAttributeValueCo
         combination_info = test_product._get_combination_info()
         self.assertEqual(round(combination_info['price'], 2), 434.78, "434.78$ + 0% tax (mapped from fp 15% -> 0% for BE)")
         self.assertEqual(round(combination_info['list_price'], 2), 434.78, "434.78$ + 0% tax (mapped from fp 15% -> 0% for BE)")
+
+@tagged('post_install', '-at_install')
+class TestWebsiteSaleProductPricelist(TestSaleProductAttributeValueCommon):
+    def test_cart_update_with_fpos(self):
+        # We will test that the mapping of an 10% included tax by a 0% by a fiscal position is taken into account when updating the cart 
+        self.env.user.partner_id.country_id = False
+        current_website = self.env['website'].get_current_website()
+        pricelist = current_website.get_current_pricelist()
+        (self.env['product.pricelist'].search([]) - pricelist).write({'active': False})
+        # Add 10% tax on product
+        tax10 = self.env['account.tax'].create({'name': "Test tax 10", 'amount': 10, 'price_include': True, 'amount_type': 'percent'})
+        tax0 = self.env['account.tax'].create({'name': "Test tax 0", 'amount': 0, 'price_include': True, 'amount_type': 'percent'})
+
+        test_product = self.env['product.template'].create({
+            'name': 'Test Product',
+            'price': 110,
+            'taxes_id': [(6, 0, [tax10.id])],
+        }).with_context(website_id=current_website.id)
+
+        # Add discout of 50% for pricelist
+        pricelist.item_ids = self.env['product.pricelist.item'].create({
+            'applied_on': "1_product",
+            'base': "list_price",
+            'compute_price': "percentage",
+            'percent_price': 50,
+            'product_tmpl_id': test_product.id,
+        })
+
+        pricelist.discount_policy = 'without_discount'
+
+        # Create fiscal position mapping taxes 10% -> 0%
+        fpos = self.env['account.fiscal.position'].create({
+            'name': 'test',
+        })
+        self.env['account.fiscal.position.tax'].create({
+            'position_id': fpos.id,
+            'tax_src_id': tax10.id,
+            'tax_dest_id': tax0.id,
+        })
+        so = self.env['sale.order'].create({
+            'partner_id': self.env.user.partner_id.id,
+        })
+        sol = self.env['sale.order.line'].create({
+            'name': test_product.name,
+            'product_id': test_product.product_variant_id.id,
+            'product_uom_qty': 1,
+            'product_uom': test_product.uom_id.id,
+            'price_unit': test_product.list_price,
+            'order_id': so.id,
+            'tax_id': [(6, 0, [tax10.id])],
+        })
+        self.assertEqual(round(sol.price_total), 110.0, "110$ with 10% included tax")
+        so.pricelist_id = pricelist
+        so.fiscal_position_id = fpos
+        sol.product_id_change()
+        with MockRequest(self.env, website=current_website, sale_order_id=so.id):
+            so._cart_update(product_id=test_product.product_variant_id.id, line_id=sol.id, set_qty=1)
+        self.assertEqual(round(sol.price_total), 50, "100$ with 50% discount + 0% tax (mapped from fp 10% -> 0%)")

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -1021,7 +1021,7 @@
                         </td>
                         <td class="text-center td-price" name="price">
                             <t t-set="combination" t-value="line.product_id.product_template_attribute_value_ids + line.product_no_variant_attribute_value_ids"/>
-                            <t t-set="combination_info" t-value="line.product_id.product_tmpl_id._get_combination_info(combination)"/>
+                            <t t-set="combination_info" t-value="line.product_id.product_tmpl_id._get_combination_info(combination, pricelist=website_sale_order.pricelist_id)"/>
 
                             <t t-set="list_price_converted" t-value="website.currency_id._convert(combination_info['list_price'], website_sale_order.currency_id, website_sale_order.company_id, date)"/>
                             <t groups="account.group_show_line_subtotals_tax_excluded" t-if="(website_sale_order.pricelist_id.discount_policy == 'without_discount' and website_sale_order.currency_id.compare_amounts(list_price_converted, line.price_reduce_taxexcl) == 1) or website_sale_order.currency_id.compare_amounts(line.price_unit, line.price_reduce) == 1" name="order_line_discount">


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

When assambling the email we are leaving the asignment of the attachments to another method that we can inherit
and then modify instead of doing it in the same method to attach them.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
