### PR TITLE
[IMP] point_of_sale: split create payment move entry logic

### DIFF
--- a/addons/point_of_sale/models/pos_payment.py
+++ b/addons/point_of_sale/models/pos_payment.py
@@ -66,31 +66,36 @@ class PosPayment(models.Model):
     def _create_payment_moves(self):
         result = self.env['account.move']
         for payment in self:
-            order = payment.pos_order_id
             payment_method = payment.payment_method_id
-            if payment_method.type == 'pay_later' or float_is_zero(payment.amount, precision_rounding=order.currency_id.rounding):
+            if payment_method.type == 'pay_later' or float_is_zero(payment.amount, precision_rounding=payment.pos_order_id.currency_id.rounding):
                 continue
-            accounting_partner = self.env["res.partner"]._find_accounting_partner(payment.partner_id)
-            pos_session = order.session_id
-            journal = pos_session.config_id.journal_id
-            payment_move = self.env['account.move'].with_context(default_journal_id=journal.id).create({
-                'journal_id': journal.id,
-                'date': fields.Date.context_today(payment),
-                'ref': _('Invoice payment for %s (%s) using %s') % (order.name, order.account_move.name, payment_method.name),
-                'pos_payment_ids': payment.ids,
-            })
-            result |= payment_move
+            payment_move = payment._create_payment_move_entry()
             payment.write({'account_move_id': payment_move.id})
-            amounts = pos_session._update_amounts({'amount': 0, 'amount_converted': 0}, {'amount': payment.amount}, payment.payment_date)
-            credit_line_vals = pos_session._credit_amounts({
-                'account_id': accounting_partner.with_company(order.company_id).property_account_receivable_id.id,  # The field being company dependant, we need to make sure the right value is received.
-                'partner_id': accounting_partner.id,
-                'move_id': payment_move.id,
-            }, amounts['amount'], amounts['amount_converted'])
-            debit_line_vals = pos_session._debit_amounts({
-                'account_id': pos_session.company_id.account_default_pos_receivable_account_id.id,
-                'move_id': payment_move.id,
-            }, amounts['amount'], amounts['amount_converted'])
-            self.env['account.move.line'].with_context(check_move_validity=False).create([credit_line_vals, debit_line_vals])
+            result |= payment_move
             payment_move._post()
         return result
+
+    def _create_payment_move_entry(self):
+        self.ensure_one()
+        order = self.pos_order_id
+        accounting_partner = self.env["res.partner"]._find_accounting_partner(self.partner_id)
+        pos_session = order.session_id
+        journal = pos_session.config_id.journal_id
+        payment_move = self.env['account.move'].with_context(default_journal_id=journal.id).create({
+            'journal_id': journal.id,
+            'date': fields.Date.context_today(self),
+            'ref': _('Invoice payment for %s (%s) using %s') % (order.name, order.account_move.name, self.payment_method_id.name),
+            'pos_payment_ids': self.ids,
+        })
+        amounts = pos_session._update_amounts({'amount': 0, 'amount_converted': 0}, {'amount': self.amount}, self.payment_date)
+        credit_line_vals = pos_session._credit_amounts({
+            'account_id': accounting_partner.with_company(order.company_id).property_account_receivable_id.id,  # The field being company dependant, we need to make sure the right value is received.
+            'partner_id': accounting_partner.id,
+            'move_id': payment_move.id,
+        }, amounts['amount'], amounts['amount_converted'])
+        debit_line_vals = pos_session._debit_amounts({
+            'account_id': pos_session.company_id.account_default_pos_receivable_account_id.id,
+            'move_id': payment_move.id,
+        }, amounts['amount'], amounts['amount_converted'])
+        self.env['account.move.line'].with_context(check_move_validity=False).create([credit_line_vals, debit_line_vals])
+        return payment_move


### PR DESCRIPTION
Odoo's default behaviour is to create a journal entry for the invoice payment ('entry'), splitting the logic used to create this entry into a new function would allow l10n modules to alter this behaviour.

As an example of the use case would be Mexico EDI, where a refund ('out_refund') needs to be generated additional to the customer invoice for correct tax purposes after the POS session has been closed.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
