### PR TITLE
Allow materialized views to be dropped with the same function as regular views

### DIFF
--- a/odoo/tools/sql.py
+++ b/odoo/tools/sql.py
@@ -242,7 +242,8 @@ def drop_index(cr, indexname, tablename):
     _schema.debug("Table %r: dropped index %r", tablename, indexname)
 
 def drop_view_if_exists(cr, viewname):
-    cr.execute("DROP view IF EXISTS %s CASCADE" % (viewname,))
+    kind = table_kind(cr, viewname)
+    cr.execute("DROP {0} VIEW IF EXISTS {1} CASCADE".format("MATERIALIZED" if kind == "m" else "", viewname))
 
 def escape_psql(to_escape):
     return to_escape.replace('\\', r'\\').replace('%', '\%').replace('_', '\_')


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
PortgreSQL's Materialized views need a special syntax to be dropped, differing from regular `DROP VIEW` syntax.

**Current behavior before PR:**
If the caller wanted to drop a materialized view, `drop_view_if_exists` would not work and the special
query would need to be called directly.

**Desired behavior after PR is merged:**
This PR allows for the materialized view to be dropped with `drop_view_if_exists` without any added logic from the calling side.
