### PR TITLE
[FIX] website: remove forced name ordering in autocomplete for search

### DIFF
--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -469,9 +469,9 @@ class Website(Home):
         for search_result in search_results:
             results_data += search_result['results_data']
             mappings.append(search_result['mapping'])
-        if search_type == 'all':
-            # Only supported order for 'all' is on name
-            results_data.sort(key=lambda r: r.get('name', ''), reverse='name desc' in order)
+        # if search_type == 'all':
+        #     # Only supported order for 'all' is on name
+        #     results_data.sort(key=lambda r: r.get('name', ''), reverse='name desc' in order)
         results_data = results_data[:limit]
         result = []
         for record in results_data:


### PR DESCRIPTION

Description of the issue/feature this PR addresses:

Ensures consistency and predictability when presenting autocomplete results, especially when custom or domain-specific sorting is required.

Current behavior before PR:

Prior to this patch, the autocomplete method on the /website/snippet/autocomplete route explicitly forced results to be ordered by name when the search_type was set to 'all'. This behavior could override custom ordering logic introduced in each model's _search_fetch method (e.g., for pages, events, blogs).

Desired behavior after PR is merged:

This patch removes the forced ordering by name for search_type 'all', allowing the ordering to respect the logic defined in each model's _search_fetch implementation. This ensures consistency and predictability when presenting autocomplete results, especially when custom or domain-specific sorting is required.

No changes were made to the default behavior for other search types.

Related to previous improvements in _search_fetch for website.page, event.event, and website.blog.

PATCH USE to 16.0

