### PR TITLE
[IMP] sale: Added context value to prevent auto invoice

### DIFF
--- a/addons/sale/models/payment.py
+++ b/addons/sale/models/payment.py
@@ -114,7 +114,7 @@ class PaymentTransaction(models.Model):
         # invoice the sale orders if needed
         self._invoice_sale_orders()
         res = super(PaymentTransaction, self)._reconcile_after_transaction_done()
-        if self.env['ir.config_parameter'].sudo().get_param('sale.automatic_invoice'):
+        if self.env['ir.config_parameter'].sudo().get_param('sale.automatic_invoice') and not self._context.get('avoid_auto_invoice'):
             default_template = self.env['ir.config_parameter'].sudo().get_param('sale.default_email_template')
             if default_template:
                 for trans in self.filtered(lambda t: t.sale_order_ids):
@@ -129,7 +129,7 @@ class PaymentTransaction(models.Model):
 
     @api.multi
     def _invoice_sale_orders(self):
-        if self.env['ir.config_parameter'].sudo().get_param('sale.automatic_invoice'):
+        if self.env['ir.config_parameter'].sudo().get_param('sale.automatic_invoice') and not self._context.get('avoid_auto_invoice'):
             for trans in self.filtered(lambda t: t.sale_order_ids):
                 ctx_company = {'company_id': trans.acquirer_id.company_id.id,
                                'force_company': trans.acquirer_id.company_id.id}


### PR DESCRIPTION
The purpose of this MR is to be able to apply the changes via patch.

In a previous development to a client (ABSA), the payment acquirers have a field
to specify the invoice policy.

Since we are not using the default invoice policy (the one from the config), the original
validation only compares the config parameter, so even if we change the policy
to delivered quantities, the invoice will be created in case the default policy has auto invoice checked.

A sale order with the invoice policy set from the payment acquirer as 'delivered quantities' will create an automatic invoice.
Using the above case, the sale order won't create an invoice.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
