### PR TITLE
[FIX] account: removes limiting `if tax_ids` condition

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -873,6 +873,7 @@ class AccountMoveLine(models.Model):
 
     def _get_computed_taxes(self):
         self.ensure_one()
+        tax_ids = self.env['account.tax']
 
         if self.move_id.is_sale_document(include_receipts=True):
             # Out invoice.
@@ -892,12 +893,12 @@ class AccountMoveLine(models.Model):
                 tax_ids = self.move_id.company_id.account_purchase_tax_id
         else:
             # Miscellaneous operation.
-            tax_ids = False if self.env.context.get('skip_computed_taxes') else self.account_id.tax_ids
+            tax_ids = self.env['account.tax'] if self.env.context.get('skip_computed_taxes') else self.account_id.tax_ids
 
         if self.company_id and tax_ids:
             tax_ids = tax_ids.filtered(lambda tax: tax.company_id == self.company_id)
 
-        if tax_ids and self.move_id.fiscal_position_id:
+        if self.move_id.fiscal_position_id:
             tax_ids = self.move_id.fiscal_position_id.map_tax(tax_ids)
 
         return tax_ids


### PR DESCRIPTION
In odoo the function `map_tax` in account.fiscal.position returns an empty recordset of account.tax if it receives an empty recordset as input.

Some extensions of odoo might change this behavior and return a non- empty recordset even with an empty input. For example `map_tax` might return `tax_ids.tax_dest_id` which have `is_fee = True`.

This commit removes the validation `if tax_ids` so that `map_tax` is always called. In vanilla Odoo this just adds a noop because it would call a method which loops over zero elements and returns.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
