### PR TITLE
[IMP] website_sale: Add statement in case we want to use another uom via context

### DIFF
--- a/addons/website_sale/models/sale_order.py
+++ b/addons/website_sale/models/sale_order.py
@@ -120,7 +120,10 @@ class SaleOrder(models.Model):
             # This part is pretty much a copy-paste of the method '_onchange_discount' of
             # 'sale.order.line'.
             price, rule_id = order.pricelist_id.with_context(product_context).get_product_price_rule(product, qty or 1.0, order.partner_id)
-            pu, currency = request.env['sale.order.line'].with_context(product_context)._get_real_price_currency(product, rule_id, qty, product.uom_id, order.pricelist_id.id)
+            if self._context.get('sale_uom'):
+                pu, currency = request.env['sale.order.line'].with_context(product_context)._get_real_price_currency(product, rule_id, qty, self._context.get('sale_uom'), order.pricelist_id.id)
+            else:
+                pu, currency = request.env['sale.order.line'].with_context(product_context)._get_real_price_currency(product, rule_id, qty, product.uom_id, order.pricelist_id.id)
             if pu != 0:
                 if order.pricelist_id.currency_id != currency:
                     # we need new_list_price in the same currency as price, which is in the SO's pricelist's currency


### PR DESCRIPTION
### ``def _website_product_id_change``

The calculation made to get the price is by using ``product.template(...).uom_id``

If we want to use a different UOM, for example ``product.template(...).uom_ids[0] = Bag with 25 units`` which is different from ``product.template(...).uom_id = Unit``

We need to send the specific UOM via context, otherwise the price will be calculated with the UOM ``unit``

**PR to be able to use it as a patch**

---

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
