### PR TITLE
[REF] base: archive merged partners instead unlink 

### DIFF
--- a/odoo/addons/base/wizard/base_partner_merge.py
+++ b/odoo/addons/base/wizard/base_partner_merge.py
@@ -327,7 +327,7 @@ class MergePartnerAutomatic(models.TransientModel):
         self._log_merge_operation(src_partners, dst_partner)
 
         # delete source partner, since they are merged
-        src_partners.unlink()
+        src_partners.write({src_partners._active_name: False})
 
     def _log_merge_operation(self, src_partners, dst_partner):
         _logger.info('(uid = %s) merged the partners %r with %s', self._uid, src_partners.ids, dst_partner.id)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

When merging partners, Odoo out-of-box deletes partner records merged, but in some cases, we need to know which partner was merged and maybe make a unmerge but if the record is deleted there is no way to recover that data, PR changes the method to archive records instead unlink.

Current behavior before PR:

Merged partners are deleted.

Desired behavior after PR is merged:

Merged partners are archived.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
