### PR TITLE
[IMP] point_of_sale: _launch_stock_rule_from_pos_order_lines now uses… T#94093 

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -1632,7 +1632,7 @@ class PosOrderLine(models.Model):
                 line.order_id.with_context(backend_recomputation=True).write({'procurement_group_id': group_id})
 
             values = line._prepare_procurement_values(group_id=group_id)
-            product_qty = line.qty
+            product_qty = line.product_uom_id._compute_quantity(line.qty, line.product_id.uom_id)
 
             procurement_uom = line.product_id.uom_id
             procurements.append(self.env['procurement.group'].Procurement(


### PR DESCRIPTION
… uom._compute_quantity

Ensure correct qty convertion before creating stock moves from procurement groups

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
