### PR TITLE
[FIX] website: Avoid duplicate pages

### DIFF
--- a/addons/website/models/ir_module_module.py
+++ b/addons/website/models/ir_module_module.py
@@ -247,13 +247,19 @@ class IrModuleModule(models.Model):
 
         if model_name in ('website.page', 'website.menu'):
             return model
-        # use active_test to also unlink archived models
-        # and use MODULE_UNINSTALL_FLAG to also unlink inherited models
-        orphans = model.with_context(**{'active_test': False, MODULE_UNINSTALL_FLAG: True}).search([
+
+        search = [
             ('key', '=like', self.name + '.%'),
             ('website_id', '=', website.id),
             ('theme_template_id', '=', False),
-        ])
+        ]
+        # Dont delete the duplicate pages
+        if model_name in ('ir.ui.view'):
+            search += [('page_ids', '=', False)]
+
+        # use active_test to also unlink archived models
+        # and use MODULE_UNINSTALL_FLAG to also unlink inherited models
+        orphans = model.with_context(**{'active_test': False, MODULE_UNINSTALL_FLAG: True}).search(search)
         orphans.unlink()
 
     def _theme_get_upstream(self):


### PR DESCRIPTION
https://github.com/odoo/odoo/issues/101510

Description of the issue/feature this PR addresses:

Impacted versions: 14

**Steps to reproduce:**

1. Install a theme with a theme.website.page
2. Duplicate the page
3. Update the theme

**Current behavior:**
The page and the template are deleted by this code
![image](https://user-images.githubusercontent.com/35231827/192895046-aa376d61-674d-4e3d-9c82-2c0b1044a729.png)


**Expected behavior:**
The page should not be deleted



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
