### PR TITLE
[FIX] account: Full Reconciled Tax Lines are not to be reconciled

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -1772,7 +1772,7 @@ class AccountPartialReconcile(models.Model):
                                 'partner_id': line.partner_id.id,
                                 'journal_id': newly_created_move.journal_id.id,
                             })
-                            if line.account_id.reconcile and not line.reconciled:
+                            if line.account_id.reconcile and not line.full_reconcile_id and not line.reconciled:
                                 #setting the account to allow reconciliation will help to fix rounding errors
                                 to_clear_aml |= line
                                 to_clear_aml.reconcile()


### PR DESCRIPTION
Main
-
[FIX] account: Full Reconciled Tax Lines are not to be reconciled


Explain
-

[FIX] account: Due to incoming changes in module APR. We have to ensure that taxes already reconciled won't be disturbed.

That is true for the ones that are already fully reconciled that won't reshuffled.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
