### PR TITLE
[FIX] http/db: handle case when db_filter is empty in the config file

### DIFF
--- a/openerp/http.py
+++ b/openerp/http.py
@@ -280,7 +280,7 @@ class WebRequest(object):
     def _handle_exception(self, exception):
         """Called within an except block to allow converting exceptions
            to abitrary responses. Anything returned (except None) will
-           be used as response.""" 
+           be used as response."""
         self._failed = exception # prevent tx commit
         if not isinstance(exception, NO_POSTMORTEM) \
                 and not isinstance(exception, werkzeug.exceptions.HTTPException):
@@ -479,7 +479,7 @@ class JsonRequest(WebRequest):
         self.jsonp = jsonp
         request = None
         request_id = args.get('id')
-        
+
         if jsonp and self.httprequest.method == 'POST':
             # jsonp 2 steps step1 POST: save call
             def handler():
@@ -627,7 +627,7 @@ def to_jsonable(o):
     return ustr(o)
 
 def jsonrequest(f):
-    """ 
+    """
         .. deprecated:: 8.0
             Use the :func:`~openerp.http.route` decorator instead.
     """
@@ -739,7 +739,7 @@ class HttpRequest(WebRequest):
         return werkzeug.exceptions.NotFound(description)
 
 def httprequest(f):
-    """ 
+    """
         .. deprecated:: 8.0
 
         Use the :func:`~openerp.http.route` decorator instead.
@@ -905,7 +905,7 @@ class Model(object):
             if not request.db or not request.uid or self.session.db != request.db \
                 or self.session.uid != request.uid:
                 raise Exception("Trying to use Model with badly configured database or user.")
-                
+
             if method.startswith('_'):
                 raise Exception("Access denied")
             mod = request.registry[self.model]
@@ -1467,8 +1467,14 @@ def db_filter(dbs, httprequest=None):
     d, _, r = h.partition('.')
     if d == "www" and r:
         d = r.partition('.')[0]
-    r = openerp.tools.config['dbfilter'].replace('%h', h).replace('%d', d)
-    dbs = [i for i in dbs if re.match(r, i)]
+    if openerp.tools.config['dbfilter']:
+        r = openerp.tools.config['dbfilter'].replace('%h', h).replace('%d', d)
+        dbs = [i for i in dbs if re.match(r, i)]
+    elif openerp.tools.config['db_name']:
+        # In case --db-filter is not provided and --database is passed, Odoo will
+        # use the value of --database as a comma seperated list of exposed databases.
+        exposed_dbs = set(db.strip() for db in openerp.tools.config['db_name'].split(','))
+        dbs = sorted(exposed_dbs.intersection(dbs))
     return dbs
 
 def db_monodb(httprequest=None):

--- a/openerp/service/db.py
+++ b/openerp/service/db.py
@@ -307,6 +307,14 @@ def exp_db_exist(db_name):
 def exp_list(document=False):
     if not openerp.tools.config['list_db'] and not document:
         raise openerp.exceptions.AccessDenied()
+
+    if not openerp.tools.config['dbfilter'] and openerp.tools.config['db_name']:
+        # In case --db-filter is not provided and --database is passed, Odoo will not
+        # fetch the list of databases available on the postgres server and instead will
+        # use the value of --database as comma seperated list of exposed databases.
+        res = sorted(db.strip() for db in openerp.tools.config['db_name'].split(','))
+        return res
+
     chosen_template = openerp.tools.config['db_template']
     templates_list = tuple(set(['template0', 'template1', 'postgres', chosen_template]))
     db = openerp.sql_db.db_connect('postgres')


### PR DESCRIPTION
In such a case the db filtering won't be applied on an empty regex so
we use the list of databases passed to `db_name` (--database) as
the database list (and we also avoid to list all the databases present
on the postgresql cluster)

As a side effect, this patch allows to strengthen the postgresql
security
by preventing Odoo to list all the databases present on the cluster.

Based on
https://github.com/Vauxoo/odoo/commit/6fa705399bc05d4b0dce5e7181c40a4a5ab8b1c3





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
