### PR TITLE
[IMP] odoo: force secure param to session_id cookie

### DIFF
--- a/odoo/http.py
+++ b/odoo/http.py
@@ -1574,7 +1574,7 @@ class Request:
 
         cookie_sid = self.httprequest.cookies.get('session_id')
         if sess.is_dirty or cookie_sid != sess.sid:
-            self.future_response.set_cookie('session_id', sess.sid, max_age=SESSION_LIFETIME, httponly=True)
+            self.future_response.set_cookie('session_id', sess.sid, max_age=SESSION_LIFETIME, httponly=True, secure=True)
 
     def _set_request_dispatcher(self, rule):
         routing = rule.endpoint.routing
@@ -1814,7 +1814,7 @@ class HttpDispatcher(Dispatcher):
             response = self.request.redirect_query('/web/login', {'redirect': self.request.httprequest.full_path})
             if was_connected:
                 root.session_store.rotate(session, self.request.env)
-                response.set_cookie('session_id', session.sid, max_age=SESSION_LIFETIME, httponly=True)
+                response.set_cookie('session_id', session.sid, max_age=SESSION_LIFETIME, httponly=True, secure=True)
             return response
 
         return (exc if isinstance(exc, HTTPException)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:

- The cookie `session_id` has the parameter `secure` set to false, and it suddenly closes the Odoo sessions when using the `session_db` module and some browsers (like Chrome).

Desired behavior after PR is merged:

- It keeps the expected time for Odoo sessions, according to the config parameter: `sessions.max_inactivity_seconds`.


WARNING: It could affect the login to the instance if you do it with HTTP; your connection should have HTTPS/SSL.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
