### PR TITLE
[IMP] portal: allow configure partner_ids in notification of portal - i#2901

### DIFF
--- a/addons/portal/controllers/mail.py
+++ b/addons/portal/controllers/mail.py
@@ -62,6 +62,13 @@ def _message_post_helper(res_model, res_id, message, token='', _hash=False, pid=
     else:  # early check on access to avoid useless computation
         record.check_access_rights('read')
         record.check_access_rule('read')
+    
+    if request.env.context.get("skip_partner_ids") and kw.get("partner_ids"):
+        kw.pop("partner_ids")
+
+    if request.env.context.get("force_only_note"):
+        kw["message_type"] = "notification"
+        kw["subtype_xmlid"] = "mail.mt_note"
 
     # deduce author of message
     author_id = request.env.user.partner_id.id if request.env.user.partner_id else False


### PR DESCRIPTION
When an order is reviewed by the partner and when an order is cancelled from the portal, a notification is sent to the followers of the order, which allows to configure that from a context.

Related: #https://gitlab.com/ircanada/ircodoo/-/issues/2901





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
