### PR TITLE
[IMP] sale: Allow avoid to auto sent an invoice by mail

### DIFF
--- a/addons/sale/models/payment.py
+++ b/addons/sale/models/payment.py
@@ -116,7 +116,8 @@ class PaymentTransaction(models.Model):
         res = super(PaymentTransaction, self)._reconcile_after_transaction_done()
         if self.env['ir.config_parameter'].sudo().get_param('sale.automatic_invoice'):
             default_template = self.env['ir.config_parameter'].sudo().get_param('sale.default_email_template')
-            if default_template:
+            avoid_autosent = self.env['ir.config_parameter'].sudo().get_param('sale.avoid_auto_sent_invoice')
+            if default_template and not avoid_autosent:
                 for trans in self.filtered(lambda t: t.sale_order_ids):
                     ctx_company = {'company_id': trans.acquirer_id.company_id.id,
                                    'force_company': trans.acquirer_id.company_id.id,


### PR DESCRIPTION
In Mexico the invoice must be signed with the SAT, and that process is
executed after of a commit, so, if this change is not applied, the email
is send to the customer without stamp.

Now, if the parameter is generated, the invoice will not to auto-sent

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
