### PR TITLE
[FIX] sale: remove duplicated message left after portal redesign

### DIFF
--- a/addons/sale/views/sale_portal_templates.xml
+++ b/addons/sale/views/sale_portal_templates.xml
@@ -121,7 +121,6 @@
                     </tr>
                 </t>
             </t>
-            <p t-else="">There are currently no orders for your account.</p>
         </t>
     </template>
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

After the portal redesign, messages for no quotations or sale orders were moved before the portal_table template, which is called when there are entries of quotations or sale orders. However, the previous version of the message for sale orders was left after the template call.

This commit removes the previous version of the message to avoid having duplicated messages.

Current behavior before PR:

Two similar messages are displayed in the portal when there are no sale orders.
- There are currently no sales orders for your account.
- There are currently no orders for your account.

Desired behavior after PR is merged:

Only one message is shown in the portal when there are no sale orders, as it happens for the quotations.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
