### PR TITLE
[REF] account_check_printing: Speed-up payment creation if they are not a check

### DIFF
--- a/addons/account_check_printing/models/account_payment.py
+++ b/addons/account_check_printing/models/account_payment.py
@@ -42,7 +42,7 @@ class AccountPayment(models.Model):
     @api.constrains('check_number', 'journal_id')
     def _constrains_check_number(self):
         payment_checks = self.filtered('check_number')
-        if not payment_checks:
+        if not payment_checks or self.env.context.get('install_mode'):
             return
         for payment_check in payment_checks:
             if not payment_check.check_number.isdecimal():


### PR DESCRIPTION
The constraint to validate the Check Number is so slow since that it is comparing the full table vs the full table
instead of only check the new items added

Analyzing the following query:

    SELECT
        payment.check_number,
        move.journal_id
    FROM
        account_payment payment
        JOIN account_move move ON move.id = payment.move_id
        JOIN account_journal journal ON journal.id = move.journal_id,
        account_payment other_payment
        JOIN account_move other_move ON other_move.id = other_payment.move_id
    WHERE
        payment.check_number::integer = other_payment.check_number::integer
        AND move.journal_id = other_move.journal_id
        AND payment.id != other_payment.id
        AND payment.id IN (1085159)
        AND move.state = 'posted'
        AND other_move.state = 'posted';

The output is:

    Planning Time: 3.354 ms
    Execution Time: 2514.660 ms

The problem is greather than you think since that the query is executed even
if you are creating a normal payment that it is not a check (check_number empty)

It bypass the validation if it is not a check

Disclaimer: It is not fixing the slow query for check number validation

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:

`PATCH USE`

PR to odoo: https://github.com/odoo/odoo/pull/82595

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
