### PR TITLE
[FIX] gamification: Update portal logged users goals

### DIFF
--- a/addons/gamification/models/gamification_challenge.py
+++ b/addons/gamification/models/gamification_challenge.py
@@ -275,8 +275,8 @@ class Challenge(models.Model):
                         FROM gamification_goal as gg
                         JOIN res_users_log as log ON gg.user_id = log.create_uid
                         JOIN res_users ru on log.create_uid = ru.id
-                       WHERE (gg.write_date < log.create_date OR ru.share IS NOT TRUE)
-                         AND ru.active IS TRUE
+                       WHERE
+                         ru.active IS TRUE
                          AND gg.closed IS NOT TRUE
                          AND gg.challenge_id IN %s
                          AND (gg.state = 'inprogress'


### PR DESCRIPTION
For performance reasons, it was avoided the compute goals for the set of users that didn't login recently (See [1]).

However, users can stay logged in for a while without having a new "log-in event" (password asked), so we are removing the validation of time or internal users, while an improvement is made (probably a backport from 17.0, [2]).

[1] https://github.com/Vauxoo/odoo/commit/ec0c0f2973459fef8bca12e850af043c1ab90b99
[2] https://github.com/odoo/odoo/commit/466ab1eee672881b31a5cf7cceaa192ba8209490


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
