### PR TITLE
[FIX] account: CABA Journal Entries could be wrongly generated for taxes

### DIFF
--- a/addons/account/models/account_partial_reconcile.py
+++ b/addons/account/models/account_partial_reconcile.py
@@ -519,6 +519,8 @@ class AccountPartialReconcile(models.Model):
                     # and well reported in the Tax Report.
                     # ==========================================================================
 
+                    cb_line_vals = {'debit': 0, 'credit': 0, 'amount_currency': 0}
+                    grouping_key = tuple()
                     if line.tax_repartition_line_id:
                         # Tax line.
 
@@ -529,6 +531,9 @@ class AccountPartialReconcile(models.Model):
 
                         cb_line_vals = self._prepare_cash_basis_base_line_vals(line, balance, amount_currency)
                         grouping_key = self._get_cash_basis_base_line_grouping_key_from_vals(cb_line_vals)
+                    else:
+                        # /!\ NOTE: Post-migration records could come with several lines that are bearing neither repartition nor taxes
+                        continue
 
                     if grouping_key in partial_lines_to_create:
                         aggregated_vals = partial_lines_to_create[grouping_key]['vals']


### PR DESCRIPTION
Main
-

[FIX] account: CABA Journal Entries could be wrongly generated 

as all records are kept and used in afterward processes



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
