### PR TITLE
[REF] product: Set max iterations to look for product combinations

### DIFF
--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -1263,8 +1263,14 @@ class ProductTemplate(models.Model):
         line_index = 0
         # determines which ptav we're working on
         current_ptav = None
-
+        max_iterations = self.env['ir.config_parameter'].sudo().get_param('product.combination_limit', 200000)
+        count = 0
         while True:
+            count += 1
+            if count > max_iterations:
+                _logger.warning("'product.combination_limit' %s reached for product_template %s product_template_attribute_values_per_line %s parent_combination %s.",
+                                count, self.id, product_template_attribute_values_per_line, parent_combination)
+                break
             current_line_values = product_template_attribute_values_per_line[line_index]
             current_ptav_index = value_index_per_line[line_index]
 


### PR DESCRIPTION
Sometimes the products are stuck for a long time looking for combinations

This patch set max iterations for this infinite loop

It is reproduced with the following script

```python
self.env.cr.execute("""
    SELECT ptal.product_tmpl_id,
        ARRAY_AGG(ptav.id) AS ptav2del
    FROM product_template_attribute_line AS ptal
    JOIN product_attribute AS pa
      ON ptal.attribute_id = pa.id
    JOIN product_template_attribute_value AS ptav
      ON ptal.id = ptav.attribute_line_id
    WHERE pa.create_variant = 'always'
      AND ptav.id IS NOT NULL
      AND ptal.active IS TRUE
    GROUP BY ptal.product_tmpl_id
""")
res = self.env.cr.fetchall()

for r in res:
    product_tmpl = self.env["product.template"].browse(r[0])
    product_templ_attr_vals = self.env["product.template.attribute.value"].browse(r[1])
    product_templ_attr_vals.unlink()
    print(product_tmpl)
    combination = product_tmpl._get_first_possible_combination()
```