### PR TITLE
[PATCH] web: Remove delay when resizing menu

### DIFF
--- a/addons/web/static/src/js/core/dom.js
+++ b/addons/web/static/src/js/core/dom.js
@@ -607,7 +607,7 @@ var dom = {
 
         var $extraItemsToggle = null;
 
-        var debouncedAdapt = _.debounce(_adapt, 250);
+        var debouncedAdapt = _.debounce(_adapt, 0);
         core.bus.on('resize', null, debouncedAdapt);
         _adapt();
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
when resizing the menu it takes a few seconds to adjust

Current behavior before PR:
Desired behavior after PR is merged:


https://user-images.githubusercontent.com/35231827/122093332-97e21580-cdd0-11eb-84f3-a6c425f5b2cb.mp4






--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
