### PR TITLE
[FIX] odoo: enable remote-allow-origins i1980

### DIFF
--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -808,6 +808,7 @@ class ChromeBrowser():
             '--remote-debugging-port': '0',
             '--no-sandbox': '',
             '--disable-gpu': '',
+            '--remote-allow-origins': '*'
         }
         cmd = [self.executable]
         cmd += ['%s=%s' % (k, v) if v else k for k, v in switches.items()]


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
![image](https://github.com/Vauxoo/odoo/assets/35231827/314848cd-6e6c-45a9-8fee-4e497f3ea07f)
https://gitlab.com/ircanada/ircodoo-dev/-/jobs/4803073661
Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
