### PR TITLE
[PATCH] account: Using amount_residual to create exchange_rate entries

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -1747,8 +1747,8 @@ class AccountPartialReconcile(models.Model):
             #create the line that will compensate all the aml_to_fix
             line_to_rec = aml_model.with_context(check_move_validity=False).create({
                 'name': _('Currency exchange rate difference'),
-                'debit': amount_diff < 0 and -aml.amount_residual or 0.0,
-                'credit': amount_diff > 0 and aml.amount_residual or 0.0,
+                'debit': aml.amount_residual < 0 and -aml.amount_residual or 0.0,
+                'credit': aml.amount_residual > 0 and aml.amount_residual or 0.0,
                 'account_id': aml.account_id.id,
                 'move_id': move.id,
                 'currency_id': currency.id,
@@ -1759,8 +1759,8 @@ class AccountPartialReconcile(models.Model):
             exchange_journal = move.company_id.currency_exchange_journal_id
             aml_model.with_context(check_move_validity=False).create({
                 'name': _('Currency exchange rate difference'),
-                'debit': amount_diff > 0 and aml.amount_residual or 0.0,
-                'credit': amount_diff < 0 and -aml.amount_residual or 0.0,
+                'debit': aml.amount_residual > 0 and aml.amount_residual or 0.0,
+                'credit': aml.amount_residual < 0 and -aml.amount_residual or 0.0,
                 'account_id': amount_diff > 0 and exchange_journal.default_debit_account_id.id or exchange_journal.default_credit_account_id.id,
                 'move_id': move.id,
                 'currency_id': currency.id,


### PR DESCRIPTION
### VX [Issue#14894](https://www.vauxoo.com/web#id=14894&model=helpdesk.ticket&view_type=form&menu_id=424)

We need to use the amount_residual instead of amount_diff because we are
getting negative numbers when positive credit and debit are expected.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
