### PR TITLE
[ADD] pos_coupon: exposed classes used to manage copupons

### DIFF
--- a/addons/pos_coupon/static/src/js/coupon.js
+++ b/addons/pos_coupon/static/src/js/coupon.js
@@ -1167,4 +1167,6 @@ odoo.define('pos_coupon.pos', function (require) {
             return result;
         },
     });
+
+    return {CouponCode, RewardsContainer, Reward};
 });


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Exposed privated clases in JS used to manage promotions in the PoS

Current behavior before PR:

Classes are privated

Desired behavior after PR is merged:

Classes are exposed


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
