### PR TITLE
[FIX] web_editor: final editor cleanup 

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -1233,6 +1233,7 @@ var SnippetsMenu = Widget.extend({
 
         this.getEditableArea().find('[contentEditable]')
             .removeAttr('contentEditable')
+            .not('lt-highlighter')
             .removeProp('contentEditable');
 
         this.getEditableArea().find('.o_we_selected_image')


### PR DESCRIPTION
Cannot delete property 'contentEditable' of The lt-highlighter elements

Description of the issue/feature this PR addresses:
When a link is edited, an editor error is showed
https://github.com/odoo/odoo/issues/115260

Current behavior before PR:
image
Desired behavior after PR is merged:
the property is not removed from the lt-highlighter elements

PATCH USE

local change of https://github.com/odoo/odoo/pull/115262



I confirm I have signed the CLA and read the PR guidelines at [www.odoo.com/submit-pr](http://www.odoo.com/submit-pr)