### PR TITLE
[IMP] base: allow exclude tables to update in merging partners

### DIFF
--- a/odoo/addons/base/wizard/base_partner_merge.py
+++ b/odoo/addons/base/wizard/base_partner_merge.py
@@ -115,8 +115,9 @@ class MergePartnerAutomatic(models.TransientModel):
         # this guarantees cache consistency
         self.env.invalidate_all()
 
+        ignore_tables = dst_partner._context.get('ignore_tables_fk', False)
         for table, column in relations:
-            if 'base_partner_merge_' in table:  # ignore two tables
+            if 'base_partner_merge_' in table or (ignore_tables and table in ignore_tables):  # ignore two tables
                 continue
 
             # get list of columns of current table (exept the current fk column)


### PR DESCRIPTION
The merges in partners are updating all tables with foreign keys related to partner, in some cases, the updating is not needed for some tables, this change allows to configure excluded tables to don't update foreign keys.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:

PATCH USE



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
