### PR TITLE
[IMP] pos_restaurant: adding method hook to be used whenever an order…

### DIFF
--- a/addons/pos_restaurant/static/src/js/Screens/SplitBillScreen/SplitBillScreen.js
+++ b/addons/pos_restaurant/static/src/js/Screens/SplitBillScreen/SplitBillScreen.js
@@ -76,6 +76,8 @@ odoo.define('pos_restaurant.SplitBillScreen', function(require) {
 
                 this.env.pos.get('orders').add(this.newOrder);
                 this.env.pos.set('selectedOrder', this.newOrder);
+                this.newOrder.on_lines_splited();
+                this.currentOrder.on_lines_splited();
             }
         }
         /**

--- a/addons/pos_restaurant/static/src/js/multiprint.js
+++ b/addons/pos_restaurant/static/src/js/multiprint.js
@@ -126,6 +126,11 @@ models.Orderline = models.Orderline.extend({
 
 var _super_order = models.Order.prototype;
 models.Order = models.Order.extend({
+    /**
+     * Hook for whenever an order has been splited. This is called on
+     * the original, and the new generated order.
+     */
+    on_lines_splited () {},
     build_line_resume: function(){
         var resume = {};
         this.orderlines.each(function(line){


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

We do not have a way to detect when an order gets splited

Current behavior before PR:

None

Desired behavior after PR is merged:

Having a hook method to recognize when the action happends, on the new and the older order.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
