### PR TITLE
[IMP] web: export company selector

### DIFF
--- a/addons/web/static/src/webclient/switch_company_menu/switch_company_menu.js
+++ b/addons/web/static/src/webclient/switch_company_menu/switch_company_menu.js
@@ -8,7 +8,7 @@ import { Component, useChildSubEnv, useState } from "@odoo/owl";
 import { debounce } from "@web/core/utils/timing";
 import { useService } from "@web/core/utils/hooks";
 
-class CompanySelector {
+export class CompanySelector {
     constructor(companyService, toggleDelay) {
         this.companyService = companyService;
         this.selectedCompaniesIds = companyService.activeCompanyIds.slice();


### PR DESCRIPTION
Right now it is not possible to inherit the company selector widget. In order to perform developments that modify the behavior of the widget, it is necessary to create a new one instead of just inheriting it, which is not a good practice. This commit makes it possible to inherit the company selector widget.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
