### PR TITLE
[FIX] web: properly handle row number column in ListRenderer

### DIFF
--- a/addons/web/static/src/views/list/column_width_hook.js
+++ b/addons/web/static/src/views/list/column_width_hook.js
@@ -157,8 +157,12 @@ function computeOptimalDateWidths() {
  */
 function computeWidths(table, state, allowedWidth, startingWidths) {
     let _columnWidths;
-    const headers = [...table.querySelectorAll("thead th")];
+    const headers = [...table.querySelectorAll("thead th:not(.o_rowno)")];
+    const rowNum = table.classList.contains("o_rowno_in_tree")
     const columns = state.columns;
+
+    if (rowNum && startingWidths)
+        startingWidths.shift();
 
     // Starting point: compute widths
     if (startingWidths) {
@@ -207,6 +211,8 @@ function computeWidths(table, state, allowedWidth, startingWidths) {
     // Expand/shrink columns for the table to fill 100% of available space
     const totalWidth = _columnWidths.reduce((tot, width) => tot + width, 0);
     let diff = totalWidth - allowedWidth;
+    if (rowNum)
+        diff += DEFAULT_MIN_WIDTH/2;
     if (diff >= 1) {
         // Case 1: table overflows its parent => shrink some columns
         const shrinkableColumns = [];
@@ -278,6 +284,8 @@ function computeWidths(table, state, allowedWidth, startingWidths) {
             }
         }
     }
+    if (rowNum)
+        _columnWidths.unshift(SELECTOR_WIDTH);
     return _columnWidths;
 }
 


### PR DESCRIPTION
Adjusted computeWidths to exclude the row number column from initial width calculations when the o_rowno_in_tree class is present. This prevents incorrect sizing by temporarily removing the starting width for the row number and restoring it after adjustments. Also ensured that total width calculations account for the row number column to maintain consistent column widths.



https://github.com/user-attachments/assets/9db3f494-2fcb-49c5-9089-2b7968148c17




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
