### PR TITLE
[FIX] website_sale: use consistent website in sale_product_domain

### DIFF
--- a/addons/website_sale/models/website.py
+++ b/addons/website_sale/models/website.py
@@ -365,13 +365,14 @@ class Website(models.Model):
         return pricelist
 
     def sale_product_domain(self):
-        website_domain = self.get_current_website().website_domain()
+        website = self or self.get_current_website()
+        website_domain = website.website_domain()
         if not self.env.user._is_internal():
             website_domain = expression.AND([website_domain, [
                 ('is_published', '=', True),
                 ('service_tracking', 'in', self.env['product.template']._get_saleable_tracking_types()),
             ]])
-        company_domain = [('company_id', 'in', [False, self.company_id.id])]
+        company_domain = [('company_id', 'in', [False, website.company_id.id])]
         return expression.AND([self._product_domain(), website_domain, company_domain])
 
     def _product_domain(self):


### PR DESCRIPTION
## Description

### Problem

[sale_product_domain](file:///home/imanie/Documents/IRC/18.0/odoo/addons/website_sale/models/website.py#367-376) uses `self.get_current_website()` for the website domain
but `self.company_id` for the company domain. This causes two issues:

1. **`company_id` is `False` when called from [models](https://github.com/odoo/odoo/blob/b011c1e3cc4597c713dfe7041c58dc224f8f758d/addons/website_sale/models/product_template.py#L278)**: Methods like
   [_get_website_accessory_product](file:///home/imanie/Documents/IRC/18.0/odoo/addons/website_sale/models/product_template.py#198-203) and [_get_website_alternative_product](file:///home/imanie/Documents/IRC/18.0/odoo/addons/website_sale/models/product_template.py#204-207) call
   `self.env['website'].sale_product_domain()` — an empty recordset where
   `self.company_id.id` evaluates to `False`. The resulting company domain
   [('company_id', 'in', [False, False])](file:///home/imanie/Documents/IRC/18.0/odoo/addons/website_sale/controllers/main.py#757-802) filters out all company-owned
   products.

https://github.com/odoo/odoo/blob/b011c1e3cc4597c713dfe7041c58dc224f8f758d/addons/website_sale/models/product_template.py#L278

2. **Inconsistent website references**: Even when `self` is a real website
   record, `get_current_website()` could return a different website, leading to
   the website domain and company domain referring to different websites.

### Steps to reproduce

1. Add accessory products to a product template
2. Visit the product page on the ecommerce shop
3. Accessory products belonging to the website's company may not appear

### Solution

Store the resolved website in a local variable (`self or self.get_current_website()`),
preferring `self` when it is a real record and falling back to
`get_current_website()` otherwise. Use this single variable for both the website
domain and the company domain.

```diff
 def sale_product_domain(self):
-    website_domain = self.get_current_website().website_domain()
+    website = self or self.get_current_website()
+    website_domain = website.website_domain()
     if not self.env.user._is_internal():
         website_domain = expression.AND([website_domain, [
             ('is_published', '=', True),
             ('service_tracking', 'in', self.env['product.template']._get_saleable_tracking_types()),
         ]])
-    company_domain = [('company_id', 'in', [False, self.company_id.id])]
+    company_domain = [('company_id', 'in', [False, website.company_id.id])]
     return expression.AND([self._product_domain(), website_domain, company_domain])
```


https://github.com/odoo/odoo/pull/260138