### PR TITLE
[FIX] pos_restaurant: Tips screen waits for the rewards to be updated, after block order again

### DIFF
--- a/addons/pos_restaurant/static/src/js/Screens/TipScreen.js
+++ b/addons/pos_restaurant/static/src/js/Screens/TipScreen.js
@@ -67,26 +67,52 @@ odoo.define('pos_restaurant.TipScreen', function (require) {
                 });
                 if (!confirmed) return;
             }
-
+            /**
+             * Callback to be notified, when all the rewards are finish being updated.
+             * kept here to have access to the variables used within `validateTip`.
+             */
+             const _callbackAfterTip = async () => {
+                /**
+                 * We only want this to be notified once so we insta-clear this callback.
+                 * Also in this point we can safely set the order back to `finalzed = true`,
+                 * since all the rewards has been applied.
+                 */
+                order.off('rewards-updated', _callbackAfterTip);
+                order.finalized = true;
+                /**
+                 * All the rest of the code within `_callbackAfterTip`, has been kept intact.
+                 */
+                const paymentline = this.env.pos.get_order().get_paymentlines()[0];
+                if (paymentline.payment_method.payment_terminal) {
+                    paymentline.amount += amount;
+                    await paymentline.payment_method.payment_terminal.send_payment_adjust(paymentline.cid);
+                }
+                // set_tip calls add_product which sets the new line as the selected_orderline
+                const tip_line = order.selected_orderline;
+                await this.rpc({
+                    method: 'set_tip',
+                    model: 'pos.order',
+                    args: [serverId, tip_line.export_as_JSON()],
+                });
+                this.goNextScreen();
+            };
             // set the tip by temporarily allowing order modification
             order.finalized = false;
-            order.set_tip(amount);
-            order.finalized = true;
-
-            const paymentline = this.env.pos.get_order().get_paymentlines()[0];
-            if (paymentline.payment_method.payment_terminal) {
-                paymentline.amount += amount;
-                await paymentline.payment_method.payment_terminal.send_payment_adjust(paymentline.cid);
+            /**
+             * The trigger `rewards-updated`, is only ran, if there is programs to be set. so we need
+             * this evaluation to use sync or async workflow.
+             */
+            if (this.env.pos.config.promo_programs_ids?.length) {
+                /**
+                 * Since `set_tip` has asyncronous actions, we need to wait for them to be done
+                 * after we block our order again, so we declare the callback.
+                 */
+                order.on('rewards-updated', _callbackAfterTip);
+                order.set_tip(amount);
+            } else {
+                order.set_tip(amount);
+                _callbackAfterTip();
             }
-
-            // set_tip calls add_product which sets the new line as the selected_orderline
-            const tip_line = order.selected_orderline;
-            await this.rpc({
-                method: 'set_tip',
-                model: 'pos.order',
-                args: [serverId, tip_line.export_as_JSON()],
-            });
-            this.goNextScreen();
         }
         goNextScreen() {
             this.env.pos.get_order().finalize();


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

When configuring a `pos.config` with: 
1. The extra tip screen
2. Rewards programs

Do the next:

1. Create an order with a discount from a reward program.
4. Pay the order witout a tip, so you can continue to the tip screen.
5. Add a tip, and print the receipt of that order.

Current behavior before PR:

The discount from the reward program is deleted from the ticket.

Desired behavior after PR is merged:

The discount from the reward program is kept in the ticket.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
