### PR TITLE
[IMP] web: change way of searching for translations with openerp-web string in its comments t#52488

### DIFF
--- a/addons/web/controllers/main.py
+++ b/addons/web/controllers/main.py
@@ -616,7 +616,7 @@ class WebClient(http.Controller):
         translations_per_module = {}
         messages = request.env['ir.translation'].sudo().search_read([
             ('module', 'in', mods), ('lang', '=', lang),
-            ('comments', 'like', 'openerp-web'), ('value', '!=', False),
+            ('has_openerp_comment', '=', True), ('value', '!=', False),
             ('value', '!=', '')],
             ['module', 'src', 'value', 'lang'], order='module')
         for mod, msg_group in itertools.groupby(messages, key=operator.itemgetter('module')):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
The search_read() method that is looking for translations that contains openerp-web in its comments is heavy, a new field added to `ir_translation`  model `has_openerp_comment` is used now to make this search_read() more effective. 




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
