### PR TITLE
[REF] base: Load country states only once

### DIFF
--- a/odoo/addons/base/__init__.py
+++ b/odoo/addons/base/__init__.py
@@ -6,11 +6,15 @@ from . import models
 from . import populate
 from . import report
 from . import wizard
+from odoo import tools
 
 
 def post_init(cr, registry):
-    """Rewrite ICP's to force groups"""
+    """Rewrite ICP's to force groups
+    Load states only once"""
     from odoo import api, SUPERUSER_ID
 
     env = api.Environment(cr, SUPERUSER_ID, {})
     env['ir.config_parameter'].init(force=True)
+
+    tools.convert.convert_file(cr, 'base', 'data/res.country.state.csv', idref=None, noupdate=True)

--- a/odoo/addons/base/__manifest__.py
+++ b/odoo/addons/base/__manifest__.py
@@ -26,7 +26,6 @@ The kernel of Odoo, needed for all installation.
         'views/base_menus.xml',
         'views/decimal_precision_views.xml',
         'views/res_config_views.xml',
-        'data/res.country.state.csv',
         'views/ir_actions_views.xml',
         'views/ir_config_parameter_views.xml',
         'views/ir_cron_views.xml',
@@ -74,6 +73,8 @@ The kernel of Odoo, needed for all installation.
         'security/ir.model.access.csv',
     ],
     'demo': [
+        # needs to be loaded in demo to avoid raising relation erros
+        'data/res.country.state.csv',
         'data/res_company_demo.xml',
         'data/res_users_demo.xml',
         'data/res_partner_bank_demo.xml',

--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -2238,6 +2238,12 @@ class IrModelData(models.Model):
         self = self.with_context({MODULE_UNINSTALL_FLAG: True})
         loaded_xmlids = self.pool.loaded_xmlids
 
+        # Load all xmlids of state that were changed to be loaded in a hook in stable but they were noupdate=False before
+        # in order to avoid deleting them
+        self.env.cr.execute("SELECT module, name FROM ir_model_data WHERE module='base' AND model='res.country.state' AND noupdate IS NOT TRUE")
+        rows = self.env.cr.dictfetchall()
+        self.pool.loaded_xmlids.update("%(module)s.%(name)s" % row for row in rows)
+
         query = """ SELECT id, module || '.' || name, model, res_id FROM ir_model_data
                     WHERE module IN %s AND res_id IS NOT NULL AND COALESCE(noupdate, false) != %s ORDER BY id DESC
                 """


### PR DESCRIPTION
Running '-u base' odoo will reload the 'data/res.country.state.csv' file
and it will trigger all the computed, constraint and extra process
for your custom modules in production database
spending extra time ~10m

So loading it only once it will be loaded only when the module is installed

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
