### PR TITLE
[PATCH] website_sale_delivery: handle delivery carrier inputs 

### DIFF
--- a/addons/website_sale_delivery/static/src/js/website_sale_delivery.js
+++ b/addons/website_sale_delivery/static/src/js/website_sale_delivery.js
@@ -12,7 +12,6 @@ odoo.define('website_sale_delivery.checkout', function (require) {
     var $pay_button = $('#o_payment_form_pay');
     var $deliveryInputs = $("input[name='delivery_type']")
 
-
     var _onCarrierUpdateAnswer = function(result) {
         var $amount_delivery = $('#order_delivery span.oe_currency_value');
         var $amount_untaxed = $('#order_total_untaxed span.oe_currency_value');
@@ -54,12 +53,12 @@ odoo.define('website_sale_delivery.checkout', function (require) {
     };
 
     var _onCarrierClick = function(ev) {
-        $deliveryInputs.prop('disabled', true);
         $pay_button.data('disabled_reasons', $pay_button.data('disabled_reasons') || {});
         $pay_button.data('disabled_reasons').carrier_selection = true;
         $pay_button.prop('disabled', true);
         var carrier_id = $(ev.currentTarget).val();
         var values = {'carrier_id': carrier_id};
+        $deliveryInputs.prop('disabled', true);
         dp.add(ajax.jsonRpc('/shop/update_carrier', 'call', values))
           .then(_onCarrierUpdateAnswer);
     };

--- a/addons/website_sale_delivery/static/src/js/website_sale_delivery.js
+++ b/addons/website_sale_delivery/static/src/js/website_sale_delivery.js
@@ -10,6 +10,8 @@ odoo.define('website_sale_delivery.checkout', function (require) {
 
     /* Handle interactive carrier choice + cart update */
     var $pay_button = $('#o_payment_form_pay');
+    var $deliveryInputs = $("input[name='delivery_type']")
+
 
     var _onCarrierUpdateAnswer = function(result) {
         var $amount_delivery = $('#order_delivery span.oe_currency_value');
@@ -48,9 +50,11 @@ odoo.define('website_sale_delivery.checkout', function (require) {
             $amount_tax.text(result.new_amount_tax);
             $amount_total.text(result.new_amount_total);
         }
+        $deliveryInputs.prop('disabled', false);
     };
 
     var _onCarrierClick = function(ev) {
+        $deliveryInputs.prop('disabled', true);
         $pay_button.data('disabled_reasons', $pay_button.data('disabled_reasons') || {});
         $pay_button.data('disabled_reasons').carrier_selection = true;
         $pay_button.prop('disabled', true);


### PR DESCRIPTION
Disabling the delivery carrier inputs when the request is incomplete prevents multiple requests from modifying the same table simultaneously, thereby mitigating concurrency issues in the database

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
