### PR TITLE
[IMP] stock: add patch in order to allow set delays into route as half

### DIFF
--- a/addons/stock/models/stock_rule.py
+++ b/addons/stock/models/stock_rule.py
@@ -53,7 +53,7 @@ class StockRule(models.Model):
     picking_type_id = fields.Many2one(
         'stock.picking.type', 'Operation Type',
         required=True)
-    delay = fields.Integer('Delay', default=0, help="The expected date of the created transfer will be computed based on this delay.")
+    delay = fields.Float('Delay', default=0, help="The expected date of the created transfer will be computed based on this delay.")
     partner_address_id = fields.Many2one('res.partner', 'Partner Address', help="Address where goods should be delivered. Optional.")
     propagate = fields.Boolean(
         'Propagate cancel and split', default=True,


### PR DESCRIPTION
days
e.g
if we want a delay half day we set 0.5 that means that after
12:00 pm the promise delivery should be the next day but before 12:00 pm
the delivery could be the same day

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
