### PR TITLE
[REF] base_vat: Speed-up check_vat if there is not vat

### DIFF
--- a/addons/base_vat/models/res_partner.py
+++ b/addons/base_vat/models/res_partner.py
@@ -145,14 +145,15 @@ class ResPartner(models.Model):
 
     @api.constrains('vat', 'country_id')
     def check_vat(self):
+        partners_with_vat = self.filtered('vat')
+        if not partners_with_vat:
+            return
         if self.env.context.get('company_id'):
             company = self.env['res.company'].browse(self.env.context['company_id'])
         else:
             company = self.env.company
         eu_countries = self.env.ref('base.europe').country_ids
-        for partner in self:
-            if not partner.vat:
-                continue
+        for partner in partners_with_vat:
 
             if company.vat_check_vies and partner.commercial_partner_id.country_id in eu_countries:
                 # force full VIES online check


### PR DESCRIPTION
The following line of code:

    self.env.ref("base.europe").with_context(lang="fr_CA").country_ids

It is executing the following query:

    SELECT res_country_res_country_group_rel.res_country_group_id, res_country_res_country_group_rel.res_country_id FROM res_country_res_country_group_rel, "res_country" LEFT JOIN "ir_translation" AS "res_country__name" ON ("res_country"."id" = "res_country__name"."res_id" AND "res_country__name"."type" = 'model' AND "res_country__name"."name" = 'res.country,name' AND "res_country__name"."lang" = 'fr_CA' AND "res_country__name"."value" != '')
    WHERE 1=1 AND res_country_res_country_group_rel.res_country_group_id IN (1) AND res_country_res_country_group_rel.res_country_id = res_country.id
    ORDER BY COALESCE("res_country__name"."value", "res_country"."name")
    OFFSET 0

With duration: 138.119ms

But it is not needed to spend processing to compute it if it even will not be used if the `vat` is empty

If your website checkout process is creating almost the partners without `vat`
it could have a better performance

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:

PATCH USE



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
