### PR TITLE
[FIX] gamification: Force goal updates for portal users

### DIFF
--- a/addons/gamification/models/gamification_challenge.py
+++ b/addons/gamification/models/gamification_challenge.py
@@ -277,9 +277,7 @@ class Challenge(models.Model):
         self.env.cr.execute("""SELECT gg.id
                         FROM gamification_goal as gg
                         JOIN bus_presence as bp ON bp.user_id = gg.user_id
-                       WHERE gg.write_date <= bp.last_presence
-                         AND bp.last_presence >= now() AT TIME ZONE 'UTC' - interval '%(session_lifetime)s seconds'
-                         AND gg.closed IS NOT TRUE
+                       WHERE gg.closed IS NOT TRUE
                          AND gg.challenge_id IN %(challenge_ids)s
                          AND (gg.state = 'inprogress'
                               OR (gg.state = 'reached' AND gg.end_date >= %(yesterday)s))


### PR DESCRIPTION
Before this commit, Odoo attempted to optimize the `_update_all` method in `gamification.challenge` by filtering users based on their recent activity in the `bus_presence` table.

While this optimization works for internal users who frequently trigger bus presence events by navigating the backend, it fails completely for portal users (e.g., donors or customers). Portal users can remain logged in and active on the website for long periods without ever generating a new `last_presence` event, causing their gamification goals to stall and stop updating.

This patch removes the `bus_presence` filters entirely from the query, forcing Odoo to evaluate and update the goals for all users involved in the challenge, regardless of their last detected presence in the notification bus.

This is an adaptation of a similar hard patch previously implemented in Odoo 16.0 (PR #614), where the optimization relied on the `res_users_log` table instead.

[1] https://github.com/Vauxoo/odoo/pull/614

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
