### PR TITLE
[FIX] base: Use rate precision in conversion rate if context given (patch)

### DIFF
--- a/odoo/addons/base/models/res_currency.py
+++ b/odoo/addons/base/models/res_currency.py
@@ -183,6 +183,9 @@ class Currency(models.Model):
     def _get_conversion_rate(self, from_currency, to_currency, company, date):
         currency_rates = (from_currency + to_currency)._get_rates(company, date)
         res = currency_rates.get(to_currency.id) / currency_rates.get(from_currency.id)
+        if self._context.get('dp_custom') or self._context.get('website_id'):
+            dp = self.env['decimal.precision'].precision_get('Rate Precision')
+            res = round(res, dp)
         return res
 
     def _convert(self, from_amount, to_currency, company, date, round=True):


### PR DESCRIPTION
# **PR will be use as a patch**

## Related to [MR#2808](https://git.vauxoo.com/absa/absa/-/merge_requests/2808)

### Issue

The custom rate from the website was different from the one in backend, this caused that the prices of products were different.

The calculation was based on this:

* Get the conversion rate
* Apply conversion to the price
* Round up the price

This is OK and is the original workflow of odoo, but in absa we have our own logic for this, that is why the conversion rates were different

If we continue the purchase, then, in the payment the custom rate is calculated and prices will still be different, since it will be using the one from backend, causing more confusion and wrong prices.

### Fix

Use the same logic that backend uses to have the same custom rate for the eCommerce, this will always ensure the same prices.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
