### PR TITLE
[IMP] web: Add format support in the barcode

### DIFF
--- a/addons/web/static/src/webclient/barcode/barcode_scanner.js
+++ b/addons/web/static/src/webclient/barcode/barcode_scanner.js
@@ -46,7 +46,7 @@ export class BarcodeDialog extends Component {
                 await loadJS("/web/static/lib/zxing-library/zxing-library.js");
                 DetectorClass = buildZXingBarcodeDetector(window.ZXing);
             }
-            const formats = await DetectorClass.getSupportedFormats();
+            const formats =  this.props.formats || await DetectorClass.getSupportedFormats();
             this.detector = new DetectorClass({ formats });
         });
 
@@ -199,7 +199,7 @@ export function isBarcodeScannerSupported() {
  *
  * @returns {Promise<string>} resolves when a {qr,bar}code has been detected
  */
-export async function scanBarcode(facingMode = "environment") {
+export async function scanBarcode(facingMode = "environment", formats) {
     const promise = new Deferred();
     const appForBarcodeDialog = new App(BarcodeDialog, {
         env: owl.Component.env,
@@ -217,6 +217,7 @@ export async function scanBarcode(facingMode = "environment") {
                 }
             },
             facingMode: facingMode,
+            formats,
         },
     });
     await appForBarcodeDialog.mount(document.body);


### PR DESCRIPTION
**\[IMP] event_venue: Allow specifying formats when scanning**


Before this change, the scanBarcode function did not allow specifying
barcode formats, relying solely on the default supported formats. This
improvement introduces an optional formats parameter, enabling users
to define the barcode types to scan.

https://gitlab.com/ircanada/ircodoo/-/merge_requests/3596

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
