### PR TITLE
[IMP] payment_stripe_sca: make PaymentForm widget inheritable

### DIFF
--- a/addons/payment_stripe_sca/static/src/js/payment_form.js
+++ b/addons/payment_stripe_sca/static/src/js/payment_form.js
@@ -184,5 +184,6 @@ odoo.define('payment_stripe.payment_form', function (require) {
             }
         },
     });
+    return PaymentForm;
 });
     


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
- Add missing return to widget PaymentForm on payments_stripe_sca module to make it inheritable

Current behavior before PR:
- Before this PR PaymentForm could not be inherited from another js

Desired behavior after PR is merged:
- After this PR PymentForm could be inherited from another js



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
