### PR TITLE
[PATCH] l10n_generic_coa: avoid installing generic CoA

### DIFF
--- a/addons/l10n_generic_coa/data/l10n_generic_coa_post.xml
+++ b/addons/l10n_generic_coa/data/l10n_generic_coa_post.xml
@@ -96,9 +96,11 @@
 
     <!-- Try to instanciate for relevant companies -->
 </data>
+<!--
 <data noupdate="1">
     <function model="account.chart.template" name="try_loading">
         <value eval="[ref('l10n_generic_coa.configurable_chart_template')]"/>
     </function>
 </data>
+-->
 </odoo>


### PR DESCRIPTION
Function commented in order to avoid installing generic CoA (Avoiding conflict when l10n_us and other localization module is needed)



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
