### PR TITLE
[REF] Use website_public_lst_price_usd field instead of price 

### DIFF
--- a/addons/website_sale/models/sale_order.py
+++ b/addons/website_sale/models/sale_order.py
@@ -133,7 +133,8 @@ class SaleOrder(models.Model):
                     discount = 0
                     pu = price
         else:
-            pu = product.price
+            # The price is already available without the need for calculations, so we take it directly from website_public_lst_price_usd
+            pu = product.website_public_lst_price_usd 
             if order.pricelist_id and order.partner_id:
                 order_line = order._cart_find_product_line(product.id)
                 if order_line:


### PR DESCRIPTION
Optimize performance by utilizing the pre-calculated prices stored in the website_public_lst_price_usd field within the
_website_product_id_change method. This approach eliminates the need for unnecessary price recomputations, resulting in a significant speed improvement of approximately **90%**.

### **Results**

**Before**
_website_product_id_change  method
![image_2023-07-18_18-43-48](https://github.com/Vauxoo/odoo/assets/76703666/60bd632a-2ac3-4848-ad18-6619cfec7e5d)
![image_2023-07-18_18-44-24](https://github.com/Vauxoo/odoo/assets/76703666/c4130e08-84ca-483c-bd62-23c5d74a4cb8)

**After**
![image_2023-07-18_18-46-31](https://github.com/Vauxoo/odoo/assets/76703666/9d2e9c2a-773a-4f34-9584-4e645fa46e72)

![image_2023-07-18_18-46-55](https://github.com/Vauxoo/odoo/assets/76703666/42bf4647-b5b0-4375-9abe-3ce433099154)

### Flamegraph

![image_2023-07-18_18-52-25](https://github.com/Vauxoo/odoo/assets/76703666/bb3c226b-5f17-49cb-aedd-22108bcf58ca)
![image_2023-07-18_18-51-59](https://github.com/Vauxoo/odoo/assets/76703666/8f808ab7-bdb4-4959-93ec-c89a707f959c)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
