### PR TITLE
[FIX] purchase: Missing round=False on auto-complete bill with multi-… i#15749

### DIFF
--- a/addons/purchase/models/purchase.py
+++ b/addons/purchase/models/purchase.py
@@ -1136,7 +1136,7 @@ class PurchaseOrderLine(models.Model):
             'product_id': self.product_id.id,
             'product_uom_id': self.product_uom.id,
             'quantity': self.qty_to_invoice,
-            'price_unit': self.currency_id._convert(self.price_unit, aml_currency, self.company_id, date),
+            'price_unit': self.currency_id._convert(self.price_unit, aml_currency, self.company_id, date, round=False),
             'tax_ids': [(6, 0, self.taxes_id.ids)],
             'analytic_account_id': self.account_analytic_id.id,
             'analytic_tag_ids': [(6, 0, self.analytic_tag_ids.ids)],


### PR DESCRIPTION
…currency

Description of the issue/feature this PR addresses:
Bug introduced at 
https://github.com/vauxoo/odoo/commit/b299e880417026688b2fbde23307bd011de8c44d

Current behavior before PR:
Odoo round amounts

Desired behavior after PR is merged:
Keep decimals without rounding



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
