### PR TITLE
[IMP] gamification, *: imp selection of cron-updated goals (Backport)

### DIFF
--- a/addons/gamification/models/gamification_challenge.py
+++ b/addons/gamification/models/gamification_challenge.py
@@ -7,7 +7,8 @@ from datetime import date, timedelta
 
 from dateutil.relativedelta import relativedelta, MO
 
-from odoo import api, models, fields, _, exceptions
+from odoo import _, api, exceptions, fields, models
+from odoo.http import SESSION_LIFETIME
 from odoo.tools import ustr
 
 _logger = logging.getLogger(__name__)
@@ -269,20 +270,25 @@ class Challenge(models.Model):
         Goals = self.env['gamification.goal']
 
         # include yesterday goals to update the goals that just ended
-        # exclude goals for portal users that did not connect since the last update
+        # exclude goals for users that have not interacted with the
+        # webclient since the last update or whose session is no longer
+        # valid.
         yesterday = fields.Date.to_string(date.today() - timedelta(days=1))
         self.env.cr.execute("""SELECT gg.id
                         FROM gamification_goal as gg
-                        JOIN res_users_log as log ON gg.user_id = log.create_uid
-                        JOIN res_users ru on log.create_uid = ru.id
-                       WHERE (gg.write_date < log.create_date OR ru.share IS NOT TRUE)
-                         AND ru.active IS TRUE
+                        JOIN bus_presence as bp ON bp.user_id = gg.user_id
+                       WHERE gg.write_date <= bp.last_presence
+                         AND bp.last_presence >= now() AT TIME ZONE 'UTC' - interval '%(session_lifetime)s seconds'
                          AND gg.closed IS NOT TRUE
-                         AND gg.challenge_id IN %s
+                         AND gg.challenge_id IN %(challenge_ids)s
                          AND (gg.state = 'inprogress'
-                              OR (gg.state = 'reached' AND gg.end_date >= %s))
+                              OR (gg.state = 'reached' AND gg.end_date >= %(yesterday)s))
                       GROUP BY gg.id
-        """, [tuple(self.ids), yesterday])
+        """, {
+            'session_lifetime': SESSION_LIFETIME,
+            'challenge_ids': tuple(self.ids),
+            'yesterday': yesterday
+        })
 
         Goals.browse(goal_id for [goal_id] in self.env.cr.fetchall()).update_goal()
 

--- a/addons/gamification/tests/test_challenge.py
+++ b/addons/gamification/tests/test_challenge.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 import datetime
+from freezegun import freeze_time
 
 from odoo.addons.gamification.tests.common import TransactionCaseGamification
+
 from odoo.exceptions import UserError
 from odoo.tools import mute_logger
 
@@ -61,14 +63,14 @@ class test_challenge(TestGamificationCommon):
         badge_ids = self.env['gamification.badge.user'].search([('badge_id', '=', badge_id), ('user_id', '=', demo.id)])
         self.assertEqual(len(badge_ids), 1, "Demo user has not received the badge")
 
-    @mute_logger('odoo.models.unlink')
+    @mute_logger('odoo.models.unlink', 'odoo.addons.mail', 'odoo.addons.auth_signup')
     def test_20_update_all_goals_filter(self):
         # Enroll two internal and two portal users in the challenge
         (
-            portal_login_before_update,
-            portal_login_after_update,
-            internal_login_before_update,
-            internal_login_after_update,
+            portal_last_active_old,
+            portal_last_active_recent,
+            internal_last_active_old,
+            internal_last_active_recent,
         ) = all_test_users = self.env['res.users'].create([
             {
                 'name': f'{kind} {age} login',
@@ -90,21 +92,33 @@ class test_challenge(TestGamificationCommon):
             'user_ids': [(6, 0, all_test_users.ids)]
         })
 
-        # Setup user access logs
-        self.env['res.users.log'].search([('create_uid', 'in', challenge.user_ids.ids)]).unlink()
-        now = datetime.datetime.now()
+        # Setup user presence
+        self.env['bus.presence'].search([('user_id', 'in', challenge.user_ids.ids)]).unlink()
+        now = self.env.cr.now()
 
         # Create "old" log in records
-        self.env['res.users.log'].create([
-            {"create_uid": internal_login_before_update.id, 'create_date': now - datetime.timedelta(minutes=3)},
-            {"create_uid": portal_login_before_update.id, 'create_date': now - datetime.timedelta(minutes=3)},
-        ])
+        twenty_minutes_ago = now - datetime.timedelta(minutes=20)
+        with freeze_time(twenty_minutes_ago):
+            # Not using BusPresence.update_presence to avoid lower level cursor handling there.
+            self.env['bus.presence'].create([
+                {
+                    'user_id': user.id,
+                    'last_presence': twenty_minutes_ago,
+                    'last_poll': twenty_minutes_ago,
+                }
+                for user in (
+                    portal_last_active_old,
+                    portal_last_active_recent,
+                    internal_last_active_old,
+                    internal_last_active_recent,
+                )
+            ])
 
         # Reset goal objective values
         all_test_users.partner_id.tz = False
 
         # Regenerate all goals
-        self.env["gamification.goal"].search([]).unlink()
+        self.env['gamification.goal'].search([]).unlink()
         self.assertFalse(self.env['gamification.goal'].search([]))
 
         challenge.action_check()
@@ -114,27 +128,28 @@ class test_challenge(TestGamificationCommon):
         self.assertEqual(len(goal_ids), 4)
         self.assertEqual(set(goal_ids.mapped('state')), {'inprogress'})
 
-        # Create more recent log in records
-        self.env['res.users.log'].create([
-            {"create_uid": internal_login_after_update.id, 'create_date': now + datetime.timedelta(minutes=3)},
-            {"create_uid": portal_login_after_update.id, 'create_date': now + datetime.timedelta(minutes=3)},
-        ])
+        # Update presence for 2 users
+        users_recent = internal_last_active_recent | portal_last_active_recent
+        users_recent_presence = self.env['bus.presence'].search([('user_id', 'in', users_recent.ids)])
+        users_recent_presence.last_presence = now
+        users_recent_presence.last_poll = now
+        users_recent_presence.flush_recordset()
 
         # Update goal objective checked by goal definition
         all_test_users.partner_id.write({'tz': 'Europe/Paris'})
+        all_test_users.flush_recordset()
 
         # Update goals as done by _cron_update
         challenge._update_all()
-        unchanged_goal_id = self.env['gamification.goal'].search([
+        unchanged_goal_ids = self.env['gamification.goal'].search([
             ('challenge_id', '=', challenge.id),
             ('state', '=', 'inprogress'),  # others were updated to "reached"
             ('user_id', 'in', challenge.user_ids.ids),
         ])
-        # Check that even though login record for internal user is older than goal update, their goal was reached.
+        # Check that goals of users not recently active were not updated
         self.assertEqual(
-            portal_login_before_update,
-            unchanged_goal_id.user_id,
-            "Only portal user last logged in before last challenge update should not have been updated.",
+            portal_last_active_old | internal_last_active_old,
+            unchanged_goal_ids.user_id,
         )
 
 

--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -303,8 +303,8 @@ class ResUsersLog(models.Model):
     _name = 'res.users.log'
     _order = 'id desc'
     _description = 'Users Log'
-    # Currenly only uses the magical fields: create_uid, create_date,
-    # for recording logins. To be extended for other uses (chat presence, etc.)
+    # Uses the magical fields `create_uid` and `create_date` for recording logins.
+    # See `bus.presence` for more recent activity tracking purposes.
 
     @api.autovacuum
     def _gc_user_logs(self):


### PR DESCRIPTION
*: base

In the cron updating challenges goals, we were historically filtering in records of users that logged in since the last update. This doesn't work because sessions can last a long time, so users are active between cron runs but their goals are not updated and stale reports were sent.

We temporarily fixed this in v14.0 by updating all goals for internal users, but this can lead to unnecessary computations too, and still misses goals of active portal users.

Instead, we are here using the `bus.presence` records to track user activity, combining it with the session lifetime to avoid indefinitely fetching old goals that couldn't need an update.
This works for both internal and portal users.

Note: we update stale base comments in favor of exposing bus.presence to guide developers.

Task-3148858

closes odoo/odoo#121763

Signed-off-by: Thibault Delavallee (tde) <tde@openerp.com>

Back-port of: https://github.com/odoo/odoo/commit/466ab1eee672881b31a5cf7cceaa192ba8209490


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
