### PR TITLE
[REF] stock: Improve backorder confirmation wizard, modifying it to v… Task#53930

### DIFF
--- a/addons/stock/wizard/stock_backorder_confirmation.py
+++ b/addons/stock/wizard/stock_backorder_confirmation.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from psycopg2.extensions import TransactionRollbackError
 from odoo import api, fields, models, _
 from odoo.tools.float_utils import float_compare
 
@@ -13,19 +14,32 @@ class StockBackorderConfirmation(models.TransientModel):
 
     @api.one
     def _process(self, cancel_backorder=False):
-        if cancel_backorder:
-            for pick_id in self.pick_ids:
-                moves_to_log = {}
-                for move in pick_id.move_lines:
-                    if float_compare(move.product_uom_qty, move.quantity_done, precision_rounding=move.product_uom.rounding) > 0:
-                        moves_to_log[move] = (move.quantity_done, move.product_uom_qty)
-                pick_id._log_less_quantities_than_expected(moves_to_log)
-        self.pick_ids.action_done()
-        if cancel_backorder:
-            for pick_id in self.pick_ids:
-                backorder_pick = self.env['stock.picking'].search([('backorder_id', '=', pick_id.id)])
-                backorder_pick.action_cancel()
-                pick_id.message_post(body=_("Back order <em>%s</em> <b>cancelled</b>.") % (",".join([b.name or '' for b in backorder_pick])))
+        auto_commit = self.env['ir.config_parameter'].sudo().get_param('auto_commit_process_backorders')
+        for pick_id in self.pick_ids:
+            for attempt in range(3):
+                try:
+                    with self.env.cr.savepoint():
+                        if cancel_backorder:
+                            moves_to_log = {}
+                            for move in pick_id.move_lines:
+                                if float_compare(move.product_uom_qty, move.quantity_done,
+                                                 precision_rounding=move.product_uom.rounding) > 0:
+                                    moves_to_log[move] = (move.quantity_done, move.product_uom_qty)
+                            if moves_to_log:
+                                pick_id._log_less_quantities_than_expected(moves_to_log)
+                        pick_id.action_done()
+                        if cancel_backorder:
+                            backorder_pick = self.env['stock.picking'].search([('backorder_id', '=', pick_id.id)])
+                            backorder_pick.action_cancel()
+                            pick_id.message_post(body=_("Back order <em>%s</em> <b>cancelled</b>.") % (
+                                ",".join([b.name or '' for b in backorder_pick])))
+                        break
+                except TransactionRollbackError as tre:
+                    if attempt < 2:
+                        continue
+                    raise tre
+            if auto_commit:
+                self.env.cr.commit()
 
     def process(self):
         self._process()


### PR DESCRIPTION
Task: https://www.vauxoo.com/web#id=53930&action=1928&model=project.task&view_type=form&cids=1&menu_id=1490

[REF] stock: Improve backorder confirmation wizard, modifying it to validate picking one by one and option to commit after each one, this is to improve performance when validating a batch with a lot of pickings.

Description of the issue/feature this PR addresses: When having a lot of pickings inside a batch, and mostly all are partially validated and need to generate a backorder, if one of the pickings has an error of concurrency then all process is stopped and has to begin anew. If the process already had 1 hour, then it has to wait another hour to reach the point were the error was caught.

Current behavior before PR: All pickings of the batch are validated at same time and the changes commit after all are done.

Desired behavior after PR is merged: Being able to commit after each picking is done, so in case of having an error it starts anew from the picking that was being validated instead of the first one. And also try another time to validate the picking in case the error was a concurrency error.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
