### PR TITLE
[FIX] pos_restaurant: get all draft orders from server in one call v2

### DIFF
--- a/addons/pos_restaurant/models/pos_order.py
+++ b/addons/pos_restaurant/models/pos_order.py
@@ -172,6 +172,7 @@ class PosOrder(models.Model):
         :type table_id: int.
         :returns: list -- list of dict representing the table orders
         """
+        self = self.with_context(prefetch_fields=False)
         table_orders = self.search_read(
                 domain=[('state', '=', 'draft'), ('table_id', '=', table_id)],
                 fields=self._get_fields_for_draft_order())
@@ -259,3 +260,9 @@ class PosOrder(models.Model):
         result = super(PosOrder, self)._export_for_ui(order)
         result['table_id'] = order.table_id.id
         return result
+
+    @api.model
+    def get_all_table_draft_orders(self, pos_config_id):
+        tables = self.env['restaurant.table'].search([('floor_id.pos_config_id', '=', pos_config_id)])
+        order_obj = self.env['pos.order']
+        return [order for table in tables for order in order_obj.get_table_draft_orders(table.id) if order]


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

After this [commit](https://github.com/odoo/odoo/commit/f6ceac07a077531c873f0715b8de5c384bb06ae5), when the user clicks on `Orders` in a session of a POS, the method is retrieving the all orders from backend to the POS and it's calling to the backend one time per each table per each floor configured in the POS.

Then if you have 4 floors, with 30 tables on each floor, only by clicking on `Orders`, it calls 120 times the method to the backend.

With this change, only one call is made to open `Orders` and synchronize the orders from the server, this a version 2 of https://github.com/odoo/odoo/pull/104930 in order to test in runbot this requested change: https://github.com/odoo/odoo/pull/104930#discussion_r1030204808

Current behavior before PR:

Many calls are made to synchronize the draft orders from the backend to the POS.

Desired behavior after PR is merged:

With this change, only `one` call is made to open `Orders` and synchronize the orders from the backend.

Fix https://github.com/odoo/odoo/issues/104666

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
