### PR TITLE
[FIX] Not change account move line currency when reconciling it with …

### DIFF
--- a/addons/account/models/account_invoice.py
+++ b/addons/account/models/account_invoice.py
@@ -1106,11 +1106,6 @@ class AccountInvoice(models.Model):
     def assign_outstanding_credit(self, credit_aml_id):
         self.ensure_one()
         credit_aml = self.env['account.move.line'].browse(credit_aml_id)
-        if not credit_aml.currency_id and self.currency_id != self.company_id.currency_id:
-            amount_currency = self.company_id.currency_id._convert(credit_aml.balance, self.currency_id, self.company_id, credit_aml.date or fields.Date.today())
-            credit_aml.with_context(allow_amount_currency=True, check_move_validity=False).write({
-                'amount_currency': amount_currency,
-                'currency_id': self.currency_id.id})
         if credit_aml.payment_id:
             credit_aml.payment_id.write({'invoice_ids': [(4, self.id, None)]})
         return self.register_payment(credit_aml)


### PR DESCRIPTION
…another which has different currency and they are reconciling using the assign outstanding credit widget.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
