### PR TITLE
[REF] account: don't duplicate *_rank fields and add them to summable…

### DIFF
--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -433,6 +433,16 @@ class ResPartner(models.Model):
     supplier_rank = fields.Integer(default=0, copy=False)
     customer_rank = fields.Integer(default=0, copy=False)
 
+    def copy(self, default=None):
+        self.ensure_one()
+        # Set context according to ranks fields to simulate where was created original partner
+        if not self.env.context.get('res_partner_search_mode'):
+            if self['supplier_rank'] > 0:
+                self = self.with_context(res_partner_search_mode='supplier')
+            if self['customer_rank'] > 0:
+                self = self.with_context(res_partner_search_mode='customer')
+        return super().copy(default)
+
     def _get_name_search_order_by_fields(self):
         res = super()._get_name_search_order_by_fields()
         partner_search_mode = self.env.context.get('res_partner_search_mode')

--- a/addons/account/wizard/__init__.py
+++ b/addons/account/wizard/__init__.py
@@ -17,3 +17,4 @@ from . import account_invoice_send
 from . import base_document_layout
 from . import account_payment_register
 from . import account_tour_upload_bill
+from . import base_partner_merge

--- a/addons/account/wizard/base_partner_merge.py
+++ b/addons/account/wizard/base_partner_merge.py
@@ -1,0 +1,12 @@
+from odoo import models
+
+
+class MergePartnerAutomatic(models.TransientModel):
+    _inherit = 'base.partner.merge.automatic.wizard'
+
+    def _get_summable_fields(self):
+        """ Add to summable fields list, fields created in this module.
+        """
+        res = super()._get_summable_fields()
+        res += ['customer_rank', 'supplier_rank']
+        return res


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Module `account` is adding `customer_rank` and `supplier_rank` in `res.partner` for computing the amount of their generated incoming/outgoing account moves but they are copied when a partner is duplicated, IMHO those fields have not to be copied, and also there is a method called `_get_summable_fields` in `base` in order to get all fields that should be summed when partners are merged and those fields apply exactly for that.

Also, we set the context in `copy` method to simulate where was create the original record.

Video of runbot where `customer_rank` is copied when duplicating a partner

https://youtu.be/2EXF6urXcsQ

Current behavior before PR:

Fields `*_rank `are copied when a partner is duplicated and aren't summed when partners are merged.

Desired behavior after PR is merged:

Fields `*_rank` are set with `1` when the original partner has a rank in any of those fields and 0 when hasn't and they are added in summable fields.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
