### PR TITLE
[IMP] web: Add a new parameter to know when to keep progressive format base on request context

### DIFF
--- a/addons/web/controllers/main.py
+++ b/addons/web/controllers/main.py
@@ -1110,9 +1110,10 @@ class Binary(http.Controller):
                 if height > 500:
                     height = 500
             try:
+                resize_kwargs = {'keep_progressive': True} if request.context.get('keep_progressive') else {}
                 content = odoo.tools.image_resize_image(base64_source=content, size=(width or None, height or None),
-                                                    encoding='base64', upper_limit=upper_limit,
-                                                    avoid_if_small=avoid_if_small)
+                                                        encoding='base64', upper_limit=upper_limit,
+                                                        avoid_if_small=avoid_if_small, **resize_kwargs)
             except Exception:
                 return request.not_found()
 


### PR DESCRIPTION
Use as a patch.

### Issue

The main issue is that when the resize is made, it creates a new image, resulting in the loss of the
original format, PIL allows progressive images only on JPEG files, we just need to pass the parameter
in order to create a new image with this format

### What changed

[IMP] odoo.tools

- Modified method `image_resize_image` to add validation to keep the progressive format if
   an JPEG image is already progressive
- Added a new parameter `keep_progresive` to use as a flag to check if the conversion needs to be done or not, `False` by default

### Desired behaviour

After this patch now the resized images keep the progressive format in their encoder info if the `keep_progressive` key is inside the request context

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
