### PR TITLE
sql_db: Add odoo pid to connection in application_name

### DIFF
--- a/odoo/sql_db.py
+++ b/odoo/sql_db.py
@@ -12,6 +12,7 @@ from contextlib import contextmanager
 from functools import wraps
 import itertools
 import logging
+import os
 import time
 import uuid
 import warnings
@@ -29,6 +30,8 @@ from odoo.api import Environment
 psycopg2.extensions.register_type(psycopg2.extensions.UNICODE)
 
 _logger = logging.getLogger(__name__)
+_logger_conn = _logger.getChild("connection")
+
 
 def unbuffer(symb, cr):
     if symb is None:
@@ -572,7 +575,7 @@ class ConnectionPool(object):
         return "ConnectionPool(used=%d/count=%d/max=%d)" % (used, count, self._maxconn)
 
     def _debug(self, msg, *args):
-        _logger.debug(('%r ' + msg), self, *args)
+        _logger_conn.debug(('%r ' + msg), self, *args)
 
     @locked
     def borrow(self, connection_info):
@@ -630,7 +633,7 @@ class ConnectionPool(object):
             raise
         result._original_dsn = connection_info
         self._connections.append((result, True))
-        self._debug('Create new connection')
+        self._debug('Create new connection backend PID %d', result.get_backend_pid())
         return result
 
     @locked
@@ -693,6 +696,7 @@ def connection_info_for(db_or_uri):
     :param str db_or_uri: database name or postgres dsn
     :rtype: (str, dict)
     """
+    app_name = "odoo-%d" % os.getpid()
     if db_or_uri.startswith(('postgresql://', 'postgres://')):
         # extract db from uri
         us = urls.url_parse(db_or_uri)
@@ -702,9 +706,9 @@ def connection_info_for(db_or_uri):
             db_name = us.username
         else:
             db_name = us.hostname
-        return db_name, {'dsn': db_or_uri}
+        return db_name, {'dsn': db_or_uri, 'application_name': app_name}
 
-    connection_info = {'database': db_or_uri}
+    connection_info = {'database': db_or_uri, 'application_name': app_name}
     for p in ('host', 'port', 'user', 'password', 'sslmode'):
         cfg = tools.config['db_' + p]
         if cfg:


### PR DESCRIPTION
Backport from 
 - https://github.com/odoo/odoo/pull/82857



It helps to debug queries executed in postgresql from Odoo
in order to know where they were called

Enabling the postgresql logs with the following `log_line_prefix`

    log_line_prefix='%t [%p]: [%l-1] db=%d,user=%u,client=%h,app=%a '

You will see the following output in the postgresql.log:

    ... UTC [394452]: [371-1] db=odoo,user=odoo,client=127.0.0.1,app=odoo-740755 LOG:  00000: duration: 0.074 ms  statement: SELECT 1

Notice `app=odoo-740755` it is the odoo pid that executed the query
and the postgresql PID `... UTC [394452]:`

Then you will be able to match the odoo.log and postgresql.log using the PIDs

    740755 DEBUG odoo odoo.sql_db.connection: ConnectionPool(used=1/count=2/max=64) Create new connection backend PID 394452
    740755 INFO odoo odoo.addons: Running SELECT 1

Notice the Odoo PID `740755 INFO` and the postgresql PID `backend pid 394452`

Note: It will require enable the sub-logger
   - `--log-handler=odoo.sql_db.connection:DEBUG`

It will helps to debug what process is executing each query in the database
or if a postgressql PID is showing a error log related to connection (not even from a query)

e.g. The livechat stuck and you don't know what happen but you can see the postgresql.log the following message
for the same PostgreSQL backend_pid related to longpolling odoo pid

    [394452]: [371-2] db=odoo,user=odoo,client=127.0.0.1,app=odoo-740755 LOG:  XX00: Could not receive data from client: Connection time out

Signed-off-by: Moises Lopez - https://www.vauxoo.com/ <moylop260@vauxoo.com>

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
