### PR TITLE
[IMP] auth_totp,base,web: New validation messages

### DIFF
--- a/addons/auth_totp/i18n/en.po
+++ b/addons/auth_totp/i18n/en.po
@@ -1,0 +1,24 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* auth_totp
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-05-09 20:03+0000\n"
+"PO-Revision-Date: 2021-05-09 20:03+0000\n"
+"Last-Translator: Jesús Valdez <jvaldez@vauxoo.com>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: auth_totp
+#: code:addons/auth_totp/models/res_users.py:0
+#: code:addons/auth_totp/wizard/auth_totp_wizard.py:0
+#, python-format
+msgid "Verification failed, please double-check the 6-digit code"
+msgstr ""
+"Verification has failed, please check your 6-digit code and enter it again"

--- a/addons/web/i18n/en.po
+++ b/addons/web/i18n/en.po
@@ -1,0 +1,22 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* web
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-05-09 20:03+0000\n"
+"PO-Revision-Date: 2021-05-09 20:03+0000\n"
+"Last-Translator: Jesús Valdez <jvaldez@vauxoo.com>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: web
+#: code:addons/web/controllers/main.py:491
+#, python-format
+msgid "Wrong login/password"
+msgstr "Incorrect username or password"

--- a/odoo/addons/base/i18n/en.po
+++ b/odoo/addons/base/i18n/en.po
@@ -1,0 +1,25 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* base
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-05-09 20:03+0000\n"
+"PO-Revision-Date: 2021-05-09 20:03+0000\n"
+"Last-Translator: Jesús Valdez <jvaldez@vauxoo.com>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: base
+#: code:addons/base/models/res_users.py:0
+#, python-format
+msgid "Too many login failures, please wait a bit before trying again."
+msgstr ""
+"Your account is temporarily locked as a security measure due to 3 "
+"unsuccessful login attempts. Please allow 1 minute to pass before trying to "
+"login again."


### PR DESCRIPTION
### Do not merge
This allows changing strings created from code that cannot be changed using i18n or i18n_extra in IRC due to the new form of saving translations.

Changed the message displayed when the user has too many login failures, the message when the user use a wrong login or password in web module and the message that appears when the verification through 2fa is not successful in auth_totp module.

Related to: [75454](https://www.vauxoo.com/web#id=75454&cids=1&action=470&model=project.task&view_type=form)