### PR TITLE
[REM] base: remove dummy mail server from neutralization

### DIFF
--- a/odoo/addons/base/data/neutralize.sql
+++ b/odoo/addons/base/data/neutralize.sql
@@ -2,10 +2,6 @@
 UPDATE ir_mail_server
    SET active = false;
 
--- insert dummy mail server to prevent using fallback servers specified using command line
-INSERT INTO ir_mail_server(name, smtp_port, smtp_host, smtp_encryption, active, smtp_authentication)
-VALUES ('neutralization - disable emails', 1025, 'invalid', 'none', true, 'login');
-
 -- deactivate crons
 UPDATE ir_cron
    SET active = false


### PR DESCRIPTION
Remove the insertion of the dummy mail server that was used to prevent using fallback servers specified via the command line.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
