### PR TITLE
[IMP] pos_sale: read_converted now uses method to get lines UoM

### DIFF
--- a/addons/pos_sale/models/sale_order.py
+++ b/addons/pos_sale/models/sale_order.py
@@ -101,12 +101,15 @@ class SaleOrderLine(models.Model):
     def _get_sale_order_fields(self):
         return ["product_id", "display_name", "price_unit", "product_uom_qty", "tax_id", "qty_delivered", "qty_invoiced", "discount", "qty_to_invoice", "price_total", "is_downpayment"]
 
+    def get_product_uom(self):
+        return self.product_id.uom_id
+
     def read_converted(self):
         field_names = self._get_sale_order_fields()
         results = []
         for sale_line in self:
             if sale_line.product_type or (sale_line.is_downpayment and sale_line.price_unit != 0):
-                product_uom = sale_line.product_id.uom_id
+                product_uom = sale_line.get_product_uom()
                 sale_line_uom = sale_line.product_uom
                 item = sale_line.read(field_names, load=False)[0]
                 if sale_line.product_id.tracking != 'none':


### PR DESCRIPTION
- Addded method `get_product_uom` to the `sale.order.line` model.
- Method `read_converted` now uses `get_product_uom`.

Description of the issue/feature this PR addresses:

The current method `read_converted` does not offers a way to change the UoM to use in a `sale.order.line`.

Current behavior before PR:

We are unable to change the UoM to use in a `sale.order.line` within the method `read_converted`.

Desired behavior after PR is merged:

We are able to change the UoM to use in a `sale.order.line` within the method `read_converted`.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
