### PR TITLE
[REF] stock: Enable Delivery Slip report to be generated for multiple…

### DIFF
--- a/addons/stock/report/report_deliveryslip.xml
+++ b/addons/stock/report/report_deliveryslip.xml
@@ -4,6 +4,7 @@
     <template id="report_delivery_document">
         <t t-call="web.html_container">
             <t t-call="web.external_layout">
+                <t t-foreach="docs" t-as="o">
                 <t t-set="o" t-value="o.with_context(lang=o.partner_id.lang)" />
                 <t t-set="partner" t-value="o.partner_id or (o.move_lines and o.move_lines[0].partner_id) or False"/>
                 <t t-if="partner" name="partner_header">
@@ -109,14 +110,14 @@
                         </t>
                     </p>
                 </div>
+                <p style="page-break-after:always"/>
+                </t>
             </t>
          </t>
     </template>
 
     <template id="report_deliveryslip">
-        <t t-foreach="docs" t-as="o">
-            <t t-call="stock.report_delivery_document" t-lang="o.partner_id.lang"/>
-        </t>
+        <t t-call="stock.report_delivery_document" t-lang="docs[0].partner_id.lang"/>
     </template>
 
 </odoo>


### PR DESCRIPTION
… pickings at once.

Description of the issue/feature this PR addresses:

Current behavior before PR: When trying to print the delivery slip report selecting multiple pickings, it will generate only one pdf for the first picking selected.

Desired behavior after PR is merged: Being able to generate one delivery slip report for all the selected pickings in one pdf, each separated on their own pages.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
