### PR TITLE
[FIX] account_check_printing: RecursionError: maximum recursion depth exceeded while calling a Python object

### DIFF
--- a/addons/account_check_printing/models/account_payment.py
+++ b/addons/account_check_printing/models/account_payment.py
@@ -41,7 +41,7 @@ class AccountPayment(models.Model):
 
     @api.constrains('check_number', 'journal_id')
     def _constrains_check_number(self):
-        if not self:
+        if not self or self.env.context.get('install_mode'):
             return
         try:
             self.mapped(lambda p: str(int(p.check_number)))


### PR DESCRIPTION
  File /home/odoo/instance/odoo/addons/account_check_printing/models/account_payment.py, line 50, in _constrains_check_number

Running `-u payment`

```txt
odoo.tools.convert.ParseError: while parsing /home/odoo/instance/odoo/addons/payment/views/payment_views.xml:170, near
<record id="action_payment_acquirer" model="ir.actions.act_window">
            <field name="name">Payment Acquirers</field>
            <field name="res_model">payment.acquirer</field>
            <field name="view_mode">kanban,tree,form</field>
            <field name="help" type="html">
                <p class="o_view_nocontent_smiling_face">
                    Create a new payment acquirer
                </p>
            </field>
```

