### PR TITLE
[FIX] PR #498 & #476

### DIFF
--- a/addons/sale/models/payment.py
+++ b/addons/sale/models/payment.py
@@ -116,7 +116,8 @@ class PaymentTransaction(models.Model):
         res = super(PaymentTransaction, self)._reconcile_after_transaction_done()
         if self.env['ir.config_parameter'].sudo().get_param('sale.automatic_invoice'):
             default_template = self.env['ir.config_parameter'].sudo().get_param('sale.default_email_template')
-            if default_template:
+            avoid_autosent = self.env['ir.config_parameter'].sudo().get_param('sale.avoid_auto_sent_invoice')
+            if default_template and not avoid_autosent:
                 for trans in self.filtered(lambda t: t.sale_order_ids):
                     ctx_company = {'company_id': trans.acquirer_id.company_id.id,
                                    'force_company': trans.acquirer_id.company_id.id,

--- a/addons/sale/models/payment.py
+++ b/addons/sale/models/payment.py
@@ -114,7 +114,7 @@ class PaymentTransaction(models.Model):
         # invoice the sale orders if needed
         self._invoice_sale_orders()
         res = super(PaymentTransaction, self)._reconcile_after_transaction_done()
-        if self.env['ir.config_parameter'].sudo().get_param('sale.automatic_invoice'):
+        if self.env['ir.config_parameter'].sudo().get_param('sale.automatic_invoice') and not self._context.get('avoid_auto_invoice'):
             default_template = self.env['ir.config_parameter'].sudo().get_param('sale.default_email_template')
             avoid_autosent = self.env['ir.config_parameter'].sudo().get_param('sale.avoid_auto_sent_invoice')
             if default_template and not avoid_autosent:
@@ -130,7 +130,7 @@ class PaymentTransaction(models.Model):
 
     @api.multi
     def _invoice_sale_orders(self):
-        if self.env['ir.config_parameter'].sudo().get_param('sale.automatic_invoice'):
+        if self.env['ir.config_parameter'].sudo().get_param('sale.automatic_invoice') and not self._context.get('avoid_auto_invoice'):
             for trans in self.filtered(lambda t: t.sale_order_ids):
                 ctx_company = {'company_id': trans.acquirer_id.company_id.id,
                                'force_company': trans.acquirer_id.company_id.id}


### PR DESCRIPTION
PR #498
=

 [IMP] sale: Added context value to prevent auto invoice #476 

In Mexico the invoice must be signed with the SAT, and that process is
executed after of a commit, so, if this change is not applied, the email
is send to the customer without stamp.

Now, if the parameter is generated, the invoice will not to auto-sent

This MR is a cherry-pick on commit vauxoo/odoo@0e354064dc5c15888d19d6b72e64c6f9529090a4 which is in PR https://github.com/Vauxoo/odoo/pull/498


PR #476
=

The purpose of this MR is to be able to apply the changes via patch.

In a previous development to a client (ABSA), the payment acquirers have a field
to specify the invoice policy.

Since we are not using the default invoice policy (the one from the config), the original
validation only compares the config parameter, so even if we change the policy
to delivered quantities, the invoice will be created in case the default policy has auto invoice checked.

A sale order with the invoice policy set from the payment acquirer as 'delivered quantities' will create an automatic invoice.
Using the above case, the sale order won't create an invoice.

This MR is a cherry-pick on comit vauxoo/odoo@967045e97cd04d12f7578cc8b2aa29bbe80989be which is in PR https://github.com/Vauxoo/odoo/pull/476/

NOTE:
=
As both PR change the same file when applying the patch by the MQT tools for patching it was not properly applying one of the patches.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
