### PR TITLE
[FIX] odoo/modules: validate vesion just for intallable modules

### DIFF
--- a/odoo/modules/module.py
+++ b/odoo/modules/module.py
@@ -344,11 +344,11 @@ def load_manifest(module, mod_path=None):
             )
     elif manifest['auto_install']:
         manifest['auto_install'] = set(manifest['depends'])
-
-    try:
-        manifest['version'] = adapt_version(manifest['version'])
-    except ValueError as e:
-        raise ValueError(f"Module {module}: invalid manifest") from e
+    if manifest['installable']:
+        try:
+            manifest['version'] = adapt_version(manifest['version'])
+        except ValueError as e:
+            raise ValueError(f"Module {module}: invalid manifest") from e
     manifest['addons_path'] = normpath(opj(mod_path, os.pardir))
 
     return manifest


### PR DESCRIPTION
Currently, the module version is being validated according to the regular expression: "^[0-9]+.[0-9]+(?:.[0-9]+)?$" in the following line:

https://github.com/odoo/odoo/blob/65ce66d4ee87db5a20d236f621ad2af3981fffe0/odoo/modules/module.py#L454

However, this validation is being performed for all modules including non-installable ones, causing the raise to be triggered when migrating non-installable modules from a version prior to version 17.

For example, let's consider the migration of the module "custom_module" from version 14.0.1.0.1 to version 17, and during the process it is changed to `installable = False`. However, it is not possible to initialize the database due to the validations doesn't exclude non-installable modules.

This commit validates the module versions only for installable modules.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
