### PR TITLE
[FIX] payment_authorize: Workaround to support multiple currencies returned by Authorize

### DIFF
--- a/addons/payment_authorize/models/payment_provider.py
+++ b/addons/payment_authorize/models/payment_provider.py
@@ -104,7 +104,7 @@ class PaymentProvider(models.Model):
             raise UserError(_("Could not fetch merchant details:\n%s", res_content['err_msg']))
 
         currency = self.env['res.currency'].search([('name', 'in', res_content.get('currencies'))])
-        self.authorize_currency_id = currency
+        self.authorize_currency_id = currency & self.company_id.currency_id
         self.authorize_client_key = res_content.get('publicClientKey')
 
     # === BUSINESS METHODS ===#


### PR DESCRIPTION
It was already fixed in v17.0
 - https://github.com/odoo/odoo/blob/be611deca82c0f0e9c110d2ff35f3e081e94b3be/addons/payment_authorize/models/payment_provider.py#L80

But it requires a change in the database from m2o to m2m fields

So, we can not break stable policies

Also, a bug was reported to Authorize in order to avoid returning 2 currencies

since that it should return only 1
