### PR TITLE
[IMP] pos_restaurant: pos_restaurant.SplitBillScreenn and product configurator work together

### DIFF
--- a/addons/pos_restaurant/static/src/js/Screens/SplitBillScreen/SplitBillScreen.js
+++ b/addons/pos_restaurant/static/src/js/Screens/SplitBillScreen/SplitBillScreen.js
@@ -85,7 +85,7 @@ odoo.define('pos_restaurant.SplitBillScreen', function(require) {
         _initSplitLines(order) {
             const splitlines = {};
             for (let line of order.get_orderlines()) {
-                splitlines[line.id] = { product: line.get_product().id, quantity: 0 };
+                splitlines[line.id] = { product: line.id, quantity: 0 };
             }
             return splitlines;
         }
@@ -95,7 +95,7 @@ odoo.define('pos_restaurant.SplitBillScreen', function(require) {
             let totalQuantity = 0;
 
             this.env.pos.get_order().get_orderlines().forEach(function(orderLine) {
-                if(orderLine.get_product().id === split.product)
+                if(orderLine.id === split.product)
                     totalQuantity += orderLine.get_quantity();
             });
 
@@ -137,13 +137,13 @@ odoo.define('pos_restaurant.SplitBillScreen', function(require) {
             let order = this.env.pos.get_order();
             let full = true;
             let splitlines = this.splitlines;
-            let groupedLines = _.groupBy(order.get_orderlines(), line => line.get_product().id);
+            let groupedLines = _.groupBy(order.get_orderlines(), line => line.id);
 
             Object.keys(groupedLines).forEach(function (lineId) {
                 var maxQuantity = groupedLines[lineId].reduce(((quantity, line) => quantity + line.get_quantity()), 0);
                 Object.keys(splitlines).forEach(id => {
                     let split = splitlines[id];
-                    if(split.product === groupedLines[lineId][0].get_product().id)
+                    if(split.product === groupedLines[lineId][0].id)
                         maxQuantity -= split.quantity;
                 });
                 if(maxQuantity !== 0)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

After this, the Bill Split screen allows to split orders with products with attributes selected by the product configurator.

Current behavior before PR:

products with attributes selected by the product configurator, breaks the split order screen.

Desired behavior after PR is merged:

products with attributes selected by the product configurator, works normaly in the split order screen.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
