### PR TITLE
[FIX] account: Avoid error on payment complement

### DIFF
--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -457,7 +457,7 @@ class account_payment(models.Model):
     def _get_move_reconciled(self):
         for payment in self:
             rec = True
-            for aml in payment.move_line_ids.filtered(lambda x: x.account_id.reconcile):
+            for aml in payment.move_line_ids.filtered(lambda x: x.account_id.reconcile and x.account_id != payment.journal_id.default_debit_account_id):
                 if not aml.reconciled:
                     rec = False
             payment.move_reconciled = rec


### PR DESCRIPTION
Avoid error when the bank journal account is not from banks and is reconcile = True

On this case, the payment must be full reconciled

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
