### PR TITLE
[IMP] payment_authorize: avoid setting VOID transactions as canceled I#3817

### DIFF
--- a/addons/payment_authorize/models/payment_transaction.py
+++ b/addons/payment_authorize/models/payment_transaction.py
@@ -107,8 +107,7 @@ class PaymentTransaction(models.Model):
         refund_tx = self.env['payment.transaction']
         tx_status = tx_details.get('transaction', {}).get('transactionStatus')
         if tx_status in TRANSACTION_STATUS_MAPPING['voided']:
-            # The payment has been voided from Authorize.net side before we could refund it.
-            self._set_canceled()
+            self.with_context(avoid_cancel=True)._set_canceled()
         elif tx_status in TRANSACTION_STATUS_MAPPING['refunded']:
             # The payment has been refunded from Authorize.net side before we could refund it. We
             # create a refund tx on Odoo to reflect the move of the funds.
@@ -235,7 +234,7 @@ class PaymentTransaction(models.Model):
                 if self.operation == 'validation':  # Validation txs are authorized and then voided
                     self._set_done()  # If the refund went through, the validation tx is confirmed
                 else:
-                    self._set_canceled()
+                    self.with_context(avoid_cancel=True)._set_canceled()
             elif status_type == 'refund' and self.operation == 'refund':
                 self._set_done()
                 # Immediately post-process the transaction as the post-processing will not be


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

https://gitlab.com/ircanada/ircodoo/-/issues/3721

https://gitlab.com/ircanada/ircodoo/-/issues/3817

This commit removes calls to _set_canceled() for VOID-type transactions.
For proper reconciliation, VOID transactions must remain in the posted state
and should not be marked as canceled in the payment.transaction record.

**To identify voided payment.transaction records, the context "transaction_voided" is provided where previously they were marked as canceled.**

Unit tests were adjusted accordingly.

Current behavior before PR:

The payment.transaction and account.payment records related to an invoice were being canceled when generating a VOID transaction.

Desired behavior after PR is merged:

Both payment.transaction and account.payment records related to an invoice should remain in the posted state to allow automatic reconciliation of the invoice for the client's requirements.