### PR TITLE
[IMP] payment_authorize: store message on declined tx

### DIFF
--- a/addons/payment_authorize/models/payment_transaction.py
+++ b/addons/payment_authorize/models/payment_transaction.py
@@ -242,7 +242,7 @@ class PaymentTransaction(models.Model):
                 # triggered by a customer browsing the transaction from the portal.
                 self.env.ref('payment.cron_post_process_payment_tx')._trigger()
         elif status_code == '2':  # Declined
-            self._set_canceled()
+            self._set_canceled(response_content.get("x_response_reason_text"))
         elif status_code == '4':  # Held for Review
             self._set_pending()
         else:  # Error / Unknown code


### PR DESCRIPTION
Transactions may be declined for different reasons and it is helpful for backend users to understand why. Therefore the response's reason text is now stored whenever an Authorize's transaction is declined.