### PR TITLE
[FIX] purchase: Pre-Creation of `purchase_method`

### DIFF
--- a/addons/purchase/__init__.py
+++ b/addons/purchase/__init__.py
@@ -5,3 +5,4 @@ from . import controllers
 from . import models
 from . import report
 from . import populate
+from .hooks import pre_init_hook

--- a/addons/purchase/__manifest__.py
+++ b/addons/purchase/__manifest__.py
@@ -34,6 +34,7 @@
     'demo': [
         'data/purchase_demo.xml',
     ],
+    "pre_init_hook": "pre_init_hook",
     'installable': True,
     'application': True,
     'assets': {

--- a/addons/purchase/hooks.py
+++ b/addons/purchase/hooks.py
@@ -1,0 +1,20 @@
+import logging
+
+from odoo.tools import column_exists
+
+_logger = logging.getLogger(__name__)
+
+
+def pre_init_hook(cr):
+    pre_create_purchase_method(cr)
+
+
+def pre_create_purchase_method(cr):
+    """Create the purchase_method field in product.template if it does not exist (added in "purchase" dependency).
+    Also, set the default value to 'purchase' for existing products by query instead of computing it with Python.
+    """
+    if not column_exists(cr, "product_template", "purchase_method"):
+        cr.execute("ALTER TABLE product_template ADD COLUMN purchase_method character varying;")
+        _logger.info("Column 'purchase_method' added to product_template table.")
+        cr.execute("UPDATE product_template AS pt SET purchase_method = 'purchase';")
+        _logger.info("Setting purchase_method to 'purchase' for %s products", cr.rowcount)


### PR DESCRIPTION
Adding a pre-init hook to pre-create the field `purchase_method` and set a default value with a SQL query to avoid the computation in Python.

This commit includes changes for the [ircodoo project's issue 3675](https://gitlab.com/ircanada/ircodoo/-/issues/3675).

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
