### PR TITLE
[IMP] base: allow configure models that can be deleted in partner mer…

### DIFF
--- a/odoo/addons/base/wizard/base_partner_merge.py
+++ b/odoo/addons/base/wizard/base_partner_merge.py
@@ -177,10 +177,23 @@ class MergePartnerAutomatic(models.TransientModel):
                 with mute_logger('odoo.sql_db'), self._cr.savepoint():
                     records.sudo().write({field_id: dst_record.id})
                     records.env.flush_all()
-            except psycopg2.Error:
-                # updating fails, most likely due to a violated unique constraint
-                # keeping record with nonexistent partner_id is useless, better delete it
-                records.sudo().unlink()
+            except psycopg2.Error as e:
+                # updating fails, if the model of records is in allowed ones to delete in case
+                # of unique violation error then delete it, in case is not in allowed ones or
+                # postgresql error is not unique violation, then raise an error
+                model_names_to_delete = self.env['ir.config_parameter'].sudo().get_param("base_partner_merge.models_allowed_to_unlink")
+                model_names_to_delete = model_names_to_delete.split(",") if model_names_to_delete else []
+                if not model_names_to_delete or (records._name in model_names_to_delete and e.pgcode == psycopg2.errorcodes.UNIQUE_VIOLATION):
+                    records.sudo().unlink()
+                elif model_names_to_delete:
+                    # Everything else is not expected and should fail.
+                    msg = """An error has ocurred meanwhile reference fields were updated: \nDestination Record: %s \nSource Record: %s, \nError: %s""" % (
+                        dst_record.id,
+                        tuple(src_records.ids),
+                        e,
+                    )
+                    _logger.error(msg)
+                    raise UserError(msg)
 
         for record in src_records:
             update_records('ir.attachment', src=record, field_model='res_model')


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

The method _update_reference_fields is handling PSQL errors in the case in the middle of updating something fails and it's deleting indiscriminately the records involved presuming that PSQL error is always a unique violation, but can occur any PSQL error, so this change is allowing configure what models can be deleted in a unique violation if the models are not defined, it's working as currently, otherwise, it's validating the model and raising an error in case model is not in allowed ones.

Current behavior before PR:

When a merge occurs, if there is a PostgreSQL error in updating reference fields, the records involved are deleted.

Desired behavior after PR is merged:

When a merge occurs, if there is a PostgreSQL unique violation error in updating reference fields and the parameter is base_partner_merge.models_allowed_to_unlink is configured, if records involved are in allowed models to delete, then delete them, otherwise raise an error to the user can review at detail.

OPW: Pending
