### PR TITLE
[IMP] website_sale: modify products domain by searching

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -162,14 +162,23 @@ class WebsiteSale(ProductConfiguratorController):
 
     def _get_search_domain(self, search, category, attrib_values):
         domain = request.website.sale_product_domain()
+        domain.pop(0)
         if search:
-            for srch in search.split(" "):
-                domain += [
-                    '|', '|', '|', ('name', 'ilike', srch), ('description', 'ilike', srch),
-                    ('description_sale', 'ilike', srch), ('product_variant_ids.default_code', 'ilike', srch)]
+            domain_ex = []
+
+            for srch in search.strip().split(" "):
+                domain_ex.append(('name', 'ilike', srch))
+                domain_ex.append(('description', 'ilike', srch))
+                domain_ex.append(('description_sale', 'ilike', srch))
+                domain_ex.append(('product_variant_ids.default_code', 'ilike', srch))
+
+            for index in range(1, len(domain_ex)):
+                domain_ex.insert(0, '|')
+
+            domain += domain_ex
 
         if category:
-            domain += [('public_categ_ids', 'child_of', int(category))]
+            domain.insert(0, ('public_categ_ids', 'child_of', int(category)))
 
         if attrib_values:
             attrib = None


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
The previous behavior of the method changed added tuples to the domain of products in the wrong way, with an AND expression of OR elements, this have issues when a searching was made because the this new tuples coming from the searching have to be added as OR expressions.

Current behavior before PR:
The new tuples resulting from the searching are being grouped an added at the end of the domain, then the number of tuples added minus one pipes are added before this bunch of new expression, in this way the tuples that search for products with attributes similar to the search words are being searched with an OR expression.

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
