### PR TITLE
[IMP] stock: improve error message

### DIFF
--- a/addons/stock/i18n/es.po
+++ b/addons/stock/i18n/es.po
@@ -2836,13 +2836,10 @@ msgstr ""
 "No es posible reservar más productos que los %s que tiene en existencias."
 
 #. module: stock
-#: code:addons/stock/models/stock_quant.py:266
+#: code:addons/stock/models/stock_quant.py:273
 #, python-format
-msgid ""
-"It is not possible to unreserve more products of %s than you have in stock."
-msgstr ""
-"No es posible deshacer la reserva de más productos que los %s que tiene en "
-"existencias."
+msgid "It is not possible to unreserve more products of %s than you have in stock. Available quantity: %s, quantity: %s"
+msgstr "No es posible deshacer la reserva de más productos que los %s que tiene en existencias. Cantidad disponible: %s, cantidad: %s"
 
 #. module: stock
 #: model:ir.model.fields,help:stock.field_stock_move__product_packaging

--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -270,7 +270,9 @@ class StockQuant(models.Model):
             # if we want to unreserve
             available_quantity = sum(quants.mapped('reserved_quantity'))
             if float_compare(abs(quantity), available_quantity, precision_rounding=rounding) > 0:
-                raise UserError(_('It is not possible to unreserve more products of %s than you have in stock.') % product_id.display_name)
+                msg = _("It is not possible to unreserve more products of %s than you have in stock."
+                        " Available quantity: %s, quantity: %s") % (product_id.display_name, available_quantity, quantity)
+                raise UserError(msg)
         else:
             return reserved_quants
 


### PR DESCRIPTION
Improve the error message displayed when confirming an order or picking items to show both the available quantity and the quantity to be validated. This will enhance the user experience, allowing them to easily verify the displayed quantities.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
