### PR TITLE
[ADD] http: Enhance multi_session

### DIFF
--- a/odoo/http.py
+++ b/odoo/http.py
@@ -1604,11 +1604,18 @@ class FutureResponse:
 
     @functools.wraps(werkzeug.Response.set_cookie)
     def set_cookie(self, key, value='', max_age=None, expires=-1, path='/', domain=None, secure=False, httponly=False, samesite=None, cookie_type='required'):
+        IrHttp = request.env and request.env['ir.http']
         if expires == -1:  # not forced value -> default value -> 1 year
             expires = datetime.now() + timedelta(days=365)
 
-        if request.db and not request.env['ir.http']._is_allowed_cookie(cookie_type):
+        if request.db and IrHttp and not IrHttp._is_allowed_cookie(cookie_type):
             max_age = 0
+
+        if request.session.get("multi_login"):
+            expires = None
+            max_age = None
+        elif request.db and key == 'session_id' and not domain and hasattr(IrHttp, '_get_subdomain') and (subdomain := IrHttp._get_subdomain(domain)):
+            werkzeug.Response.set_cookie(self, "multi_session_id", value=value, max_age=max_age, expires=expires, path=path, domain=subdomain, secure=secure, httponly=httponly, samesite=samesite)
         werkzeug.Response.set_cookie(self, key, value=value, max_age=max_age, expires=expires, path=path, domain=domain, secure=secure, httponly=httponly, samesite=samesite)
 
 


### PR DESCRIPTION
Enhance session management in an Islamic website by implementing a secondary cookie (multi_session_id). Upon user login, the system must register the multi_session_id cookie within the base domain, ensuring it functions alongside the original session cookie. Similarly, upon user logout, the multi_session_id cookie should be deleted in the same manner as the primary session cookie to maintain consistency and security

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
