### PR TITLE
[REF] pos_restaurant: get all draft orders from server in one call

### DIFF
--- a/addons/pos_restaurant/models/pos_config.py
+++ b/addons/pos_restaurant/models/pos_config.py
@@ -63,3 +63,13 @@ class PosConfig(models.Model):
         if ('is_order_printer' in vals and vals['is_order_printer'] == False):
             vals['printer_ids'] = [(5, 0, 0)]
         return super(PosConfig, self).write(vals)
+
+    def get_all_table_draft_orders(self):
+        self.ensure_one()
+        self = self.with_context(prefetch_fields=False)
+        order_obj = self.env['pos.order']
+        tables = self.env['restaurant.table'].search([('floor_id.pos_config_id', '=', self.id)])
+        return {
+            table.id: order_obj.get_table_draft_orders(table.id)
+            for table in tables
+        }

--- a/addons/pos_restaurant/static/src/js/ChromeWidgets/TicketButton.js
+++ b/addons/pos_restaurant/static/src/js/ChromeWidgets/TicketButton.js
@@ -18,11 +18,19 @@ odoo.define('pos_restaurant.TicketButton', function (require) {
             async _syncAllFromServer() {
                 const pos = this.env.pos;
                 try {
-                    for (const floor of pos.floors) {
-                        for (const table of floor.tables) {
-                            await pos.replace_table_orders_from_server(table);
-                        }
-                    }
+                    const orders_by_table = await this.rpc({
+                        model: 'pos.config',
+                        method: 'get_all_table_draft_orders',
+                        args: [pos.config.id],
+                        kwargs: {context: pos.session.user_context},
+                    }, {
+                        timeout: 7500,
+                        shadow: false,
+                    });
+                    Object.entries(orders_by_table).forEach(([table_id, server_orders]) => {
+                        const orders = pos.get_table_orders(pos.tables_by_id[table_id]);
+                        pos._replace_orders(orders, server_orders);
+                    });
                 } catch (e) {
                     await this.showPopup('ErrorPopup', {
                         title: this.env._t('Connection Error'),


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

After this [commit](https://github.com/odoo/odoo/commit/f6ceac07a077531c873f0715b8de5c384bb06ae5), when the user clicks on `Orders` in a session of a POS, the method is retrieving the all orders from backend to the POS and it's calling to the backend one time per each table per each floor configured in the POS.

Then if you have 4 floors, with 30 tables on each floor, only by clicking on `Orders`, it calls 120 times the method to the backend.

With this change, only one call is made to open `Orders` and synchronize the orders from server.

Current behavior before PR:

Many calls are made to synchronize the draft orders from the backend to the POS.

Desired behavior after PR is merged:

With this change, only `one` call is made to open `Orders` and synchronize the orders from the backend.

Fix https://github.com/odoo/odoo/issues/104666

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
