### PR TITLE
[FIX] sms_marketing: ensure SMS links use the correct domain

### DIFF
--- a/addons/mass_mailing_sms/models/sms_sms.py
+++ b/addons/mass_mailing_sms/models/sms_sms.py
@@ -16,6 +16,7 @@ class SmsSms(models.Model):
         """ Override to tweak shortened URLs by adding statistics ids, allowing to
         find customer back once clicked. """
         res = dict.fromkeys(self.ids, False)
+        base_url = self.env['website'].get_current_website().get_base_url()
         for sms in self:
             if not sms.mailing_id or not sms.body:
                 res[sms.id] = sms.body
@@ -23,7 +24,7 @@ class SmsSms(models.Model):
 
             body = sms.body
             for url in set(re.findall(tools.TEXT_URL_REGEX, body)):
-                if url.startswith(sms.get_base_url() + '/r/'):
+                if url.startswith(sms.get_base_url() + '/r/') or url.startswith(base_url + '/r/'):
                     body = re.sub(re.escape(url) + r'(?![\w@:%.+&~#=/-])', url + f'/s/{sms.id}', body)
             res[sms.id] = body
         return res


### PR DESCRIPTION
Before this commit, the generated SMS link did not include the SMS code because it was created using the domain of the current website(second) instead of the intended one. This happened because the comparison was made against the `web.base.url` parameter instead of the current website domain.

With this fix, the system correctly uses the current website domain for both link generation and comparison, ensuring the SMS code is applied.

Steps to reproduce:
- Go to **SMS Marketing**.
- Create a new `mailing.mailing` with **Concat Recipients**.
- Set up **two websites** with different domains.
- Configure `web.base.url` using the same domain as the **first website**.
- Log in to the **second website**.
- Send the `mailing.mailing`.

CUrrent behavior:
- The SMS link does not include the SMS code.

Expected behavior:
- The SMS link should include the SMS code.

Closes #201641
 Fixes #201641

#### **Screenshots**  
![image](https://github.com/user-attachments/assets/7ed0e983-9fc8-4cdb-9355-f04c4e80a1ef)
![image](https://github.com/user-attachments/assets/c13e68d1-6397-4074-9645-51f49abcec94)




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
