### PR TITLE
[FIX] mail: missing ARIA attributes after OWL

### DIFF
--- a/addons/mail/i18n/mail.pot
+++ b/addons/mail/i18n/mail.pot
@@ -80,6 +80,20 @@ msgstr ""
 
 #. module: mail
 #. openerp-web
+#: code:addons/mail/static/src/components/chatter_topbar/chatter_topbar.xml:0
+#, python-format
+msgid "%s Attachment(s)"
+msgstr ""
+
+#. module: mail
+#. openerp-web
+#: code:addons/mail/static/src/components/follower_list_menu/follower_list_menu.xml:0
+#, python-format
+msgid "%s Follower(s)"
+msgstr ""
+
+#. module: mail
+#. openerp-web
 #: code:addons/mail/static/src/models/thread/thread.js:0
 #, python-format
 msgid "%s and %s are typing..."
@@ -602,6 +616,7 @@ msgstr ""
 #. module: mail
 #. openerp-web
 #: code:addons/mail/static/src/components/composer/composer.xml:0
+#: code:addons/mail/static/src/components/composer/composer.xml:0
 #, python-format
 msgid "Add attachment"
 msgstr ""
@@ -930,14 +945,6 @@ msgstr ""
 #. module: mail
 #: model:ir.model.fields,field_description:mail.field_mail_channel__moderation_notify
 msgid "Automatic notification"
-msgstr ""
-
-#. module: mail
-#. openerp-web
-#: code:addons/mail/static/src/components/follower/follower.xml:0
-#: code:addons/mail/static/src/components/message/message.xml:0
-#, python-format
-msgid "Avatar"
 msgstr ""
 
 #. module: mail
@@ -1699,6 +1706,13 @@ msgid "Delivery Failed"
 msgstr ""
 
 #. module: mail
+#. openerp-web
+#: code:addons/mail/static/src/components/message/message.xml:0
+#, python-format
+msgid "Delivery failure"
+msgstr ""
+
+#. module: mail
 #: model:ir.model.fields,field_description:mail.field_mail_channel__description
 #: model:ir.model.fields,field_description:mail.field_mail_message_subtype__description
 #: model:ir.model.fields,field_description:mail.field_mail_shortcode__description
@@ -1921,6 +1935,8 @@ msgstr ""
 #. openerp-web
 #: code:addons/mail/static/src/components/attachment/attachment.xml:0
 #: code:addons/mail/static/src/components/attachment/attachment.xml:0
+#: code:addons/mail/static/src/components/attachment/attachment.xml:0
+#: code:addons/mail/static/src/components/attachment/attachment.xml:0
 #: code:addons/mail/static/src/components/attachment_viewer/attachment_viewer.xml:0
 #: code:addons/mail/static/src/components/attachment_viewer/attachment_viewer.xml:0
 #: code:addons/mail/static/src/xml/thread.xml:0
@@ -2008,6 +2024,7 @@ msgstr ""
 
 #. module: mail
 #. openerp-web
+#: code:addons/mail/static/src/components/follower/follower.xml:0
 #: code:addons/mail/static/src/components/follower/follower.xml:0
 #, python-format
 msgid "Edit subscription"
@@ -2170,6 +2187,13 @@ msgstr ""
 #: model:ir.ui.menu,name:mail.menu_mail_mail
 #: model_terms:ir.ui.view,arch_db:mail.view_mail_tree
 msgid "Emails"
+msgstr ""
+
+#. module: mail
+#. openerp-web
+#: code:addons/mail/static/src/components/composer/composer.xml:0
+#, python-format
+msgid "Emojis"
 msgstr ""
 
 #. module: mail
@@ -2499,6 +2523,7 @@ msgstr ""
 
 #. module: mail
 #. openerp-web
+#: code:addons/mail/static/src/components/composer/composer.xml:0
 #: code:addons/mail/static/src/components/composer/composer.xml:0
 #, python-format
 msgid "Full composer"
@@ -3466,6 +3491,7 @@ msgstr ""
 #. module: mail
 #. openerp-web
 #: code:addons/mail/static/src/components/message/message.xml:0
+#: code:addons/mail/static/src/components/message/message.xml:0
 #: code:addons/mail/static/src/components/thread_needaction_preview/thread_needaction_preview.xml:0
 #: code:addons/mail/static/src/components/thread_preview/thread_preview.xml:0
 #, python-format
@@ -3474,6 +3500,7 @@ msgstr ""
 
 #. module: mail
 #. openerp-web
+#: code:addons/mail/static/src/components/message/message.xml:0
 #: code:addons/mail/static/src/components/message/message.xml:0
 #, python-format
 msgid "Mark as Todo"
@@ -4127,6 +4154,13 @@ msgstr ""
 #: model:ir.model.fields,field_description:mail.field_mail_activity__note
 #: model:mail.message.subtype,name:mail.mt_note
 msgid "Note"
+msgstr ""
+
+#. module: mail
+#. openerp-web
+#: code:addons/mail/static/src/components/message/message.xml:0
+#, python-format
+msgid "Note by"
 msgstr ""
 
 #. module: mail
@@ -5021,6 +5055,8 @@ msgstr ""
 #. openerp-web
 #: code:addons/mail/static/src/components/attachment/attachment.xml:0
 #: code:addons/mail/static/src/components/attachment/attachment.xml:0
+#: code:addons/mail/static/src/components/attachment/attachment.xml:0
+#: code:addons/mail/static/src/components/attachment/attachment.xml:0
 #, python-format
 msgid "Remove"
 msgstr ""
@@ -5052,6 +5088,7 @@ msgstr ""
 #. module: mail
 #. openerp-web
 #: code:addons/mail/static/src/components/follower/follower.xml:0
+#: code:addons/mail/static/src/components/follower/follower.xml:0
 #, python-format
 msgid "Remove this follower"
 msgstr ""
@@ -5065,6 +5102,7 @@ msgstr ""
 
 #. module: mail
 #. openerp-web
+#: code:addons/mail/static/src/components/message/message.xml:0
 #: code:addons/mail/static/src/components/message/message.xml:0
 #: model_terms:ir.ui.view,arch_db:mail.view_mail_form
 #, python-format
@@ -5683,6 +5721,13 @@ msgid "System notification"
 msgstr ""
 
 #. module: mail
+#. openerp-web
+#: code:addons/mail/static/src/components/message/message.xml:0
+#, python-format
+msgid "System notification by"
+msgstr ""
+
+#. module: mail
 #: model:ir.model.fields,field_description:mail.field_mail_template_preview__model_id
 msgid "Targeted model"
 msgstr ""
@@ -6257,12 +6302,14 @@ msgstr ""
 #. module: mail
 #. openerp-web
 #: code:addons/mail/static/src/components/attachment/attachment.xml:0
+#: code:addons/mail/static/src/components/attachment/attachment.xml:0
 #, python-format
 msgid "Uploaded"
 msgstr ""
 
 #. module: mail
 #. openerp-web
+#: code:addons/mail/static/src/components/attachment/attachment.xml:0
 #: code:addons/mail/static/src/components/attachment/attachment.xml:0
 #, python-format
 msgid "Uploading"

--- a/addons/mail/static/src/components/activity/activity.xml
+++ b/addons/mail/static/src/components/activity/activity.xml
@@ -47,7 +47,7 @@
                                 <t t-esc="assignedUserText"/>
                             </div>
                         </t>
-                        <a class="o_Activity_detailsButton btn btn-link" t-on-click="_onClickDetailsButton" role="button">
+                        <a href="javascript:;" class="o_Activity_detailsButton btn btn-link" t-on-click="_onClickDetailsButton" role="button" t-att-aria-expanded="state.areDetailsVisible ? 'true' : 'false'">
                             <i class="fa fa-info-circle" role="img" title="Info"/>
                         </a>
                     </div>

--- a/addons/mail/static/src/components/activity_box/activity_box.xml
+++ b/addons/mail/static/src/components/activity_box/activity_box.xml
@@ -4,7 +4,7 @@
     <t t-name="mail.ActivityBox" owl="1">
         <div class="o_ActivityBox">
             <t t-if="chatter and chatter.thread">
-                <a role="button" class="o_ActivityBox_title btn" t-on-click="_onClickTitle">
+                <a href="javascript:;" role="button" class="o_ActivityBox_title btn" t-on-click="_onClickTitle" t-att-aria-expanded="chatter.isActivityBoxVisible ? 'true' : 'false'">
                     <hr class="o_ActivityBox_titleLine" />
                     <span class="o_ActivityBox_titleText">
                         <i class="fa fa-fw" t-att-class="chatter.isActivityBoxVisible ? 'fa-caret-down' : 'fa-caret-right'"/>

--- a/addons/mail/static/src/components/attachment/attachment.scss
+++ b/addons/mail/static/src/components/attachment/attachment.scss
@@ -43,6 +43,14 @@
     justify-content: center;
 }
 
+.o_Attachment_button {
+    background: none;
+    color: inherit;
+    border: none;
+    padding: 0;
+    cursor: pointer;
+}
+
 .o_Attachment_asideItemUnlink.o-pretty {
     position: absolute;
     top: 0;
@@ -128,7 +136,6 @@
 
 .o_Attachment_action {
     border-radius: 10px;
-    cursor: pointer;
     text-align: center;
 
     &:hover {
@@ -141,16 +148,12 @@
 }
 
 .o_Attachment_asideItemDownload {
-    cursor: pointer;
-
     &:hover {
         background-color: gray('400');
     }
 }
 
 .o_Attachment_asideItemUnlink {
-    cursor: pointer;
-
     &:not(.o-pretty):hover {
         background-color: gray('400');
     }

--- a/addons/mail/static/src/components/attachment/attachment.xml
+++ b/addons/mail/static/src/components/attachment/attachment.xml
@@ -10,6 +10,8 @@
                 'o-temporary': attachment and attachment.isTemporary,
                 'o-viewable': attachment and attachment.isViewable,
             }" t-att-title="attachment ? attachment.displayName : undefined" t-att-data-attachment-local-id="attachment ? attachment.localId : undefined"
+                t-att-aria-label="attachment ? attachment.displayName : undefined"
+                role="group"
         >
             <t t-if="attachment">
                 <!-- Image style-->
@@ -40,19 +42,20 @@
                             <div class="o_Attachment_actions">
                                 <!-- Remove button -->
                                 <t t-if="props.isEditable" t-key="'unlink'">
-                                    <div class="o_Attachment_action o_Attachment_actionUnlink"
+                                    <button class="o_Attachment_action o_Attachment_button o_Attachment_actionUnlink"
                                         t-att-class="{
                                             'o-pretty': attachment.isLinkedToComposer,
                                         }" t-on-click="_onClickUnlink" title="Remove"
+                                        aria-label="Remove"
                                     >
                                         <i class="fa fa-times"/>
-                                    </div>
+                                    </button>
                                 </t>
                                 <!-- Download button -->
                                 <t t-if="props.isDownloadable and !attachment.isTemporary" t-key="'download'">
-                                    <div class="o_Attachment_action o_Attachment_actionDownload" t-on-click="_onClickDownload" title="Download">
+                                    <button class="o_Attachment_action o_Attachment_button o_Attachment_actionDownload" t-on-click="_onClickDownload" title="Download" aria-label="Download">
                                         <i class="fa fa-download"/>
-                                    </div>
+                                    </button>
                                 </t>
                             </div>
                         </div>
@@ -78,27 +81,27 @@
                     <div class="o_Attachment_aside" t-att-class="{ 'o-has-multiple-action': props.isDownloadable and props.isEditable }">
                         <!-- Uploading icon -->
                         <t t-if="attachment.isTemporary and attachment.isLinkedToComposer">
-                            <div class="o_Attachment_asideItem o_Attachment_asideItemUploading" title="Uploading">
+                            <div class="o_Attachment_asideItem o_Attachment_asideItemUploading" title="Uploading" aria-label="Uploading">
                                 <i class="fa fa-spin fa-spinner"/>
                             </div>
                         </t>
                         <!-- Uploaded icon -->
                         <t t-if="!attachment.isTemporary and attachment.isLinkedToComposer">
-                            <div class="o_Attachment_asideItem o_Attachment_asideItemUploaded" title="Uploaded">
+                            <div class="o_Attachment_asideItem o_Attachment_asideItemUploaded" title="Uploaded" aria-label="Uploaded">
                                 <i class="fa fa-check"/>
                             </div>
                         </t>
                         <!-- Remove button -->
                         <t t-if="props.isEditable">
-                            <div class="o_Attachment_asideItem o_Attachment_asideItemUnlink" t-att-class="{ 'o-pretty': attachment.isLinkedToComposer }" t-on-click="_onClickUnlink" title="Remove">
+                            <button class="o_Attachment_asideItem o_Attachment_button o_Attachment_asideItemUnlink" t-att-class="{ 'o-pretty': attachment.isLinkedToComposer }" t-on-click="_onClickUnlink" title="Remove" aria-label="Remove">
                                 <i class="fa fa-times"/>
-                            </div>
+                            </button>
                         </t>
                         <!-- Download button -->
                         <t t-if="props.isDownloadable and !attachment.isTemporary">
-                            <div class="o_Attachment_asideItem o_Attachment_asideItemDownload" t-on-click="_onClickDownload" title="Download">
+                            <button class="o_Attachment_asideItem o_Attachment_button o_Attachment_asideItemDownload" t-on-click="_onClickDownload" title="Download" aria-label="Download">
                                 <i class="fa fa-download"/>
-                            </div>
+                            </button>
                         </t>
                     </div>
                 </t>

--- a/addons/mail/static/src/components/chatter_topbar/chatter_topbar.js
+++ b/addons/mail/static/src/components/chatter_topbar/chatter_topbar.js
@@ -17,6 +17,7 @@ class ChatterTopbar extends Component {
      */
     constructor(...args) {
         super(...args);
+        this.sprintf = _.str.sprintf;
         useShouldUpdateBasedOnProps();
         useStore(props => {
             const chatter = this.env.models['mail.chatter'].get(props.chatterLocalId);

--- a/addons/mail/static/src/components/chatter_topbar/chatter_topbar.xml
+++ b/addons/mail/static/src/components/chatter_topbar/chatter_topbar.xml
@@ -37,10 +37,18 @@
                     </t>
                     <div class="o-autogrow"/>
                         <div class="o_ChatterTopbar_rightSection">
-                            <button class="btn btn-link o_ChatterTopbar_button o_ChatterTopbar_buttonAttachments" type="button" t-att-disabled="chatter.isDisabled" t-on-click="_onClickAttachments">
+                            <t t-set="attachmentCount" t-value="chatter.thread ? chatter.thread.allAttachments.length : 0"/>
+                            <t t-set="attachmentButtonAria">%s Attachment(s)</t>
+                            <button class="btn btn-link o_ChatterTopbar_button o_ChatterTopbar_buttonAttachments"
+                                type="button"
+                                t-att-disabled="chatter.isDisabled"
+                                t-on-click="_onClickAttachments"
+                                t-att-aria-label="sprintf(attachmentButtonAria.toString(), attachmentCount)"
+                                t-att-aria-expanded="chatter.isAttachmentBoxVisible ? 'true' : 'false'"
+                            >
                                 <i class="fa fa-paperclip"/>
                                 <t t-if="chatter.isDisabled or !chatter.isShowingAttachmentsLoading">
-                                    <span class="o_ChatterTopbar_buttonCount o_ChatterTopbar_buttonAttachmentsCount" t-esc="chatter.thread ? chatter.thread.allAttachments.length : 0"/>
+                                    <span class="o_ChatterTopbar_buttonCount o_ChatterTopbar_buttonAttachmentsCount" t-esc="attachmentCount"/>
                                 </t>
                                 <t t-else="">
                                     <i class="o_ChatterTopbar_buttonAttachmentsCountLoader fa fa-spinner fa-spin" aria-label="Attachment counter loading..."/>

--- a/addons/mail/static/src/components/composer/composer.xml
+++ b/addons/mail/static/src/components/composer/composer.xml
@@ -97,13 +97,15 @@
                             </t>
                             <div class="o_Composer_primaryToolButtons" t-att-class="{ 'o-composer-is-compact': props.isCompact }">
                                 <Popover position="'top'" t-on-o-emoji-selection="_onEmojiSelection">
-                                    <!-- TODO FIXME o-open not possible to code due to https://github.com/odoo/owl/issues/693 -->
+                                    <!-- TODO FIXME o-open and aria-expanded not possible to code due to https://github.com/odoo/owl/issues/693 -->
                                     <button class="o_Composer_button o_Composer_buttonEmojis o_Composer_toolButton btn btn-light"
                                         t-att-class="{
                                             'o-open': false and state.displayed,
                                             'o-mobile': env.messaging.device.isMobile,
                                         }"
                                         t-on-keydown="_onKeydownEmojiButton"
+                                        aria-label="Emojis"
+                                        t-att-aria-expanded="false and (state.displayed ? 'true' : 'false')"
                                     >
                                         <i class="fa fa-smile-o"/>
                                     </button>
@@ -111,11 +113,11 @@
                                         <EmojisPopover t-ref="emojisPopover"/>
                                     </t>
                                 </Popover>
-                                <button class="o_Composer_button o_Composer_buttonAttachment o_Composer_toolButton btn btn-light fa fa-paperclip" t-att-class="{ 'o-mobile': env.messaging.device.isMobile }" title="Add attachment" type="button" t-on-click="_onClickAddAttachment"/>
+                                <button class="o_Composer_button o_Composer_buttonAttachment o_Composer_toolButton btn btn-light fa fa-paperclip" t-att-class="{ 'o-mobile': env.messaging.device.isMobile }" title="Add attachment" aria-label="Add attachment" type="button" t-on-click="_onClickAddAttachment"/>
                             </div>
                             <t t-if="props.isExpandable">
                                 <div class="o_Composer_secondaryToolButtons">
-                                    <button class="btn btn-light fa fa-expand o_Composer_button o_Composer_buttonFullComposer o_Composer_toolButton" t-att-class="{ 'o-mobile': env.messaging.device.isMobile }" title="Full composer" type="button" t-on-click="_onClickFullComposer"/>
+                                    <button class="btn btn-light fa fa-expand o_Composer_button o_Composer_buttonFullComposer o_Composer_toolButton" t-att-class="{ 'o-mobile': env.messaging.device.isMobile }" title="Full composer" aria-label="Full composer" type="button" t-on-click="_onClickFullComposer"/>
                                 </div>
                             </t>
                         </div>

--- a/addons/mail/static/src/components/emojis_popover/emojis_popover.xml
+++ b/addons/mail/static/src/components/emojis_popover/emojis_popover.xml
@@ -2,9 +2,9 @@
 <templates xml:space="preserve">
 
     <t t-name="mail.EmojisPopover" owl="1">
-        <div class="o_EmojisPopover">
+        <div role="menu" class="o_EmojisPopover">
             <t t-foreach="emojis" t-as="emoji" t-key="emoji.unicode">
-                <span class="o_EmojisPopover_emoji" t-on-click="_onClickEmoji" t-att-title="emoji.description" t-att-data-source="emoji.sources[0]" t-att-data-unicode="emoji.unicode">
+                <span role="menuitem" class="o_EmojisPopover_emoji" t-on-click="_onClickEmoji" t-att-title="emoji.description" t-att-aria-label="emoji.description" t-att-data-source="emoji.sources[0]" t-att-data-unicode="emoji.unicode">
                     <t t-esc="emoji.unicode"/>
                 </span>
             </t>

--- a/addons/mail/static/src/components/follower/follower.xml
+++ b/addons/mail/static/src/components/follower/follower.xml
@@ -4,15 +4,15 @@
     <t t-name="mail.Follower" owl="1">
         <div class="o_Follower">
             <t t-if="follower">
-                <a class="o_Follower_details" t-att-class="{ 'o-inactive': !follower.isActive }" href="#" t-on-click="_onClickDetails">
-                    <img class="o_Follower_avatar" t-attf-src="/web/image/{{ follower.resModel }}/{{ follower.resId }}/image_128" alt="Avatar"/>
+                <a role="menuitem" class="o_Follower_details" t-att-class="{ 'o-inactive': !follower.isActive }" href="#" t-on-click="_onClickDetails">
+                    <img class="o_Follower_avatar" t-attf-src="/web/image/{{ follower.resModel }}/{{ follower.resId }}/image_128" alt=""/>
                     <span class="o_Follower_name" t-esc="follower.name or follower.displayName"/>
                 </a>
                 <t t-if="follower.isEditable">
-                    <button class="btn btn-icon o_Follower_button o_Follower_editButton" title="Edit subscription" t-on-click="_onClickEdit">
+                    <button class="btn btn-icon o_Follower_button o_Follower_editButton" title="Edit subscription" aria-label="Edit subscription" t-on-click="_onClickEdit">
                         <i class="fa fa-pencil"/>
                     </button>
-                    <button class="btn btn-icon o_Follower_button o_Follower_removeButton" title="Remove this follower" t-on-click="_onClickRemove">
+                    <button class="btn btn-icon o_Follower_button o_Follower_removeButton" aria-label="Remove this follower" title="Remove this follower" t-on-click="_onClickRemove">
                         <i class="fa fa-remove"/>
                     </button>
                 </t>

--- a/addons/mail/static/src/components/follower_list_menu/follower_list_menu.js
+++ b/addons/mail/static/src/components/follower_list_menu/follower_list_menu.js
@@ -16,6 +16,7 @@ class FollowerListMenu extends Component {
      */
     constructor(...args) {
         super(...args);
+        this.sprintf = _.str.sprintf;
         useShouldUpdateBasedOnProps();
         this.state = useState({
             /**

--- a/addons/mail/static/src/components/follower_list_menu/follower_list_menu.xml
+++ b/addons/mail/static/src/components/follower_list_menu/follower_list_menu.xml
@@ -4,7 +4,14 @@
     <t t-name="mail.FollowerListMenu" owl="1">
         <div class="o_FollowerListMenu" t-on-keydown="_onKeydown">
             <div class="o_FollowerListMenu_followers" t-ref="dropdown">
-                <button class="o_FollowerListMenu_buttonFollowers btn btn-link" t-att-disabled="props.isDisabled" t-on-click="_onClickFollowersButton" title="Show Followers">
+                <t t-set="FollowersButtonAria">%s Follower(s)</t>
+                <button class="o_FollowerListMenu_buttonFollowers btn btn-link"
+                    t-att-disabled="props.isDisabled"
+                    t-on-click="_onClickFollowersButton"
+                    title="Show Followers"
+                    t-att-aria-label="sprintf(FollowersButtonAria.toString(), thread.followers.length)"
+                    t-att-aria-expanded="state.isDropdownOpen ? 'true' : 'false'"
+                >
                     <i class="fa fa-user"/>
                     <span class="o_FollowerListMenu_buttonFollowersCount pl-1" t-esc="thread.followers.length"/>
                 </button>

--- a/addons/mail/static/src/components/message/message.xml
+++ b/addons/mail/static/src/components/message/message.xml
@@ -18,7 +18,7 @@
                 <div class="o_Message_sidebar" t-att-class="{ 'o-message-squashed': props.isSquashed }">
                     <t t-if="!props.isSquashed">
                         <div class="o_Message_authorAvatarContainer o_Message_sidebarItem">
-                            <img class="o_Message_authorAvatar rounded-circle" t-att-class="{ o_Message_authorRedirect: hasAuthorOpenChat, o_redirect: hasAuthorOpenChat }" t-att-src="avatar" t-on-click="_onClickAuthorAvatar" t-att-title="hasAuthorOpenChat ? OPEN_CHAT : ''" alt="Avatar"/>
+                            <img class="o_Message_authorAvatar rounded-circle" t-att-class="{ o_Message_authorRedirect: hasAuthorOpenChat, o_redirect: hasAuthorOpenChat }" t-att-src="avatar" t-on-click="_onClickAuthorAvatar" t-att-title="hasAuthorOpenChat ? OPEN_CHAT : ''" t-att-alt="hasAuthorOpenChat ? OPEN_CHAT : ''" role="button" tabindex="0"/>
                             <t t-if="message.author and message.author.im_status">
                                 <PartnerImStatusIcon
                                     class="o_Message_partnerImStatusIcon"
@@ -61,7 +61,12 @@
                     <t t-if="!props.isSquashed">
                         <div class="o_Message_header">
                             <t t-if="message.author">
-                                <div class="o_Message_authorName o_Message_authorRedirect o_redirect" t-on-click="_onClickAuthorName" title="Open profile">
+                                <div role="link" tabindex="0" class="o_Message_authorName o_Message_authorRedirect o_redirect" t-on-click="_onClickAuthorName" title="Open profile">
+                                    <span class="sr-only">
+                                        <t t-if="message.message_type === 'notification'">System notification by</t>
+                                        <t t-elif="!(message.is_discussion or message.is_notification)">Note by</t>
+                                        <span t-esc="' '"/>
+                                    </span>
                                     <t t-if="threadView and threadView.thread">
                                         <t t-esc="threadView.thread.getMemberName(message.author)"/>
                                     </t>
@@ -103,7 +108,7 @@
                             </t>
                             <t t-if="threadView and message.originThread and message.originThread === threadView.thread and message.notifications.length > 0">
                                 <t t-if="message.failureNotifications.length > 0">
-                                    <span class="o_Message_notificationIconClickable o-error" t-on-click="_onClickFailure">
+                                    <span role="button" tabindex="0" class="o_Message_notificationIconClickable o-error" t-on-click="_onClickFailure" aria-label="Delivery failure">
                                         <i name="failureIcon" class="o_Message_notificationIcon fa fa-envelope"/>
                                     </span>
                                 </t>
@@ -130,6 +135,10 @@
                                             'o-message-starred': message.isStarred,
                                             'o-mobile': env.messaging.device.isMobile,
                                         }" t-on-click="_onClickStar" title="Mark as Todo"
+                                        role="button"
+                                        tabindex="0"
+                                        aria-label="Mark as Todo"
+                                        t-att-aria-pressed="message.isStarred ? 'true' : 'false'"
                                     />
                                 </t>
                                 <t t-if="props.hasReplyIcon">
@@ -138,6 +147,9 @@
                                             'o-message-selected': props.isSelected,
                                             'o-mobile': env.messaging.device.isMobile,
                                         }" t-on-click="_onClickReply" title="Reply"
+                                        role="button"
+                                        tabindex="0"
+                                        aria-label="Reply"
                                     />
                                 </t>
                                 <t t-if="props.hasMarkAsReadIcon">
@@ -146,6 +158,9 @@
                                             'o-message-selected': props.isSelected,
                                             'o-mobile': env.messaging.device.isMobile,
                                         }" t-on-click="_onClickMarkAsRead" title="Mark as Read"
+                                        role="button"
+                                        tabindex="0"
+                                        aria-label="Mark as Read"
                                     />
                                 </t>
                             </div>
@@ -173,12 +188,12 @@
                             <ul class="o_Message_trackingValues">
                                 <t t-foreach="trackingValues" t-as="value" t-key="value.id">
                                     <li>
-                                        <div class="o_Message_trackingValue">
+                                        <div class="o_Message_trackingValue" aria-atomic="true">
                                             <div class="o_Message_trackingValueFieldName o_Message_trackingValueItem" t-esc="value.changed_field"/>
                                             <t t-if="value.old_value">
                                                 <div class="o_Message_trackingValueOldValue o_Message_trackingValueItem" t-esc="value.old_value"/>
                                             </t>
-                                            <div class="o_Message_trackingValueSeparator o_Message_trackingValueItem fa fa-long-arrow-right" title="Changed" role="img"/>
+                                            <div class="o_Message_trackingValueSeparator o_Message_trackingValueItem fa fa-long-arrow-right" title="Changed" role="img" tabindex="-1"/>
                                             <t t-if="value.new_value">
                                                 <div class="o_Message_trackingValueNewValue o_Message_trackingValueItem" t-esc="value.new_value"/>
                                             </t>


### PR DESCRIPTION
After the refactor performed on 3fea5b213 to start using OWL, a lot of
aria attributes were lost.

ARIA attributes are required to ensure good compatibility with asistive
tchnologies and keyboard users.

This commit reintroduces such attributes, which includes:
- `aria-label`: used for elements with title but no text
- `role`: mainly used for elements that behaves as buttons or links
- `aria-expanded`: used on buttons that toggle menus or content, e.g.
  button to open attachments or followers
- And another ones like `aria-pressed`, `tabindex`, etc


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
