### PR TITLE
[FIX] requirements.txt: unpin pytz

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ pyparsing==2.1.10
 PyPDF2==1.26.0
 pyserial==3.1.1
 python-dateutil==2.5.3
-pytz==2016.7
+pytz  # no version pinning to avoid OS perturbations
 pyusb==1.0.0
 qrcode==5.3
 reportlab==3.3.0


### PR DESCRIPTION
On Debian based systems, the `tzdata` package is maintained to reflect changes in timezones and there is no need to upgrade the `python3-tz` package. On the other hand, for those who are using `pip` and thus our `requirements.txt`, the package needs to be up to date. By unpinning it in the requirements.txt:

- new installations based on pip will be up to date
- older installations based on pip can easily upgrade
- debian based installations have to maintain the tzdata package
- mixed installs like on runbot will rely on Debian tzdata

closes odoo/odoo#117527


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
