### PR TITLE
[IMP] web: Allow setting Char Field as Field's Domain

### DIFF
--- a/addons/web/static/src/legacy/js/core/py_utils.js
+++ b/addons/web/static/src/legacy/js/core/py_utils.js
@@ -161,7 +161,28 @@ function eval_domains(domains, evaluation_context) {
         if (need_normalization) {
             domain_array_to_combine = get_normalized_domain(domain_array_to_combine);
         }
-        result_domain.push.apply(result_domain, domain_array_to_combine);
+        // NOTE: Allow setting a Char Field as domain of another field:
+        // In v17 this was refactored and the field is accepted as the domain.
+        // https://github.com/odoo/odoo/commit/3fac03b7
+        try {
+            result_domain.push.apply(result_domain, domain_array_to_combine);
+        } catch (err) {
+            let ChromeMessage = "CreateListFromArrayLike",
+                FirefoxMessage = "second argument to Function.prototype.apply must be an array";
+            if (
+                err.message.indexOf(ChromeMessage) !== -1
+                || err.message.indexOf(FirefoxMessage) !== -1
+            ) {
+                if (typeof (domain_array_to_combine) === "string") {
+                    domain_array_to_combine = JSON.parse(domain_array_to_combine)
+                    result_domain.push.apply(result_domain, domain_array_to_combine);
+                } else {
+                    throw err;
+                }
+            } else {
+                throw err;
+            }
+        }
     });
     return result_domain;
 }


### PR DESCRIPTION
Allow setting a Char Field as the domain for another field, this will avoid having to create a `many2many` computed field to have the allowed registers of another domain field like `[("id", "=", many2many_allowed_field)]` because that was messing with the performance when the allowed records was a large amount of them.

Now with this, we only have to create a computed char field with the dynamic domain as a JSON, and set it like this:
`domain="allowed_domain_field"`.

This was refactored in v17 and isn't necessary https://github.com/odoo/odoo/commit/3fac03b7

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
