### PR TITLE
[REF] many modules: Set auto_install False

### DIFF
--- a/addons/account_edi/__manifest__.py
+++ b/addons/account_edi/__manifest__.py
@@ -24,5 +24,5 @@ governements, etc.)
     ],
     'installable': True,
     'application': False,
-    'auto_install': True,
+    'auto_install': False,
 }

--- a/addons/account_edi_facturx/__manifest__.py
+++ b/addons/account_edi_facturx/__manifest__.py
@@ -10,5 +10,5 @@
     ],
     'installable': True,
     'application': False,
-    'auto_install': True,
+    'auto_install': False,
 }

--- a/addons/account_edi_ubl/__manifest__.py
+++ b/addons/account_edi_ubl/__manifest__.py
@@ -9,5 +9,5 @@
     ],
     'installable': True,
     'application': False,
-    'auto_install': True,
+    'auto_install': False,
 }

--- a/addons/account_qr_code_sepa/__manifest__.py
+++ b/addons/account_qr_code_sepa/__manifest__.py
@@ -15,5 +15,5 @@
     'data': [
     ],
 
-    'auto_install': True,
+    'auto_install': False,
 }

--- a/addons/partner_autocomplete/__manifest__.py
+++ b/addons/partner_autocomplete/__manifest__.py
@@ -26,5 +26,5 @@
     'qweb': [
         'static/src/xml/partner_autocomplete.xml',
     ],
-    'auto_install': True,
+    'auto_install': False,
 }


### PR DESCRIPTION
Odoo has an obsession auto installing modules
Even if you don't need it
Even if it has errors
More info: https://github.com/odoo/odoo/issues/71190
So, this method will uninstall useless modules auto-installed

For use of patches.txt in DeployV