### PR TITLE
[IMP] base: allow bypass validation for merging with more than 3 partners

### DIFF
--- a/odoo/addons/base/wizard/base_partner_merge.py
+++ b/odoo/addons/base/wizard/base_partner_merge.py
@@ -275,6 +275,8 @@ class MergePartnerAutomatic(models.TransientModel):
             :param dst_partner : record of destination res.partner
             :param extra_checks: pass False to bypass extra sanity check (e.g. email address)
         """
+        # This context is used to don't show errors, only in loggers to allow continue from the cron job
+        skip_raise_errors = self._context.get("skip_validation_merging_more_contacts_together", False)
         # super-admin can be used to bypass extra checks
         if self.env.is_admin():
             extra_checks = False
@@ -284,7 +286,7 @@ class MergePartnerAutomatic(models.TransientModel):
         if len(partner_ids) < 2:
             return
 
-        if len(partner_ids) > 3:
+        if len(partner_ids) > 3 and not skip_raise_errors:
             raise UserError(_("For safety reasons, you cannot merge more than 3 contacts together. You can re-open the wizard several times if needed."))
 
         # check if the list of partners to merge contains child/parent relation


### PR DESCRIPTION

Currently the mergings of partner cannot be done if the partners to merge are more than 3, in proposals of Deduplication rules, the groups can be more than 3 partners and the error is stopping the cron job.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:

PATCH USE




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
