### PR TITLE
[IMP] payment_authorize: avoid setting VOID transactions as canceled

### DIFF
--- a/addons/payment_authorize/models/payment_transaction.py
+++ b/addons/payment_authorize/models/payment_transaction.py
@@ -106,10 +106,7 @@ class PaymentTransaction(models.Model):
 
         refund_tx = self.env['payment.transaction']
         tx_status = tx_details.get('transaction', {}).get('transactionStatus')
-        if tx_status in TRANSACTION_STATUS_MAPPING['voided']:
-            # The payment has been voided from Authorize.net side before we could refund it.
-            self._set_canceled()
-        elif tx_status in TRANSACTION_STATUS_MAPPING['refunded']:
+        if tx_status in TRANSACTION_STATUS_MAPPING['refunded']:
             # The payment has been refunded from Authorize.net side before we could refund it. We
             # create a refund tx on Odoo to reflect the move of the funds.
             refund_tx = super()._send_refund_request(amount_to_refund=amount_to_refund)
@@ -234,8 +231,6 @@ class PaymentTransaction(models.Model):
             elif status_type == 'void':
                 if self.operation == 'validation':  # Validation txs are authorized and then voided
                     self._set_done()  # If the refund went through, the validation tx is confirmed
-                else:
-                    self._set_canceled()
             elif status_type == 'refund' and self.operation == 'refund':
                 self._set_done()
                 # Immediately post-process the transaction as the post-processing will not be

--- a/addons/payment_authorize/tests/test_refund_flows.py
+++ b/addons/payment_authorize/tests/test_refund_flows.py
@@ -12,7 +12,7 @@ from odoo.addons.payment_authorize.tests.common import AuthorizeCommon
 class TestRefundFlows(AuthorizeCommon):
 
     def test_refunding_voided_tx_cancels_it(self):
-        """ Test that refunding a transaction that has been voided from Authorize.net side cancels
+        """ Test that refunding a transaction that has been voided from Authorize.net side does not cancel
         it on Odoo. """
         source_tx = self._create_transaction('direct', state='done')
         with patch(
@@ -21,7 +21,7 @@ class TestRefundFlows(AuthorizeCommon):
             return_value={'transaction': {'transactionStatus': 'voided'}},
         ):
             source_tx._send_refund_request(amount_to_refund=source_tx.amount)
-        self.assertEqual(source_tx.state, 'cancel')
+        self.assertNotEqual(source_tx.state, 'cancel')
 
     def test_refunding_refunded_tx_creates_refund_tx(self):
         """ Test that refunding a transaction that has been refunded from Authorize.net side creates


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

https://gitlab.com/ircanada/ircodoo/-/issues/3721

 This commit removes calls to `_set_canceled()` for VOID-type transactions.
  For proper reconciliation, VOID transactions must remain in the `posted` state
  and should not be marked as canceled in the `payment.transaction` record.
  
Unit tests were adjusted accordingly.

Current behavior before PR:

The payment.transaction and account.payment records related to an invoice were being canceled when generating a VOID transaction.

Desired behavior after PR is merged:

Both payment.transaction and account.payment records related to an invoice should remain in the posted state to allow automatic reconciliation of the invoice for the client's requirements.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
