### PR TITLE
[FIX] Inheritance in constructor of Order Model.

### DIFF
--- a/addons/pos_coupon/static/src/js/coupon.js
+++ b/addons/pos_coupon/static/src/js/coupon.js
@@ -254,6 +254,9 @@ odoo.define('pos_coupon.pos', function (require) {
 
         initialize: function () {
             let res = _order_super.initialize.apply(this, arguments);
+            if(!res){
+                res = this;
+            }
             res.on(
                 'update-rewards',
                 () => {


### PR DESCRIPTION
- Odoo is returning a promise in the module point_of_sale but promises
are resolved until all data is loaded, since the promise is not
resolved we must pass to the constructor the context object to grant
acces to the object and its properties.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
