### PR TITLE
[FIX] hr_expense: correctly migrate expense tax amount field

### DIFF
--- a/addons/hr_expense/tests/test_expenses.py
+++ b/addons/hr_expense/tests/test_expenses.py
@@ -83,10 +83,10 @@ class TestExpenses(TestExpenseCommon):
             {'total_amount': 1160.00, 'untaxed_amount':  992.65, 'total_tax_amount': 167.35, 'state': 'draft', 'accounting_date': False},
         ])
         self.assertRecordValues(expense_sheets.expense_line_ids, [
-            {'total_amount_currency': 1600.00, 'untaxed_amount_currency': 1391.30, 'price_unit':  800.00, 'tax_amount': 208.70, 'state': 'reported'},
-            {'total_amount_currency':  160.00, 'untaxed_amount_currency':  123.08, 'price_unit':  160.00, 'tax_amount':  36.92, 'state': 'reported'},
-            {'total_amount_currency': 1000.00, 'untaxed_amount_currency':  869.57, 'price_unit': 1000.00, 'tax_amount': 130.43, 'state': 'reported'},
-            {'total_amount_currency':  160.00, 'untaxed_amount_currency':  123.08, 'price_unit':  160.00, 'tax_amount':  36.92, 'state': 'reported'},
+            {'total_amount_currency': 1600.00, 'untaxed_amount_currency': 1391.30, 'price_unit':  800.00, 'tax_amount_currency': 208.70, 'state': 'reported'},
+            {'total_amount_currency':  160.00, 'untaxed_amount_currency':  123.08, 'price_unit':  160.00, 'tax_amount_currency':  36.92, 'state': 'reported'},
+            {'total_amount_currency': 1000.00, 'untaxed_amount_currency':  869.57, 'price_unit': 1000.00, 'tax_amount_currency': 130.43, 'state': 'reported'},
+            {'total_amount_currency':  160.00, 'untaxed_amount_currency':  123.08, 'price_unit':  160.00, 'tax_amount_currency':  36.92, 'state': 'reported'},
         ])
 
         # Submitting properly change states

--- a/addons/hr_expense/views/hr_expense_views.xml
+++ b/addons/hr_expense/views/hr_expense_views.xml
@@ -213,7 +213,7 @@
                                        widget="many2many_tags"
                                        readonly="not is_editable"
                                        options="{'no_create': True}"/>
-                                <field name="tax_amount"/>
+                                <field name="tax_amount_currency"/>
                             </div>
                             <t groups="hr_expense.group_hr_expense_team_approver">
                                 <field name="employee_id" groups="!hr.group_hr_user"


### PR DESCRIPTION
The technical refactor in [1] renamed the tax amount in currency from `amount_tax` to `tax_amount_currency`. However, in some instances, it was mistakenly renamed to `tax_amount`, including in the commit description. This commit corrects this minor oversight.

[1]: https://github.com/odoo/odoo/commit/68fbdc96

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
