### PR TITLE
[FIX] sale_crm: Typo error

### DIFF
--- a/addons/sale_crm/views/crm_lead_views.xml
+++ b/addons/sale_crm/views/crm_lead_views.xml
@@ -29,7 +29,7 @@
 
         <!-- add needaction_menu_ref to reload quotation needaction when opportunity needaction is reloaded -->
         <record id="crm.crm_lead_opportunities" model="ir.actions.act_window">
-            <field name="context">{'default_move_type': 'opportunity', 'default_user_id': uid}</field>
+            <field name="context">{'default_type': 'opportunity', 'default_user_id': uid}</field>
         </record>
 
         <record id="sales_team.mail_activity_type_action_config_sales" model="ir.actions.act_window">


### PR DESCRIPTION
Introduced by https://github.com/odoo/odoo/commit/d675dbaa4c7174591e0e7c1a3caf3e76877312ce

opw:2746271

closes odoo/odoo#83642

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:

`PATCH USE`




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
