### PR TITLE
[FIX] payment_stripe: Fixed checkout bug when using multiple stripe cards

### DIFF
--- a/addons/payment_stripe/static/src/js/payment_form.js
+++ b/addons/payment_stripe/static/src/js/payment_form.js
@@ -76,6 +76,9 @@ PaymentForm.include({
         var stripe = this.stripe;
         var card = this.stripe_card_element;
         if (card._invalid) {
+            // if we don't enable the button again, at this point the button is displaying the 'loading' animation
+            // and since we break the workflow here it gives the impression that something is happening, but it isn't
+            self.enableButton(button);
             return;
         }
         this._createPaymentMethod(stripe, formData, card, addPmEvent).then(function(result) {

--- a/addons/payment_stripe/static/src/js/payment_form.js
+++ b/addons/payment_stripe/static/src/js/payment_form.js
@@ -129,7 +129,9 @@ PaymentForm.include({
         var stripe = Stripe(formData.stripe_publishable_key);
         var element = stripe.elements();
         var card = element.create('card', {hidePostalCode: true});
-        card.mount('#card-element');
+        // use more specific css selector so that '#card-element' is found inside the selected stripe card, otherwise
+        // this won't happen, and the card will be mounted to the first element found.
+        card.mount(`#o_payment_add_token_acq_${acquirerID} #card-element`);
         card.on('ready', function(ev) {
             card.focus();
         });


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

**1. Bug when using multiple stripe cards at checkout**

The selector is not properly enclosed to the clicked stripe card, therefore the `card` is mounted to the
first element found with `#card-element`. The problem with this is that if we have multiple stripe
cards they won't be having the widget to fill the credit card information.

<img width="763" alt="Screen Shot 2022-12-02 at 12 44 11 p m" src="https://user-images.githubusercontent.com/47955967/205364421-1f11b60e-59c0-4dab-91de-661ec9d84314.png">

<img width="802" alt="Screen Shot 2022-12-02 at 12 44 05 p m" src="https://user-images.githubusercontent.com/47955967/205364437-2588bf6e-285e-4315-a5d7-3f6e4dc19a79.png">


**2. Bug when stripe card is invalid, the button is disabled forever**

When the stripe card is invalid, we break the `PayEvent` workflow to prevent purchases,
the problem is that the button is never enabled again.

This gives the wrong impression that something is happening because the payment button
is disabled and the spinning icon is there.


https://user-images.githubusercontent.com/47955967/205364532-b0a46a47-23ed-4630-a77e-d0b4257d170a.mp4



Current behavior before PR:

**1. Bug when using multiple stripe cards at checkout**

Only the first stripe card will have the widget to fill the credit card

**2. Bug when stripe card is invalid, the button is disabled forever**

After the card is invalid, the payment button is always disabled and is displaying the loading animation

Desired behavior after PR is merged:

**1. Bug when using multiple stripe cards at checkout**

By using a more specific selector, we ensure that `#card-selector` is searched in the current stripe card,
therefore, the `card` will be mounted on the clicked stripe card.

**2. Bug when stripe card is invalid, the button is disabled forever**

By `enabling` the button again, we ensure that if the card is invalid, the user changes its values and tries again.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
