### PR TITLE
[IMP] account: allow Off-Balance Sheet play nice with other accounts  vx#45938

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3729,6 +3729,8 @@ class AccountMoveLine(models.Model):
 
     @api.constrains('account_id', 'tax_ids', 'tax_line_id', 'reconciled')
     def _check_off_balance(self):
+        if not self._context.get('check_move_validity', True):
+            return
         checked_moves = set()
         # /!\ NOTE: We have to cycle through the whole Journal Entry from the
         # Journal Item because self could be coming from several Journal


### PR DESCRIPTION
Explanation
-

Now
=

This Journal Entry is not allowed. Thought both Off-Balance and
Balance Sheet accounts are balanced among themselves.

    Balance Account 1 (dr)             1000
        Balance Account 2 (cr)                      1000
    Off-Balance Account X (dr)          700
        Off-Balance Account Y (cr)                   700

Following Constraint will be kept in place when they are not balance
among themselves

    Balance Account 1 (dr)             1000
        Off-Balance Account Y (cr)                   700
