### PR TITLE
[ADD] point_of_sale: Send Context Closing POS Session

### DIFF
--- a/addons/point_of_sale/static/src/js/Popups/ClosePosPopup.js
+++ b/addons/point_of_sale/static/src/js/Popups/ClosePosPopup.js
@@ -152,10 +152,17 @@ odoo.define('point_of_sale.ClosePosPopup', function(require) {
                     const bankPaymentMethodDiffPairs = this.otherPaymentMethods
                         .filter((pm) => pm.type == 'bank')
                         .map((pm) => [pm.id, this.state.payments[pm.id].difference]);
+                    let posContext = {};
+                    if (this.env.pos.env && this.env.pos.env.context){
+                        posContext = this.env.pos.env.context;
+                    }
                     response = await this.rpc({
                         model: 'pos.session',
                         method: 'close_session_from_ui',
                         args: [this.env.pos.pos_session.id, bankPaymentMethodDiffPairs],
+                        context: _.extend(
+                            this.env.session.userContext,
+                            posContext),
                     });
                     if (!response.successful) {
                         return this.handleClosingError(response);


### PR DESCRIPTION
### Based on PR https://github.com/odoo/odoo/pull/97864

Sending a context when you are closing a `pos.session` will allow you to make some validations/actions only when the closing is being done from the UI. For example, sending values for new fields or a message that includes something from the pos, like the Cashier ID, name, etc.

Also, it will help more when it is necessary to inherit the function in a simpler way, to avoid having to overwrite it.
