### PR TITLE
[REF] account_check_printing: Speed-up payment creation if they are not a check

### DIFF
--- a/addons/account_check_printing/models/account_payment.py
+++ b/addons/account_check_printing/models/account_payment.py
@@ -41,7 +41,7 @@ class AccountPayment(models.Model):
 
     @api.constrains('check_number', 'journal_id')
     def _constrains_check_number(self):
-        if not self:
+        if not self.filtered('check_number') or self.env.context.get('install_mode'):
             return
         try:
             self.mapped(lambda p: str(int(p.check_number)))


### PR DESCRIPTION
Commit performs:

1. Speed-up payment creation if they are not a check

The constraint to validate the Check Number is so slow since that it is comparing the full table vs the full table
instead of only check the new items added

Analyzing the following query:

    SELECT
        payment.check_number,
        move.journal_id
    FROM
        account_payment payment
        JOIN account_move move ON move.id = payment.move_id
        JOIN account_journal journal ON journal.id = move.journal_id,
        account_payment other_payment
        JOIN account_move other_move ON other_move.id = other_payment.move_id
    WHERE
        payment.check_number::integer = other_payment.check_number::integer
        AND move.journal_id = other_move.journal_id
        AND payment.id != other_payment.id
        AND payment.id IN (1085159)
        AND move.state = 'posted'
        AND other_move.state = 'posted';

The output is:

    Planning Time: 3.354 ms
    Execution Time: 2514.660 ms

The problem is greather than you think since that the query is executed even
if you are creating a normal payment that it is not a check (check_number empty)

It bypass the validation if it is not a check

Disclaimer: It is not fixing the slow query for check number validation

2. RecursionError: maximum recursion depth exceeded while calling a Python object

File /home/odoo/instance/odoo/addons/account_check_printing/models/account_payment.py, line 50, in _constrains_check_number

Original Author: @moylop260

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr

PATCH USE
