### PR TITLE
[IMP] barcodes, point_of_sale: Scanning Barcodes (Multiple Rules Apply)

### DIFF
--- a/addons/barcodes/static/src/js/barcode_parser.js
+++ b/addons/barcodes/static/src/js/barcode_parser.js
@@ -196,6 +196,7 @@ var BarcodeParser = Class.extend({
      *      - base_code: the barcode with all the encoding parts set to zero; the one put on the product in the backend
      */
     parse_barcode: function(barcode){
+        var results = [];
         var parsed_result = {
             encoding: '',
             type:'error',
@@ -230,27 +231,29 @@ var BarcodeParser = Class.extend({
 
             var match = this.match_pattern(cur_barcode, rules[i].pattern, rule.encoding);
             if (match.match) {
+                var parsed_result_tmp = {...parsed_result};
                 if(rules[i].type === 'alias') {
                     barcode = rules[i].alias;
                     parsed_result.code = barcode;
                     parsed_result.type = 'alias';
                 }
                 else {
-                    parsed_result.encoding  = rules[i].encoding;
-                    parsed_result.type      = rules[i].type;
-                    parsed_result.value     = match.value;
-                    parsed_result.code      = cur_barcode;
+                    parsed_result_tmp.encoding  = rules[i].encoding;
+                    parsed_result_tmp.type      = rules[i].type;
+                    parsed_result_tmp.value     = match.value;
+                    parsed_result_tmp.code      = cur_barcode;
                     if (rules[i].encoding === "ean13"){
-                        parsed_result.base_code = this.sanitize_ean(match.base_code);
+                        parsed_result_tmp.base_code = this.sanitize_ean(match.base_code);
                     }
                     else{
-                        parsed_result.base_code = match.base_code;
+                        parsed_result_tmp.base_code = match.base_code;
                     }
-                    return parsed_result;
+                    parsed_result_tmp.rule = rules[i];
+                    results.push(parsed_result_tmp);
                 }
             }
         }
-        return parsed_result;
+        return results || parsed_result;
     },
 
     //--------------------------------------------------------------------------

--- a/addons/point_of_sale/static/src/js/Screens/ProductScreen/ProductScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/ProductScreen/ProductScreen.js
@@ -268,6 +268,7 @@ odoo.define('point_of_sale.ProductScreen', function(require) {
                 });
             }
             await this.currentOrder.add_product(product,  options);
+            return true;
         }
         _barcodeClientAction(code) {
             const partner = this.env.pos.db.get_partner_by_barcode(code.code);
@@ -289,12 +290,16 @@ odoo.define('point_of_sale.ProductScreen', function(require) {
             var last_orderline = this.currentOrder.get_last_orderline();
             if (last_orderline) {
                 last_orderline.set_discount(code.value);
+                return true;
             }
         }
         // IMPROVEMENT: The following two methods should be in PosScreenComponent?
         // Why? Because once we start declaring barcode actions in different
         // screens, these methods will also be declared over and over.
         _barcodeErrorAction(code) {
+            if (this.env.pos.show_barcode_error_modal === false) {
+                return ;
+            }
             this.showPopup('ErrorBarcodePopup', { code: this._codeRepr(code) });
         }
         _codeRepr(code) {

--- a/addons/point_of_sale/static/src/js/barcode_reader.js
+++ b/addons/point_of_sale/static/src/js/barcode_reader.js
@@ -19,6 +19,7 @@ var BarcodeReader = core.Class.extend({
     init: function (attributes) {
         this.mutex = new Mutex();
         this.pos = attributes.pos;
+        this.pos.show_barcode_error_modal = true;
         this.action_callbacks = {};
         this.exclusive_callbacks = {};
         this.proxy = attributes.proxy;
@@ -114,10 +115,16 @@ var BarcodeReader = core.Class.extend({
         if (! Array.isArray(parsed_results)) {
             parsed_results = [parsed_results];
         }
-        for (const parsed_result of parsed_results) {
+        parsed_results_loop:
+        for (const [index, parsed_result] of parsed_results.entries()) {
+            let is_last_index = index + 1 === parsed_results.length;
+            this.pos.show_barcode_error_modal = is_last_index;
             if (callbacks[parsed_result.type]) {
                 for (const cb of callbacks[parsed_result.type]) {
-                    await cb(parsed_result);
+                    let result_callback = await cb(parsed_result);
+                    if (result_callback) {
+                        break parsed_results_loop;
+                    }
                 }
             } else if (callbacks.error) {
                 [...callbacks.error].map(cb => cb(parsed_result));


### PR DESCRIPTION
### [Ticket#18452](https://www.vauxoo.com/web#id=18452&view_type=form&model=helpdesk.ticket)

**[FIX] barcodes: Parsing Barcodes (Multiple Rules Apply)**

Now when the Barcode match with multiple barcode patterns in the rules of the Barcode Nomenclatures all the possible matching will be returned instead of only returning the first option.

This will solve the issue that exists when more than one rule has the same barcode pattern [1] and allow doing those searches and not only searching for one option when the result can be in the second option.

For example, before this change having the "Customer Barcodes" and "Product Barcodes" with the same pattern `.*` as rules in the Barcode Nomenclatures if we scan in the POS the barcode "0020200002" the first that applies will be the customer for the sequence in the POS if we search for a product with the barcode "0020200002" the first rule will be "Customer" for the sequence and if there is no customer with that barcode it will return an error saying "The Point of Sale could not find any product, client, employee or action associated with the scanned barcode." which is not true because there is a product with that barcode.

Now it will return both rules instead of only the first one, also we add in the results the rule that is matching in order to keep the return almost the same as in the module `barcodes_gs1_nomenclature` in the method `parse_gs1_rule_pattern` (that is inside of their parser) returns the rule and the `stock_barcode` module in Odoo Enterprise use it.

[1] [Issue 90353: Unknown Barcode in POS when Product exists](https://github.com/odoo/odoo/issues/90353)

**[FIX] point_of_sale: Barcode Error**

As we can now have multiple rules (Barcode Nomenclatures) that apply in the parse of the barcode we have multiple parsed results that we can search in the scanning process we had to avoid showing the error of the function `_barcodeErrorAction` when we have more parsed results to search into so now we only want to show it when is the last result and none of the callbacks returned a successful response.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
