### PR TITLE
16.0 add check environment validation in authorizeapi irvingreyes

### DIFF
--- a/addons/payment_authorize/models/authorize_request.py
+++ b/addons/payment_authorize/models/authorize_request.py
@@ -39,8 +39,12 @@ class AuthorizeAPI:
         self.name = provider.authorize_login
         self.transaction_key = provider.authorize_transaction_key
         self.payment_method_type = provider.authorize_payment_method_type
+        self.provider = provider
 
     def _make_request(self, operation, data=None):
+        check_env = getattr(self.provider, "_check_environment", None)
+        if callable(check_env):
+            check_env()
         request = {
             operation: {
                 'merchantAuthentication': {


### PR DESCRIPTION
## This MR is related to [ISSUE#2000](https://gitlab.com/ircanada/ircodoo/-/issues/2000)

## [MR](https://gitlab.com/ircanada/ircodoo/-/merge_requests/3960) 

Added a safe call to `_check_environment` in the `_make_request` method
of the `AuthorizeAPI` class, using `getattr` to avoid errors if the
method is missing. This ensures payment operations are only executed in
a valid environment, enhancing protection against unintentional use of
production credentials in test or staging environments.

**Description of the issue/feature this PR addresses:**

Allow payment providers to validate the environment before executing
external API requests. Prevent unintended usage of production
credentials in non-production environments.

**Current behavior before PR:**

The `AuthorizeAPI._make_request` method did not verify if the environment
was safe for performing real transactions. As a result, production
credentials could be used inadvertently in staging or test environments.

**Desired behavior after PR is merged:**

The `_make_request` method attempts to call the `_check_environment`
method on the provider (if it exists and is callable), enforcing
environment validation before continuing with the payment request.
This ensures that production transactions only occur in authorized
environments.


PATCH USE to 16.0