### PR TITLE
[REF] website_event: Refresh recaptcha on submit event registration form

### DIFF
--- a/addons/website_event/static/src/js/website_event.js
+++ b/addons/website_event/static/src/js/website_event.js
@@ -99,6 +99,7 @@ var EventRegistrationForm = Widget.extend({
                 $modal.on('submit', 'form', async function (ev) {
                     ev.preventDefault();
                     ev.stopPropagation();
+                    $modal.find('.modal-footer > button.btn-primary').prop('disabled', true);
                     tokenObj = await self._recaptcha.getToken('website_event_registration');
                     const tokenInput = document.createElement('input');
                     tokenInput.setAttribute('name', 'recaptcha_token_response');

--- a/addons/website_event/static/src/js/website_event.js
+++ b/addons/website_event/static/src/js/website_event.js
@@ -72,7 +72,7 @@ var EventRegistrationForm = Widget.extend({
             var action = $form.data('action') || $form.attr('action');
             var self = this;
             return ajax.jsonRpc(action, 'call', post).then(async function (modal) {
-                const tokenObj = await self._recaptcha.getToken('website_event_registration');
+                let tokenObj = await self._recaptcha.getToken('website_event_registration');
                 if (tokenObj.error) {
                     self.displayNotification({
                         type: 'danger',
@@ -96,12 +96,16 @@ var EventRegistrationForm = Widget.extend({
                 $modal.on('click', '.btn-close', function () {
                     $button.prop('disabled', false);
                 });
-                $modal.on('submit', 'form', function (ev) {
+                $modal.on('submit', 'form', async function (ev) {
+                    ev.preventDefault();
+                    ev.stopPropagation();
+                    tokenObj = await self._recaptcha.getToken('website_event_registration');
                     const tokenInput = document.createElement('input');
                     tokenInput.setAttribute('name', 'recaptcha_token_response');
                     tokenInput.setAttribute('type', 'hidden');
                     tokenInput.setAttribute('value', tokenObj.token);
                     ev.currentTarget.appendChild(tokenInput);
+                    ev.currentTarget.submit();
                 })
             });
         }


### PR DESCRIPTION
[REF] website_event: Refresh recaptcha on submit event registration form.

When you want to register for an event, after selecting the number of tickets it opens a modal with a form to fill, on this moment it generates a recaptcha token, but if you take more than 2 minutes to submit the form it will return an error of timeout recaptcha, which is unavoidable for cases of wanting to register a great quantity of tickets at the same time, because it takes a long time to fill the form. To avoid this issue, we refresh the token on the submit.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
