### PR TITLE
[DUMMY] base: insert logger.info to catch login error

### DIFF
--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -558,6 +558,7 @@ class Users(models.Model):
             for user in self:
                 if not user.active and not user.partner_id.active:
                     user.partner_id.toggle_active()
+        _logger.info("%s, %s, %s, %s" % (self, self.env.user, values, self.env.su))
         if self == self.env.user:
             for key in list(values):
                 if not (key in self.SELF_WRITEABLE_FIELDS or key.startswith('context_')):
@@ -568,7 +569,7 @@ class Users(models.Model):
                         del values['company_id']
                 # safe fields only, so we write as super-user to bypass access rights
                 self = self.sudo().with_context(binary_field_real_user=self.env.user)
-
+                _logger.info("%s, %s" % (self, self.env.su))
         res = super(Users, self).write(values)
         if 'company_id' in values:
             for user in self:

--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -558,7 +558,7 @@ class Users(models.Model):
             for user in self:
                 if not user.active and not user.partner_id.active:
                     user.partner_id.toggle_active()
-        _logger.info("%s, %s, %s, %s" % (self, self.env.user, values, self.env.su))
+        _logger.info("%s, %s, %s, %s", self, self.env.user, values, self.env.su)
         if self == self.env.user:
             for key in list(values):
                 if not (key in self.SELF_WRITEABLE_FIELDS or key.startswith('context_')):


### PR DESCRIPTION
Insert logger.info parameter to catch login error when an user login
fails via auth SAML in ADFS.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
