### PR TITLE
[IMP] stock_account: add fix to update average cost when quants into

### DIFF
--- a/addons/stock_account/models/stock.py
+++ b/addons/stock_account/models/stock.py
@@ -437,7 +437,7 @@ class StockMove(models.Model):
         # adapt standard price on incomming moves if the product cost_method is 'average'
         std_price_update = {}
         for move in self.filtered(lambda move: move._is_in() and move.product_id.cost_method == 'average'):
-            product_tot_qty_available = move.product_id.with_context(owner_id=False).qty_available + tmpl_dict[move.product_id.id]
+            product_tot_qty_available = move.product_id.with_context(owner_id=False, company_owned=True).qty_available + tmpl_dict[move.product_id.id]
             rounding = move.product_id.uom_id.rounding
 
             qty_done = move.product_uom._compute_quantity(move.with_context(exclude_owner=True).quantity_done, move.product_id.uom_id)


### PR DESCRIPTION
transit, eg.

1. purchase order quantity 1, $120 USD
Current cost 120

2. Create transfer to another warehouse using transit location
Stock A -> Transit
Transit -> Stock B

3. Validate only the move from Stock A -> Transit
Current cost 120

4. Create purchase order quantity 1, $100 USD
After validate purchase order the current cost $100 USD

After this commit the current cost $110 USD

Before this commit odoo when calculate 'qty_available' do not calculated
the quants into transit

After this commit whe force to recalculate 'qty_available' calculating
the quants into transit as well

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
